### PR TITLE
feat: add support for managing accounts

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -75,7 +75,6 @@ linters:
     - tparallel
     - typecheck
     - unconvert
-    - unparam
     - unused
     - usestdlibvars
     - varnamelen
@@ -139,7 +138,6 @@ linters-settings:
       - nilValReturn
       - octalLiteral
       - offBy1
-      - paramTypeCombine
       - preferDecodeRune
       - preferFilepathJoin
       - preferFprint

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/hashicorp/go-hclog v1.4.0 // indirect
+	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-plugin v1.4.9 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/go-hclog v1.4.0 h1:ctuWFGrhFha8BnnzxqeRGidlEcQkDyL5u8J8t5eA11I=
-github.com/hashicorp/go-hclog v1.4.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
+github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
+github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-plugin v1.4.9 h1:ESiK220/qE0aGxWdzKIvRH69iLiuN/PjoLTm69RoWtU=
 github.com/hashicorp/go-plugin v1.4.9/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// AccountsClient is a client for working with accounts.
+type AccountsClient interface {
+	Get(ctx context.Context, id uuid.UUID) (*AccountResponse, error)
+	Update(ctx context.Context, id uuid.UUID, data AccountUpdate) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+// Account is a representation of an account.
+type Account struct {
+	BaseModel
+	Name                  string   `json:"name"`
+	Handle                string   `json:"handle"`
+	Location              *string  `json:"location"`
+	Link                  *string  `json:"link"`
+	ImageLocation         *string  `json:"image_location"`
+	StripeCustomerID      *string  `json:"stripe_customer_id"`
+	WorkOSDirectoryIDs    []string `json:"workos_directory_ids"`
+	WorkOSOrganizationID  *string  `json:"workos_organization_id"`
+	WorkOSConnectionIDs   []string `json:"workos_connection_ids"`
+	AuthExpirationSeconds *int64   `json:"auth_expiration_seconds"`
+	AllowPublicWorkspaces *bool    `json:"allow_public_workspaces"`
+}
+
+// AccountResponse is the data about an account returned by the Accounts API.
+type AccountResponse struct {
+	Account
+	PlanType              string   `json:"plan_type"`
+	SelfServe             bool     `json:"self_serve"`
+	RunRetentionDays      int64    `json:"run_retention_days"`
+	AuditLogRetentionDays int64    `json:"audit_log_retention_days"`
+	AutomationsLimit      int64    `json:"automations_limit"`
+	SCIMState             string   `json:"scim_state"`
+	SSOState              string   `json:"sso_state"`
+	BillingEmail          *string  `json:"billing_email"`
+	Features              []string `json:"features"`
+}
+
+// AccountUpdate is the data sent when updating an account.
+type AccountUpdate struct {
+	Name                  *string `json:"name"`
+	Handle                *string `json:"handle"`
+	Location              *string `json:"location"`
+	Link                  *string `json:"link"`
+	AuthExpirationSeconds *int64  `json:"auth_expiration_seconds"`
+	AllowPublicWorkspaces *bool   `json:"allow_public_workspaces"`
+	BillingEmail          *string `json:"billing_email"`
+}

--- a/internal/api/base_model.go
+++ b/internal/api/base_model.go
@@ -6,6 +6,8 @@ import (
 	"github.com/google/uuid"
 )
 
+// BaseModel is embedded in all other types and defines fields
+// common to all Prefect data models.
 type BaseModel struct {
 	ID      uuid.UUID  `json:"id"`
 	Created *time.Time `json:"created"`

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,7 +1,10 @@
 package api
 
+import "github.com/google/uuid"
+
 // PrefectClient returns clients for different aspects of our API.
 type PrefectClient interface {
-	WorkPools() WorkPoolsClient
-	Variables() VariablesClient
+	Accounts() (AccountsClient, error)
+	WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (WorkPoolsClient, error)
+	Variables(accountID uuid.UUID, workspaceID uuid.UUID) (VariablesClient, error)
 }

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+)
+
+var _ = api.AccountsClient(&AccountsClient{})
+
+// AccountsClient is a client for working with accounts.
+type AccountsClient struct {
+	hc       *http.Client
+	endpoint string
+	apiKey   string
+}
+
+// Accounts returns an AccountsClient.
+//
+//nolint:ireturn // required to support PrefectClient mocking
+func (c *Client) Accounts() (api.AccountsClient, error) {
+	return &AccountsClient{
+		hc:       c.hc,
+		endpoint: c.endpoint,
+		apiKey:   c.apiKey,
+	}, nil
+}
+
+// Get returns details for an account by ID.
+func (c *AccountsClient) Get(ctx context.Context, accountID uuid.UUID) (*api.AccountResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+"/accounts/"+accountID.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := doRequest(c.hc, c.apiKey, req)
+	if err != nil {
+		return nil, fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code %s", resp.Status)
+	}
+
+	var account api.AccountResponse
+	if err := json.NewDecoder(resp.Body).Decode(&account); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &account, nil
+}
+
+// Update modifies an existing account by ID.
+func (c *AccountsClient) Update(ctx context.Context, accountID uuid.UUID, data api.AccountUpdate) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&data); err != nil {
+		return fmt.Errorf("failed to encode data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.endpoint+"/accounts/"+accountID.String(), &buf)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := doRequest(c.hc, c.apiKey, req)
+	if err != nil {
+		return fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("status code %s", resp.Status)
+	}
+
+	return nil
+}
+
+// Delete removes an account by ID.
+func (c *AccountsClient) Delete(ctx context.Context, accountID uuid.UUID) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.endpoint+"/accounts/"+accountID.String(), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := doRequest(c.hc, c.apiKey, req)
+	if err != nil {
+		return fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("status code %s", resp.Status)
+	}
+
+	return nil
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 )
 
