### PR TITLE
docs: fix example.tf 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,11 +34,13 @@ To build and install locally into _~/go/bin_:
 go install
 ```
 
-To use the locally built version of the provider, tell terraform where to find it (only needed once):
+To use the locally built version of the provider, use dev overrides to tell terraform where to find it (only needed once):
 
 ```
 make ~/.terraformrc
 ```
+
+NB: when using dev overrides `terraform init` will fail, but this can be ignored. If you have more than one provider then they all must be overridden. For more info see [#27459](https://github.com/hashicorp/terraform/issues/27459#issuecomment-1381507253).
 
 ## Prefect API
 

--- a/devtools/.terraformrc
+++ b/devtools/.terraformrc
@@ -1,7 +1,7 @@
 provider_installation {
 
   dev_overrides {
-      "prefect" = "<GOBIN>"
+      "PrefectHQ/prefect" = "<GOBIN>"
   }
 
   # For all other providers, install them directly from their origin provider

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -31,7 +31,7 @@ resource "prefect_service_account" "test" {
   ]
 }
 
-# example showing how to inject the store the api key as a secret value
+# example showing how to store the api key in an AWS Secrets Manager secret
 
 # resource "aws_secretsmanager_secret" "this" {
 #   name = "prefect-svc.apikey"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     prefect = {
-      source = "registry.terraform.io/PrefectHQ/prefect"
+      source = "PrefectHQ/prefect"
     }
   }
   required_version = ">= 1.0"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     prefect = {
-      source = "egistry.terraform.io/PrefectHQ/prefect"
+      source = "registry.terraform.io/PrefectHQ/prefect"
     }
   }
   required_version = ">= 1.0"
@@ -22,20 +22,22 @@ resource "prefect_service_account" "test" {
   api_keys = [
     {
       name       = "key1"
-      expiration = "2015-10-21T00:00:00+11:00"
+      expiration = "2015-10-21T00:00:00+00:00"
     },
     {
       name       = "key2"
-      expiration = "2015-10-21T00:00:00+11:00"
+      expiration = "2015-10-21T00:00:00+00:00"
     }
   ]
 }
 
-resource "aws_secretsmanager_secret" "this" {
-  name = "prefect-svc.apikey"
-}
+# example showing how to inject the store the api key as a secret value
 
-resource "aws_secretsmanager_secret_version" "this" {
-  secret_id     = aws_secretsmanager_secret.this.id
-  secret_string = prefect_service_account.test.api_keys[0].key
-}
+# resource "aws_secretsmanager_secret" "this" {
+#   name = "prefect-svc.apikey"
+# }
+
+# resource "aws_secretsmanager_secret_version" "this" {
+#   secret_id     = aws_secretsmanager_secret.this.id
+#   secret_string = prefect_service_account.test.api_keys[0].key
+# }


### PR DESCRIPTION
Running `terraform plan` on the example when dev overrides are enabled failed because it was using the aws provider without a dev override:
```
❯ terraform plan
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/tekumara/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state
│ to become incompatible with published releases.
╵
╷
│ Error: Inconsistent dependency lock file
│ 
│ The following dependency selections recorded in the lock file are inconsistent with the current configuration:
│   - provider registry.terraform.io/hashicorp/aws: required by this configuration but no version is selected
│ 
│ To make the initial dependency selections that will initialize the dependency lock file, run:
│   terraform init
```

I've commented out the aws section of the example so this now works, and fixed a few other issues that prevented the example from running successfully.