### PR TITLE
feat: add workspace support

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,7 +25,6 @@ linters:
     - forcetypeassert
     - gocheckcompilerdirectives
     - gochecknoinits
-    - gocognit
     - goconst
     - gocritic
     - gocyclo

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,6 +5,7 @@ import "github.com/google/uuid"
 // PrefectClient returns clients for different aspects of our API.
 type PrefectClient interface {
 	Accounts() (AccountsClient, error)
+	Workspaces(accountID uuid.UUID) (WorkspacesClient, error)
 	WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (WorkPoolsClient, error)
 	Variables(accountID uuid.UUID, workspaceID uuid.UUID) (VariablesClient, error)
 }

--- a/internal/api/workspaces.go
+++ b/internal/api/workspaces.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// WorkspacesClient is a client for working with workspaces.
+type WorkspacesClient interface {
+	Create(ctx context.Context, data WorkspaceCreate) (*Workspace, error)
+	Get(ctx context.Context, workspaceID uuid.UUID) (*Workspace, error)
+	Update(ctx context.Context, workspaceID uuid.UUID, data WorkspaceUpdate) error
+	Delete(ctx context.Context, workspaceID uuid.UUID) error
+}
+
+// Workspace is a representation of a workspace.
+type Workspace struct {
+	BaseModel
+	AccountID              uuid.UUID `json:"account_id"`
+	Name                   string    `json:"name"`
+	Description            *string   `json:"description"`
+	Handle                 string    `json:"handle"`
+	DefaultWorkspaceRoleID uuid.UUID `json:"default_workspace_role_id"`
+	IsPublic               bool      `json:"is_public"`
+}
+
+// WorkspaceCreate is a subset of Workspace used when creating workspaces.
+type WorkspaceCreate struct {
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
+	Handle      string  `json:"handle"`
+}
+
+// WorkspaceUpdate is a subset of Workspace used when updating workspaces.
+type WorkspaceUpdate struct {
+	Name                   *string    `json:"name"`
+	Description            *string    `json:"description"`
+	Handle                 *string    `json:"handle"`
+	DefaultWorkspaceRoleID *uuid.UUID `json:"default_workspace_role_id"`
+}

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -8,30 +8,39 @@ import (
 	"github.com/google/uuid"
 )
 
-// getAccountScopedURL constructs a URL for an account-scoped route
+// getAccountScopedURL constructs a URL for an account-scoped route.
 func getAccountScopedURL(endpoint string, accountID uuid.UUID, route string) string {
-	var sb strings.Builder
-	sb.WriteString(endpoint)
-	sb.WriteString("/accounts/")
-	sb.WriteString(accountID.String())
-	sb.WriteRune('/')
-	sb.WriteString(route)
-	return sb.String()
+	var builder strings.Builder
+
+	builder.WriteString(endpoint)
+
+	builder.WriteString("/accounts/")
+	builder.WriteString(accountID.String())
+	builder.WriteRune('/')
+
+	builder.WriteString(route)
+
+	return builder.String()
 }
 
-// getWorkspaceScopedURL constructs a URL for a workspace-scoped route
+// getWorkspaceScopedURL constructs a URL for a workspace-scoped route.
 func getWorkspaceScopedURL(endpoint string, accountID uuid.UUID, workspaceID uuid.UUID, route string) string {
-	var sb strings.Builder
-	sb.WriteString(endpoint)
+	var builder strings.Builder
+
+	builder.WriteString(endpoint)
+
 	if accountID != uuid.Nil && workspaceID != uuid.Nil {
-		sb.WriteString("/accounts/")
-		sb.WriteString(accountID.String())
-		sb.WriteString("/workspaces/")
-		sb.WriteString(workspaceID.String())
+		builder.WriteString("/accounts/")
+		builder.WriteString(accountID.String())
+
+		builder.WriteString("/workspaces/")
+		builder.WriteString(workspaceID.String())
 	}
-	sb.WriteRune('/')
-	sb.WriteString(route)
-	return sb.String()
+
+	builder.WriteRune('/')
+	builder.WriteString(route)
+
+	return builder.String()
 }
 
 // setAuthorizationHeader will set the Authorization header to the
@@ -46,9 +55,7 @@ func doRequest(client *http.Client, apiKey string, request *http.Request) (*http
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "application/json")
 