@@ -75,8 +77,22 @@ func WithEndpoint(endpoint string) Option {
 
 // WithAPIKey configures the API Key to use to authenticate to Prefect.
 func WithAPIKey(apiKey string) Option {
-	return func(c *Client) error {
-		c.apiKey = apiKey
+	return func(client *Client) error {
+		client.apiKey = apiKey
+
+		return nil
+	}
+}
+
+// WithDefaults configures the default account and workspace ID.
+func WithDefaults(accountID uuid.UUID, workspaceID uuid.UUID) Option {
+	return func(client *Client) error {
+		if accountID == uuid.Nil && workspaceID != uuid.Nil {
+			return fmt.Errorf("accountID and workspaceID are inconsistent: accountID is nil and workspaceID is %q", workspaceID)
+		}
+
+		client.defaultAccountID = accountID
+		client.defaultWorkspaceID = workspaceID
 
 		return nil
 	}

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -1,11 +1,17 @@
 package client
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+)
 
 type Client struct {
-	hc       *http.Client
-	endpoint string
-	apiKey   string
+	hc                 *http.Client
+	endpoint           string
+	apiKey             string
+	defaultAccountID   uuid.UUID
+	defaultWorkspaceID uuid.UUID
 }
 
 type Option func(c *Client) error

--- a/internal/provider/datasources/account.go
+++ b/internal/provider/datasources/account.go
@@ -1,0 +1,170 @@
+package datasources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+)
+
+var _ = datasource.DataSourceWithConfigure(&AccountDataSource{})
+
+// AccountDataSource contains state for the data source.
+type AccountDataSource struct {
+	client api.AccountsClient
+}
+
+// AccountDataSourceModel defines the Terraform data source model.
+type AccountDataSourceModel struct {
+	ID      types.String `tfsdk:"id"`
+	Created types.String `tfsdk:"created"`
+	Updated types.String `tfsdk:"updated"`
+
+	Name                  types.String `tfsdk:"name"`
+	Handle                types.String `tfsdk:"handle"`
+	Location              types.String `tfsdk:"location"`
+	Link                  types.String `tfsdk:"link"`
+	AllowPublicWorkspaces types.Bool   `tfsdk:"allow_public_workspaces"`
+	BillingEmail          types.String `tfsdk:"billing_email"`
+}
+
+// NewAccountDataSource returns a new AccountDataSource.
+//
+//nolint:ireturn // required by Terraform API
+func NewAccountDataSource() datasource.DataSource {
+	return &AccountDataSource{}
+}
+
+// Metadata returns the data source type name.
+func (d *AccountDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_account"
+}
+
+// Configure initializes runtime state for the data source.
+func (d *AccountDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(api.PrefectClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected api.PrefectClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client, _ = client.Accounts()
+}
+
+// Schema defines the schema for the data source.
+func (d *AccountDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Data Source representing a Prefect Cloud account",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Required:    true,
+				Description: "Account UUID",
+			},
+			"created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Date and time of the account creation in RFC 3339 format",
+			},
+			"updated": schema.StringAttribute{
+				Computed:    true,
+				Description: "Date and time that the account was last updated in RFC 3339 format",
+			},
+			"name": schema.StringAttribute{
+				Computed:    true,
+				Description: "Name of the account",
+			},
+			"handle": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique handle of the account",
+			},
+			"location": schema.StringAttribute{
+				Computed:    true,
+				Description: "An optional physical location for the account, e.g. Washington, D.C.",
+			},
+			"link": schema.StringAttribute{
+				Computed:    true,
+				Description: "An optional for an external url associated with the account, e.g. https://prefect.io/",
+			},
+			"allow_public_workspaces": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether or not this account allows public workspaces",
+			},
+			"billing_email": schema.StringAttribute{
+				Computed:    true,
+				Description: "Billing email to apply to the account's stripe customer",
+			},
+		},
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *AccountDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var model AccountDataSourceModel
+
+	// Populate the model from data source configuration and emit diagnostics on error
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accountID, err := uuid.Parse(model.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Account ID",
+			fmt.Sprintf("Could not parse account ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	account, err := d.client.Get(ctx, accountID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error refreshing account state",
+			fmt.Sprintf("Could not read account, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	model.ID = types.StringValue(account.ID.String())
+
+	if account.Created == nil {
+		model.Created = types.StringNull()
+	} else {
+		model.Created = types.StringValue(account.Created.Format(time.RFC3339))
+	}
+
+	if account.Updated == nil {
+		model.Updated = types.StringNull()
+	} else {
+		model.Updated = types.StringValue(account.Updated.Format(time.RFC3339))
+	}
+
+	model.AllowPublicWorkspaces = types.BoolPointerValue(account.AllowPublicWorkspaces)
+	model.BillingEmail = types.StringPointerValue(account.BillingEmail)
+	model.Handle = types.StringValue(account.Handle)
+	model.Link = types.StringPointerValue(account.Link)
+	model.Location = types.StringPointerValue(account.Location)
+	model.Name = types.StringValue(account.Name)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/internal/provider/datasources/variable.go
+++ b/internal/provider/datasources/variable.go
@@ -60,7 +60,7 @@ func (d *VariableDataSource) Configure(_ context.Context, req datasource.Configu
 		return
 	}
 
-	d.client = client.Variables()
+	d.client, _ = client.Variables(uuid.Nil, uuid.Nil)
 }
 
 var variableAttributes = map[string]schema.Attribute{
@@ -96,7 +96,8 @@ var variableAttributes = map[string]schema.Attribute{
 // Schema defines the schema for the data source.
 func (d *VariableDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Attributes: variableAttributes,
+		Description: "Data Source representing a Prefect variable",
+		Attributes:  variableAttributes,
 	}
 }
 
@@ -106,7 +107,6 @@ func (d *VariableDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	// Populate the model from data source configuration and emit diagnostics on error
 	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -181,7 +181,6 @@ func (d *VariableDataSource) Read(ctx context.Context, req datasource.ReadReques
 	model.Tags = list
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/datasources/work_pool.go
+++ b/internal/provider/datasources/work_pool.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -65,13 +66,14 @@ func (d *WorkPoolDataSource) Configure(_ context.Context, req datasource.Configu
 		return
 	}
 
-	d.client = client.WorkPools()
+	d.client, _ = client.WorkPools(uuid.Nil, uuid.Nil)
 }
 
 var workPoolAttributes = map[string]schema.Attribute{
 	"id": schema.StringAttribute{
 		Computed:    true,
 		Description: "Work pool UUID",
+		Optional:    true,
 	},
 	"created": schema.StringAttribute{
 		Computed:    true,
@@ -82,12 +84,14 @@ var workPoolAttributes = map[string]schema.Attribute{
 		Description: "Date and time that the work pool was last updated in RFC 3339 format",
 	},
 	"name": schema.StringAttribute{
-		Required:    true,
+		Computed:    true,
 		Description: "Name of the work pool",
+		Optional:    true,
 	},
 	"description": schema.StringAttribute{
 		Computed:    true,
 		Description: "Description of the work pool",
+		Optional:    true,
 	},
 	"type": schema.StringAttribute{
 		Computed:    true,
@@ -100,10 +104,12 @@ var workPoolAttributes = map[string]schema.Attribute{
 	"concurrency_limit": schema.Int64Attribute{
 		Computed:    true,
 		Description: "The concurrency limit applied to this work pool",
+		Optional:    true,
 	},
 	"default_queue_id": schema.StringAttribute{
 		Computed:    true,
 		Description: "The UUID of the default queue associated with this work pool",
+		Optional:    true,
 	},
 	"base_job_template": schema.StringAttribute{
 		Computed:    true,
@@ -114,7 +120,8 @@ var workPoolAttributes = map[string]schema.Attribute{
 // Schema defines the schema for the data source.
 func (d *WorkPoolDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Attributes: workPoolAttributes,
+		Description: "Data Source representing a Prefect Work Pool",
+		Attributes:  workPoolAttributes,
 	}
 }
 
@@ -124,7 +131,6 @@ func (d *WorkPoolDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	// Populate the model from data source configuration and emit diagnostics on error
 	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -177,7 +183,6 @@ func (d *WorkPoolDataSource) Read(ctx context.Context, req datasource.ReadReques
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/datasources/work_pools.go
+++ b/internal/provider/datasources/work_pools.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -57,12 +58,13 @@ func (d *WorkPoolsDataSource) Configure(_ context.Context, req datasource.Config
 		return
 	}
 
-	d.client = client.WorkPools()
+	d.client, _ = client.WorkPools(uuid.Nil, uuid.Nil)
 }
 
 // Schema defines the schema for the data source.
 func (d *WorkPoolsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: "Data Source for querying work pools",
 		Attributes: map[string]schema.Attribute{
 			"filter_any": schema.ListAttribute{
 				ElementType: types.StringType,
@@ -86,7 +88,6 @@ func (d *WorkPoolsDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	// Populate the model from data source configuration and emit diagnostics on error
 	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -177,7 +178,6 @@ func (d *WorkPoolsDataSource) Read(ctx context.Context, req datasource.ReadReque
 	model.WorkPools = list
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -164,6 +164,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 // DataSources defines the data sources implemented in the provider.
 func (p *Provider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		datasources.NewAccountDataSource,
 		datasources.NewVariableDataSource,
 		datasources.NewWorkPoolDataSource,
 		datasources.NewWorkPoolsDataSource,
@@ -173,6 +174,7 @@ func (p *Provider) DataSources(_ context.Context) []func() datasource.DataSource
 // Resources defines the resources implemented in the provider.
 func (p *Provider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
+		resources.NewAccountResource,
 		resources.NewVariableResource,
 		resources.NewWorkPoolResource,
 	}

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -121,11 +121,11 @@ func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 }
 
 // Create creates the resource and sets the initial Terraform state.
-func (r *AccountResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *AccountResource) Create(_ context.Context, _ resource.CreateRequest, resp *resource.CreateResponse) {
 	resp.Diagnostics.AddError("Cannot create account", "Account is an import-only resource and cannot be created by Terraform.")
 }
 
-// copyAccountToModel copies an api.AccountResponse to an AccountResourceModel
+// copyAccountToModel copies an api.AccountResponse to an AccountResourceModel.
 func copyAccountToModel(account *api.AccountResponse, model *AccountResourceModel) error {
 	model.ID = types.StringValue(account.ID.String())
 

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -1,0 +1,303 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+)
+
+var (
+	_ = resource.ResourceWithConfigure(&AccountResource{})
+	_ = resource.ResourceWithImportState(&AccountResource{})
+)
+
+// AccountResource contains state for the resource.
+type AccountResource struct {
+	client api.AccountsClient
+}
+
+// AccountResourceModel defines the Terraform resource model.
+type AccountResourceModel struct {
+	ID      types.String `tfsdk:"id"`
+	Created types.String `tfsdk:"created"`
+	Updated types.String `tfsdk:"updated"`
+
+	Name                  types.String `tfsdk:"name"`
+	Handle                types.String `tfsdk:"handle"`
+	Location              types.String `tfsdk:"location"`
+	Link                  types.String `tfsdk:"link"`
+	AllowPublicWorkspaces types.Bool   `tfsdk:"allow_public_workspaces"`
+	BillingEmail          types.String `tfsdk:"billing_email"`
+}
+
+// NewAccountResource returns a new AccountResource.
+//
+//nolint:ireturn // required by Terraform API
+func NewAccountResource() resource.Resource {
+	return &AccountResource{}
+}
+
+// Metadata returns the resource type name.
+func (r *AccountResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_account"
+}
+
+// Configure initializes runtime state for the resource.
+func (r *AccountResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(api.PrefectClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected api.PrefectClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client, _ = client.Accounts()
+}
+
+// Schema defines the schema for the resource.
+func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Resource representing a Prefect Cloud account",
+		Version:     0,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Account UUID",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Date and time of the account creation in RFC 3339 format",
+			},
+			"updated": schema.StringAttribute{
+				Computed:    true,
+				Description: "Date and time that the account was last updated in RFC 3339 format",
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the account",
+				Required:    true,
+			},
+			"handle": schema.StringAttribute{
+				Description: "Unique handle of the account",
+				Required:    true,
+			},
+			"location": schema.StringAttribute{
+				Description: "An optional physical location for the account, e.g. Washington, D.C.",
+				Required:    true,
+			},
+			"link": schema.StringAttribute{
+				Description: "An optional for an external url associated with the account, e.g. https://prefect.io/",
+				Required:    true,
+			},
+			"allow_public_workspaces": schema.BoolAttribute{
+				Description: "Whether or not this account allows public workspaces",
+				Required:    true,
+			},
+			"billing_email": schema.StringAttribute{
+				Description: "Billing email to apply to the account's stripe customer",
+				Required:    true,
+			},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *AccountResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.Diagnostics.AddError("Cannot create account", "Account is an import-only resource and cannot be created by Terraform.")
+}
+
+// copyAccountToModel copies an api.AccountResponse to an AccountResourceModel
+func copyAccountToModel(account *api.AccountResponse, model *AccountResourceModel) error {
+	model.ID = types.StringValue(account.ID.String())
+
+	if account.Created == nil {
+		model.Created = types.StringNull()
+	} else {
+		model.Created = types.StringValue(account.Created.Format(time.RFC3339))
+	}
+
+	if account.Updated == nil {
+		model.Updated = types.StringNull()
+	} else {
+		model.Updated = types.StringValue(account.Updated.Format(time.RFC3339))
+	}
+
+	model.AllowPublicWorkspaces = types.BoolPointerValue(account.AllowPublicWorkspaces)
+	model.BillingEmail = types.StringPointerValue(account.BillingEmail)
+	model.Handle = types.StringValue(account.Handle)
+	model.Link = types.StringPointerValue(account.Link)
+	model.Location = types.StringPointerValue(account.Location)
+	model.Name = types.StringValue(account.Name)
+
+	return nil
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *AccountResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var model AccountResourceModel
+
+	// Populate the model from state and emit diagnostics on error
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accountID, err := uuid.Parse(model.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Variable ID",
+			fmt.Sprintf("Could not parse account ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	account, err := r.client.Get(ctx, accountID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error refreshing account state",
+			fmt.Sprintf("Could not read account, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	err = copyAccountToModel(account, &model)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error mapping AccountResponse to Model",
+			fmt.Sprintf("This is an internal error in the Terraform provider, please report this to the maintainers: %s", err.Error()),
+		)
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var model AccountResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accountID, err := uuid.Parse(model.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Account ID",
+			fmt.Sprintf("Could not parse account ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	err = r.client.Update(ctx, accountID, api.AccountUpdate{
+		Name:                  model.Name.ValueStringPointer(),
+		Handle:                model.Handle.ValueStringPointer(),
+		Location:              model.Location.ValueStringPointer(),
+		Link:                  model.Link.ValueStringPointer(),
+		AllowPublicWorkspaces: model.AllowPublicWorkspaces.ValueBoolPointer(),
+		BillingEmail:          model.BillingEmail.ValueStringPointer(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating account",
+			fmt.Sprintf("Could not update account, unexpected error: %s", err),
+		)
+
+		return
+	}
+
+	account, err := r.client.Get(ctx, accountID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error refreshing account state",
+			fmt.Sprintf("Could not read account, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	err = copyAccountToModel(account, &model)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error mapping AccountResponse to Model",
+			fmt.Sprintf("This is an internal error in the Terraform provider, please report this to the maintainers: %s", err.Error()),
+		)
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *AccountResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var model AccountResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accountID, err := uuid.Parse(model.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Account ID",
+			fmt.Sprintf("Could not parse account ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	err = r.client.Delete(ctx, accountID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting account",
+			fmt.Sprintf("Could not delete account, unexpected error: %s", err),
+		)
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// ImportState imports the resource into Terraform state.
+func (r *AccountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}


### PR DESCRIPTION
* Refactor client to support selecting account (organization) and workspaces, so that we can manage unscoped and account-scoped resources
* Implement client and resources for accounts
* Fix inconsistencies where we were reading the wrong field from lifecycle methods (e.g. req.Config, req.Plan, req.State)

Closes: #26