### PR TITLE
chore: use Go module conventions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-prefect
+module github.com/prefecthq/terraform-provider-prefect
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"terraform-provider-prefect/prefect"
+	"github.com/prefecthq/terraform-provider-prefect/prefect"
 )
 
 func main() {

--- a/prefect/client.go
+++ b/prefect/client.go
@@ -2,7 +2,7 @@ package prefect
 
 import (
 	"fmt"
-	hc "terraform-provider-prefect/prefect_api"
+	hc "github.com/prefecthq/terraform-provider-prefect/prefect_api"
 )
 
 func getClient(m interface{}) (*hc.Client, error) {

--- a/prefect/data_source_block_documents.go
+++ b/prefect/data_source_block_documents.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	hc "terraform-provider-prefect/prefect_api"
+	hc "github.com/prefecthq/terraform-provider-prefect/prefect_api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/prefect/data_source_block_schemas.go
+++ b/prefect/data_source_block_schemas.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	hc "terraform-provider-prefect/prefect_api"
+	hc "github.com/prefecthq/terraform-provider-prefect/prefect_api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/prefect/data_source_block_types.go
+++ b/prefect/data_source_block_types.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	hc "terraform-provider-prefect/prefect_api"
+	hc "github.com/prefecthq/terraform-provider-prefect/prefect_api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/prefect/data_source_work_queues.go
+++ b/prefect/data_source_work_queues.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	hc "terraform-provider-prefect/prefect_api"
+	hc "github.com/prefecthq/terraform-provider-prefect/prefect_api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/prefect/data_source_workspaces.go
+++ b/prefect/data_source_workspaces.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"time"
 
-	hc "terraform-provider-prefect/prefect_api"
+	hc "github.com/prefecthq/terraform-provider-prefect/prefect_api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/prefect/provider.go
+++ b/prefect/provider.go
@@ -3,7 +3,7 @@ package prefect
 import (
 	"context"
 
-	"terraform-provider-prefect/prefect_api"
+	"github.com/prefecthq/terraform-provider-prefect/prefect_api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/prefect/resource_block.go
+++ b/prefect/resource_block.go
@@ -2,7 +2,7 @@ package prefect
 
 import (
 	"context"
-	hc "terraform-provider-prefect/prefect_api"
+	hc "github.com/prefecthq/terraform-provider-prefect/prefect_api"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/prefect/resource_work_queue.go
+++ b/prefect/resource_work_queue.go
@@ -2,7 +2,7 @@ package prefect
 
 import (
 	"context"
-	hc "terraform-provider-prefect/prefect_api"
+	hc "github.com/prefecthq/terraform-provider-prefect/prefect_api"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/prefect/resource_workspace.go
+++ b/prefect/resource_workspace.go
@@ -3,7 +3,7 @@ package prefect
 import (
 	"context"
 
-	hc "terraform-provider-prefect/prefect_api"
+	hc "github.com/prefecthq/terraform-provider-prefect/prefect_api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"


### PR DESCRIPTION
By convention, Go modules use the full GitHub repository path when they are hosted on GitHub. This allows "go get" to identify and load modules from GitHub directly.