-	if apiKey != "" {
-		request.Header.Set("Authorization", "Bearer "+apiKey)
-	}
+	setAuthorizationHeader(request, apiKey)
 
 	resp, err := client.Do(request)
 	if err != nil {

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -3,7 +3,44 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
 )
+
+// getAccountScopedURL constructs a URL for an account-scoped route
+func getAccountScopedURL(endpoint string, accountID uuid.UUID, route string) string {
+	var sb strings.Builder
+	sb.WriteString(endpoint)
+	sb.WriteString("/accounts/")
+	sb.WriteString(accountID.String())
+	sb.WriteRune('/')
+	sb.WriteString(route)
+	return sb.String()
+}
+
+// getWorkspaceScopedURL constructs a URL for a workspace-scoped route
+func getWorkspaceScopedURL(endpoint string, accountID uuid.UUID, workspaceID uuid.UUID, route string) string {
+	var sb strings.Builder
+	sb.WriteString(endpoint)
+	if accountID != uuid.Nil && workspaceID != uuid.Nil {
+		sb.WriteString("/accounts/")
+		sb.WriteString(accountID.String())
+		sb.WriteString("/workspaces/")
+		sb.WriteString(workspaceID.String())
+	}
+	sb.WriteRune('/')
+	sb.WriteString(route)
+	return sb.String()
+}
+
+// setAuthorizationHeader will set the Authorization header to the
+// provided apiKey, if set.
+func setAuthorizationHeader(request *http.Request, apiKey string) {
+	if apiKey != "" {
+		request.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+}
 
 func doRequest(client *http.Client, apiKey string, request *http.Request) (*http.Response, error) {
 	request.Header.Set("Content-Type", "application/json")

--- a/internal/client/workspaces.go
+++ b/internal/client/workspaces.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+)
+
+var _ = api.WorkspacesClient(&WorkspacesClient{})
+
+// WorkspacesClient is a client for working with Workspaces.
+type WorkspacesClient struct {
+	hc          *http.Client
+	routePrefix string
+	apiKey      string
+	accountID   uuid.UUID
+}
+
+// Workspaces returns a WorkspacesClient.
+//
+//nolint:ireturn // required to support PrefectClient mocking
+func (c *Client) Workspaces(accountID uuid.UUID) (api.WorkspacesClient, error) {
+	if accountID == uuid.Nil {
+		accountID = c.defaultAccountID
+	}
+
+	return &WorkspacesClient{
+		hc:          c.hc,
+		routePrefix: getAccountScopedURL(c.endpoint, accountID, "workspaces"),
+		apiKey:      c.apiKey,
+		accountID:   accountID,
+	}, nil
+}
+
+// Create returns details for a new Workspace.
+func (c *WorkspacesClient) Create(ctx context.Context, data api.WorkspaceCreate) (*api.Workspace, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&data); err != nil {
+		return nil, fmt.Errorf("failed to encode data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.routePrefix+"/", &buf)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := doRequest(c.hc, c.apiKey, req)
+	if err != nil {
+		return nil, fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("status code %s", resp.Status)
+	}
+
+	var workspace api.Workspace
+	if err := json.NewDecoder(resp.Body).Decode(&workspace); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &workspace, nil
+}
+
+// Get returns details for a Workspace by ID.
+func (c *WorkspacesClient) Get(ctx context.Context, workspaceID uuid.UUID) (*api.Workspace, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.routePrefix+"/"+workspaceID.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	reqStr, _ := httputil.DumpRequest(req, false)
+	tflog.Warn(ctx, "prefect client request contents", map[string]interface{}{
+		"request": string(reqStr),
+	})
+
+	resp, err := doRequest(c.hc, c.apiKey, req)
+	if err != nil {
+		return nil, fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code %s", resp.Status)
+	}
+
+	var workspace api.Workspace
+	if err := json.NewDecoder(resp.Body).Decode(&workspace); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &workspace, nil
+}
+
+// Update modifies an existing Workspace by ID.
+func (c *WorkspacesClient) Update(ctx context.Context, workspaceID uuid.UUID, data api.WorkspaceUpdate) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&data); err != nil {
+		return fmt.Errorf("failed to encode data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.routePrefix+"/"+workspaceID.String(), &buf)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := doRequest(c.hc, c.apiKey, req)
+	if err != nil {
+		return fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("status code %s", resp.Status)
+	}
+
+	return nil
+}
+
+// Delete removes a Workspace by ID.
+func (c *WorkspacesClient) Delete(ctx context.Context, workspaceID uuid.UUID) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.routePrefix+"/"+workspaceID.String(), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := doRequest(c.hc, c.apiKey, req)
+	if err != nil {
+		return fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("status code %s", resp.Status)
+	}
+
+	return nil
+}

--- a/internal/provider/datasources/workspace.go
+++ b/internal/provider/datasources/workspace.go
@@ -1,0 +1,193 @@
+package datasources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+)
+
+var _ = datasource.DataSourceWithConfigure(&WorkspaceDataSource{})
+
+// WorkspaceDataSource contains state for the data source.
+type WorkspaceDataSource struct {
+	client api.PrefectClient
+}
+
+// WorkspaceDataSourceModel defines the Terraform data source model.
+type WorkspaceDataSourceModel struct {
+	ID        types.String `tfsdk:"id"`
+	Created   types.String `tfsdk:"created"`
+	Updated   types.String `tfsdk:"updated"`
+	AccountID types.String `tfsdk:"account_id"`
+
+	Name        types.String `tfsdk:"name"`
+	Handle      types.String `tfsdk:"handle"`
+	Description types.String `tfsdk:"description"`
+}
+
+// NewWorkspaceDataSource returns a new WorkspaceDataSource.
+//
+//nolint:ireturn // required by Terraform API
+func NewWorkspaceDataSource() datasource.DataSource {
+	return &WorkspaceDataSource{}
+}
+
+// Metadata returns the data source type name.
+func (d *WorkspaceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_workspace"
+}
+
+// Configure initializes runtime state for the data source.
+func (d *WorkspaceDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(api.PrefectClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected api.PrefectClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}
+
+var workspaceAttributes = map[string]schema.Attribute{
+	"id": schema.StringAttribute{
+		Description: "Workspace UUID",
+		Required:    true,
+	},
+	"created": schema.StringAttribute{
+		Computed:    true,
+		Description: "Date and time of the workspace creation in RFC 3339 format",
+	},
+	"updated": schema.StringAttribute{
+		Computed:    true,
+		Description: "Date and time that the workspace was last updated in RFC 3339 format",
+	},
+	"account_id": schema.StringAttribute{
+		Description: "Account UUID, defaults to the account set in the provider",
+		Optional:    true,
+	},
+	"name": schema.StringAttribute{
+		Computed:    true,
+		Description: "Name of the workspace",
+	},
+	"handle": schema.StringAttribute{
+		Computed:    true,
+		Description: "Unique handle for the workspace",
+	},
+	"description": schema.StringAttribute{
+		Computed:    true,
+		Description: "Description for the workspace",
+	},
+}
+
+// Schema defines the schema for the data source.
+func (d *WorkspaceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Data Source representing a Prefect workspace",
+		Attributes:  workspaceAttributes,
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var model WorkspaceDataSourceModel
+
+	// Populate the model from data source configuration and emit diagnostics on error
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !model.ID.IsNull() && !model.Name.IsNull() {
+		resp.Diagnostics.AddError(
+			"Conflicting workspace lookup keys",
+			"Workspaces can be identified by their unique name or ID, but not both.",
+		)
+
+		return
+	}
+
+	accountID := uuid.Nil
+	if !model.AccountID.IsNull() && model.AccountID.ValueString() != "" {
+		var err error
+		accountID, err = uuid.Parse(model.AccountID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("account_id"),
+				"Error parsing Account ID",
+				fmt.Sprintf("Could not parse account ID to UUID, unexpected error: %s", err.Error()),
+			)
+
+			return
+		}
+	}
+
+	client, err := d.client.Workspaces(accountID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating workspace client",
+			fmt.Sprintf("Could not create workspace client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
+		)
+
+		return
+	}
+
+	workspaceID, err := uuid.Parse(model.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Workspace ID",
+			fmt.Sprintf("Could not parse workspace ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	workspace, err := client.Get(ctx, workspaceID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error refreshing workspace state",
+			fmt.Sprintf("Could not read workspace, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	model.ID = types.StringValue(workspace.ID.String())
+
+	if workspace.Created == nil {
+		model.Created = types.StringNull()
+	} else {
+		model.Created = types.StringValue(workspace.Created.Format(time.RFC3339))
+	}
+
+	if workspace.Updated == nil {
+		model.Updated = types.StringNull()
+	} else {
+		model.Updated = types.StringValue(workspace.Updated.Format(time.RFC3339))
+	}
+
+	model.Name = types.StringValue(workspace.Name)
+	model.Handle = types.StringValue(workspace.Handle)
+	model.Description = types.StringPointerValue(workspace.Description)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,22 +18,22 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/resources"
 )
 
-var _ = provider.Provider(&Provider{})
+var _ = provider.Provider(&PrefectProvider{})
 
 // New returns a new Prefect Provider instance.
 //
 //nolint:ireturn // required by Terraform API
 func New() provider.Provider {
-	return &Provider{}
+	return &PrefectProvider{}
 }
 
 // Metadata returns the provider type name.
-func (p *Provider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+func (p *PrefectProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "prefect"
 }
 
 // Schema defines the provider-level schema for configuration data.
-func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+func (p *PrefectProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"endpoint": schema.StringAttribute{
@@ -58,8 +58,8 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 }
 
 // Configure configures the provider's internal client.
-func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	config := &ProviderModel{}
+func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	config := &PrefectProviderModel{}
 
 	// Populate the model from provider configuration and emit diagnostics on error
 	resp.Diagnostics.Append(req.Config.Get(ctx, config)...)
@@ -222,7 +222,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 }
 
 // DataSources defines the data sources implemented in the provider.
-func (p *Provider) DataSources(_ context.Context) []func() datasource.DataSource {
+func (p *PrefectProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		datasources.NewAccountDataSource,
 		datasources.NewVariableDataSource,
@@ -233,7 +233,7 @@ func (p *Provider) DataSources(_ context.Context) []func() datasource.DataSource
 }
 
 // Resources defines the resources implemented in the provider.
-func (p *Provider) Resources(_ context.Context) []func() resource.Resource {
+func (p *PrefectProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		resources.NewAccountResource,
 		resources.NewVariableResource,

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -126,7 +127,7 @@ func (r *AccountResource) Create(_ context.Context, _ resource.CreateRequest, re
 }
 
 // copyAccountToModel copies an api.AccountResponse to an AccountResourceModel.
-func copyAccountToModel(account *api.AccountResponse, model *AccountResourceModel) error {
+func copyAccountToModel(_ context.Context, account *api.AccountResponse, model *AccountResourceModel) diag.Diagnostics {
 	model.ID = types.StringValue(account.ID.String())
 
 	if account.Created == nil {
@@ -182,13 +183,8 @@ func (r *AccountResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	err = copyAccountToModel(account, &model)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error mapping AccountResponse to Model",
-			fmt.Sprintf("This is an internal error in the Terraform provider, please report this to the maintainers: %s", err.Error()),
-		)
-
+	resp.Diagnostics.Append(copyAccountToModel(ctx, account, &model)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -245,13 +241,8 @@ func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	err = copyAccountToModel(account, &model)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error mapping AccountResponse to Model",
-			fmt.Sprintf("This is an internal error in the Terraform provider, please report this to the maintainers: %s", err.Error()),
-		)
-
+	resp.Diagnostics.Append(copyAccountToModel(ctx, account, &model)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -1,0 +1,376 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+)
+
+var (
+	_ = resource.ResourceWithConfigure(&WorkspaceResource{})
+	_ = resource.ResourceWithImportState(&WorkspaceResource{})
+)
+
+// WorkspaceResource contains state for the resource.
+type WorkspaceResource struct {
+	client api.PrefectClient
+}
+
+// WorkspaceResourceModel defines the Terraform resource model.
+type WorkspaceResourceModel struct {
+	ID        types.String `tfsdk:"id"`
+	Created   types.String `tfsdk:"created"`
+	Updated   types.String `tfsdk:"updated"`
+	AccountID types.String `tfsdk:"account_id"`
+
+	Name        types.String `tfsdk:"name"`
+	Handle      types.String `tfsdk:"handle"`
+	Description types.String `tfsdk:"description"`
+}
+
+// NewWorkspaceResource returns a new WorkspaceResource.
+//
+//nolint:ireturn // required by Terraform API
+func NewWorkspaceResource() resource.Resource {
+	return &WorkspaceResource{}
+}
+
+// Metadata returns the resource type name.
+func (r *WorkspaceResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_workspace"
+}
+
+// Configure initializes runtime state for the resource.
+func (r *WorkspaceResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(api.PrefectClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected api.PrefectClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+// Schema defines the schema for the resource.
+func (r *WorkspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Resource representing a Prefect Workspace",
+		Version:     0,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Workspace UUID",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created": schema.StringAttribute{
+				Computed:    true,
+				Description: "Date and time of the workspace creation in RFC 3339 format",
+			},
+			"updated": schema.StringAttribute{
+				Computed:    true,
+				Description: "Date and time that the workspace was last updated in RFC 3339 format",
+			},
+			"account_id": schema.StringAttribute{
+				Description: "Account UUID, defaults to the account set in the provider",
+				Optional:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the workspace",
+				Required:    true,
+			},
+			"handle": schema.StringAttribute{
+				Description: "Unique handle for the workspace",
+				Required:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "Description for the workspace",
+				Required:    true,
+			},
+		},
+	}
+}
+
+// copyWorkspaceToModel copies an api.Workspace to a WorkspaceResourceModel.
+func copyWorkspaceToModel(ctx context.Context, workspace *api.Workspace, model *WorkspaceResourceModel) diag.Diagnostics {
+	model.ID = types.StringValue(workspace.ID.String())
+
+	if workspace.Created == nil {
+		model.Created = types.StringNull()
+	} else {
+		model.Created = types.StringValue(workspace.Created.Format(time.RFC3339))
+	}
+
+	if workspace.Updated == nil {
+		model.Updated = types.StringNull()
+	} else {
+		model.Updated = types.StringValue(workspace.Updated.Format(time.RFC3339))
+	}
+
+	model.Name = types.StringValue(workspace.Name)
+	model.Handle = types.StringValue(workspace.Handle)
+	model.Description = types.StringValue(*workspace.Description)
+
+	return nil
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var model WorkspaceResourceModel
+
+	// Populate the model from resource configuration and emit diagnostics on error
+	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	accountID := uuid.Nil
+	if !model.AccountID.IsNull() && model.AccountID.ValueString() != "" {
+		var err error
+		accountID, err = uuid.Parse(model.AccountID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("account_id"),
+				"Error parsing Account ID",
+				fmt.Sprintf("Could not parse account ID to UUID, unexpected error: %s", err.Error()),
+			)
+
+			return
+		}
+	}
+
+	client, err := r.client.Workspaces(accountID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating workspace client",
+			fmt.Sprintf("Could not create workspace client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
+		)
+	}
+
+	workspace, err := client.Create(ctx, api.WorkspaceCreate{
+		Name:        model.Name.ValueString(),
+		Handle:      model.Handle.ValueString(),
+		Description: model.Description.ValueStringPointer(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating workspace",
+			fmt.Sprintf("Could not create workspace, unexpected error: %s", err),
+		)
+
+		return
+	}
+
+	model.ID = types.StringValue(workspace.ID.String())
+
+	if workspace.Created == nil {
+		model.Created = types.StringNull()
+	} else {
+		model.Created = types.StringValue(workspace.Created.Format(time.RFC3339))
+	}
+
+	if workspace.Updated == nil {
+		model.Updated = types.StringNull()
+	} else {
+		model.Updated = types.StringValue(workspace.Updated.Format(time.RFC3339))
+	}
+
+	model.Name = types.StringValue(workspace.Name)
+	model.Handle = types.StringValue(workspace.Handle)
+	model.Description = types.StringPointerValue(workspace.Description)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var model WorkspaceResourceModel
+
+	// Populate the model from state and emit diagnostics on error
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	workspaceID, err := uuid.Parse(model.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Workspace ID",
+			fmt.Sprintf("Could not parse Workspace ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	client, err := r.client.Workspaces(uuid.Nil)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating workspace client",
+			fmt.Sprintf("Could not create workspace client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
+		)
+	}
+
+	workspace, err := client.Get(ctx, workspaceID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error refreshing Workspace state",
+			fmt.Sprintf("Could not read Workspace, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	model.ID = types.StringValue(workspace.ID.String())
+
+	if workspace.Created == nil {
+		model.Created = types.StringNull()
+	} else {
+		model.Created = types.StringValue(workspace.Created.Format(time.RFC3339))
+	}
+
+	if workspace.Updated == nil {
+		model.Updated = types.StringNull()
+	} else {
+		model.Updated = types.StringValue(workspace.Updated.Format(time.RFC3339))
+	}
+
+	model.Name = types.StringValue(workspace.Name)
+	model.Handle = types.StringValue(workspace.Handle)
+	model.Description = types.StringPointerValue(workspace.Description)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *WorkspaceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var model WorkspaceResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	workspaceID, err := uuid.Parse(model.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Workspace ID",
+			fmt.Sprintf("Could not parse Workspace ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	client, err := r.client.Workspaces(uuid.Nil)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating workspace client",
+			fmt.Sprintf("Could not create workspace client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
+		)
+	}
+
+	err = client.Update(ctx, workspaceID, api.WorkspaceUpdate{
+		Name:        model.Name.ValueStringPointer(),
+		Handle:      model.Handle.ValueStringPointer(),
+		Description: model.Description.ValueStringPointer(),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating workspace",
+			fmt.Sprintf("Could not update workspace, unexpected error: %s", err),
+		)
+
+		return
+	}
+
+	workspace, _ := client.Get(ctx, workspaceID)
+	model.Created = types.StringValue(workspace.Created.Format(time.RFC3339))
+	model.Updated = types.StringValue(workspace.Created.Format(time.RFC3339))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *WorkspaceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var model WorkspaceResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	workspaceID, err := uuid.Parse(model.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Workspace ID",
+			fmt.Sprintf("Could not parse Workspace ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	client, err := r.client.Workspaces(uuid.Nil)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating workspace client",
+			fmt.Sprintf("Could not create workspace client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
+		)
+	}
+
+	err = client.Delete(ctx, workspaceID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting Workspace",
+			fmt.Sprintf("Could not delete Workspace, unexpected error: %s", err),
+		)
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// ImportState imports the resource into Terraform state.
+func (r *WorkspaceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if strings.HasPrefix(req.ID, "name/") {
+		name := strings.TrimPrefix(req.ID, "name/")
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
+	} else {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	}
+}

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -11,8 +11,10 @@ type Provider struct {
 	client *client.Client
 }
 
-// providerModel maps provider schema data to a Go type.
-type providerModel struct {
-	Endpoint types.String `tfsdk:"endpoint"`
-	APIKey   types.String `tfsdk:"api_key"`
+// ProviderModel maps provider schema data to a Go type.
+type ProviderModel struct {
+	Endpoint    types.String `tfsdk:"endpoint"`
+	APIKey      types.String `tfsdk:"api_key"`
+	AccountID   types.String `tfsdk:"account_id"`
+	WorkspaceID types.String `tfsdk:"workspace_id"`
 }

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -6,13 +6,13 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/client"
 )
 
-// Provider implements the Prefect Terraform provider.
-type Provider struct {
+// PrefectProvider implements the Prefect Terraform provider.
+type PrefectProvider struct {
 	client *client.Client
 }
 
-// ProviderModel maps provider schema data to a Go type.
-type ProviderModel struct {
+// PrefectProviderModel maps provider schema data to a Go type.
+type PrefectProviderModel struct {
 	Endpoint    types.String `tfsdk:"endpoint"`
 	APIKey      types.String `tfsdk:"api_key"`
 	AccountID   types.String `tfsdk:"account_id"`

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 const providerAddress = "registry.terraform.io/prefecthq/prefect"
 
 func main() {
-	providerServer := providerserver.NewProtocol6(&provider.Provider{})
+	providerServer := providerserver.NewProtocol6(&provider.PrefectProvider{})
 
 	err := tf6server.Serve(providerAddress, providerServer)
 	if err != nil {


### PR DESCRIPTION
* Allow provider to create and destroy workspaces in an account
* Add a default provider-scoped account_id and workspace_id for convenience
* Add utility functions to generate account- and workspace-scoped route prefixes, used when creating a client for account- or workspace-scoped resources

Closes: #31