### PR TITLE
feat: support overriding account and workspace

### DIFF
--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -38,7 +38,9 @@ func (c *AccountsClient) Get(ctx context.Context, accountID uuid.UUID) (*api.Acc
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}
@@ -68,7 +70,9 @@ func (c *AccountsClient) Update(ctx context.Context, accountID uuid.UUID, data a
 		return fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("http error: %w", err)
 	}
@@ -88,7 +92,9 @@ func (c *AccountsClient) Delete(ctx context.Context, accountID uuid.UUID) error 
 		return fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("http error: %w", err)
 	}

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -51,16 +50,11 @@ func setAuthorizationHeader(request *http.Request, apiKey string) {
 	}
 }
 
-func doRequest(client *http.Client, apiKey string, request *http.Request) (*http.Response, error) {
-	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Accept", "application/json")
-
+// setDefaultHeaders will set Authorization, Content-Type, and Accept
+// headers that are common to most requests.
+func setDefaultHeaders(request *http.Request, apiKey string) {
 	setAuthorizationHeader(request, apiKey)
 
-	resp, err := client.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("http error: %w", err)
-	}
-
-	return resp, nil
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
 }

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -17,10 +17,8 @@ var _ = api.VariablesClient(&VariablesClient{})
 // VariablesClient is a client for working with variables.
 type VariablesClient struct {
 	hc          *http.Client
-	endpoint    string
+	routePrefix string
 	apiKey      string
-	accountID   uuid.UUID
-	workspaceID uuid.UUID
 }
 
 // Variables returns a VariablesClient.
@@ -45,10 +43,7 @@ func (c *Client) Variables(accountID uuid.UUID, workspaceID uuid.UUID) (api.Vari
 
 	return &VariablesClient{
 		hc:          c.hc,
-		endpoint:    c.endpoint,
-		apiKey:      c.apiKey,
-		accountID:   accountID,
-		workspaceID: workspaceID,
+		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "variables"),
 	}, nil
 }
 
@@ -59,12 +54,14 @@ func (c *VariablesClient) Create(ctx context.Context, data api.VariableCreate) (
 		return nil, fmt.Errorf("failed to encode data: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+"/variables", &buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.routePrefix+"/variables/", &buf)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}
@@ -92,12 +89,14 @@ func (c *VariablesClient) List(ctx context.Context, filter api.VariableFilter) (
 
 // Get returns details for a variable by ID.
 func (c *VariablesClient) Get(ctx context.Context, variableID uuid.UUID) (*api.Variable, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+"/variables/"+variableID.String(), http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.routePrefix+"/variables/"+variableID.String(), http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}
@@ -117,12 +116,14 @@ func (c *VariablesClient) Get(ctx context.Context, variableID uuid.UUID) (*api.V
 
 // GetByName returns details for a variable by name.
 func (c *VariablesClient) GetByName(ctx context.Context, name string) (*api.Variable, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+"/variables/name/"+name, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.routePrefix+"/variables/name/"+name, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}
@@ -147,12 +148,14 @@ func (c *VariablesClient) Update(ctx context.Context, variableID uuid.UUID, data
 		return fmt.Errorf("failed to encode data: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.endpoint+"/variables/"+variableID.String(), &buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.routePrefix+"/variables/"+variableID.String(), &buf)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("http error: %w", err)
 	}
@@ -167,12 +170,14 @@ func (c *VariablesClient) Update(ctx context.Context, variableID uuid.UUID, data
 
 // Delete removes a variable by ID.
 func (c *VariablesClient) Delete(ctx context.Context, variableID uuid.UUID) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.endpoint+"/variables/"+variableID.String(), http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.routePrefix+"/variables/"+variableID.String(), http.NoBody)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("http error: %w", err)
 	}

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -16,10 +16,8 @@ var _ = api.WorkPoolsClient(&WorkPoolsClient{})
 // WorkPoolsClient is a client for working with work pools.
 type WorkPoolsClient struct {
 	hc          *http.Client
-	endpoint    string
 	apiKey      string
-	accountID   uuid.UUID
-	workspaceID uuid.UUID
+	routePrefix string
 }
 
 // WorkPools returns a WorkPoolsClient.
@@ -44,10 +42,7 @@ func (c *Client) WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (api.Work
 
 	return &WorkPoolsClient{
 		hc:          c.hc,
-		endpoint:    c.endpoint,
-		apiKey:      c.apiKey,
-		accountID:   accountID,
-		workspaceID: workspaceID,
+		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "work_pools"),
 	}, nil
 }
 
@@ -58,12 +53,14 @@ func (c *WorkPoolsClient) Create(ctx context.Context, data api.WorkPoolCreate) (
 		return nil, fmt.Errorf("failed to encode data: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+"/work_pools/", &buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.routePrefix+"/", &buf)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}
@@ -88,12 +85,14 @@ func (c *WorkPoolsClient) List(ctx context.Context, filter api.WorkPoolFilter) (
 		return nil, fmt.Errorf("failed to encode filter: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint+"/work_pools/filter", &buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.routePrefix+"/filter", &buf)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}
@@ -113,12 +112,14 @@ func (c *WorkPoolsClient) List(ctx context.Context, filter api.WorkPoolFilter) (
 
 // Get returns details for a work pool by name.
 func (c *WorkPoolsClient) Get(ctx context.Context, name string) (*api.WorkPool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+"/work_pools/"+name, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.routePrefix+"/work_pools/"+name, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}
@@ -143,12 +144,14 @@ func (c *WorkPoolsClient) Update(ctx context.Context, name string, data api.Work
 		return fmt.Errorf("failed to encode data: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.endpoint+"/work_pools/"+name, &buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.routePrefix+"/work_pools/"+name, &buf)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("http error: %w", err)
 	}
@@ -163,12 +166,14 @@ func (c *WorkPoolsClient) Update(ctx context.Context, name string, data api.Work
 
 // Delete removes a work pool by name.
 func (c *WorkPoolsClient) Delete(ctx context.Context, name string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.endpoint+"/work_pools/"+name, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.routePrefix+"/work_pools/"+name, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("http error: %w", err)
 	}

--- a/internal/client/workspaces.go
+++ b/internal/client/workspaces.go
@@ -6,10 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 
 	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 )
@@ -21,7 +19,6 @@ type WorkspacesClient struct {
 	hc          *http.Client
 	routePrefix string
 	apiKey      string
-	accountID   uuid.UUID
 }
 
 // Workspaces returns a WorkspacesClient.
@@ -36,7 +33,6 @@ func (c *Client) Workspaces(accountID uuid.UUID) (api.WorkspacesClient, error) {
 		hc:          c.hc,
 		routePrefix: getAccountScopedURL(c.endpoint, accountID, "workspaces"),
 		apiKey:      c.apiKey,
-		accountID:   accountID,
 	}, nil
 }
 
@@ -52,7 +48,9 @@ func (c *WorkspacesClient) Create(ctx context.Context, data api.WorkspaceCreate)
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}
@@ -77,12 +75,9 @@ func (c *WorkspacesClient) Get(ctx context.Context, workspaceID uuid.UUID) (*api
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
 
-	reqStr, _ := httputil.DumpRequest(req, false)
-	tflog.Warn(ctx, "prefect client request contents", map[string]interface{}{
-		"request": string(reqStr),
-	})
+	setDefaultHeaders(req, c.apiKey)
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}
@@ -112,7 +107,9 @@ func (c *WorkspacesClient) Update(ctx context.Context, workspaceID uuid.UUID, da
 		return fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("http error: %w", err)
 	}
@@ -132,7 +129,9 @@ func (c *WorkspacesClient) Delete(ctx context.Context, workspaceID uuid.UUID) er
 		return fmt.Errorf("error creating request: %w", err)
 	}
 
-	resp, err := doRequest(c.hc, c.apiKey, req)
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("http error: %w", err)
 	}

--- a/internal/provider/datasources/account.go
+++ b/internal/provider/datasources/account.go
@@ -63,7 +63,16 @@ func (d *AccountDataSource) Configure(_ context.Context, req datasource.Configur
 		return
 	}
 
-	d.client, _ = client.Accounts()
+	var err error
+	d.client, err = client.Accounts()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error creating account client",
+			fmt.Sprintf("Could not create account client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
+		)
+
+		return
+	}
 }
 
 // Schema defines the schema for the data source.

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -214,7 +214,22 @@ func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	client, err := r.client.Workspaces(uuid.Nil)
+	accountID := uuid.Nil
+	if !model.AccountID.IsNull() && model.AccountID.ValueString() != "" {
+		var err error
+		accountID, err = uuid.Parse(model.AccountID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("account_id"),
+				"Error parsing Account ID",
+				fmt.Sprintf("Could not parse account ID to UUID, unexpected error: %s", err.Error()),
+			)
+
+			return
+		}
+	}
+
+	client, err := r.client.Workspaces(accountID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating workspace client",
@@ -263,7 +278,22 @@ func (r *WorkspaceResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	client, err := r.client.Workspaces(uuid.Nil)
+	accountID := uuid.Nil
+	if !model.AccountID.IsNull() && model.AccountID.ValueString() != "" {
+		var err error
+		accountID, err = uuid.Parse(model.AccountID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("account_id"),
+				"Error parsing Account ID",
+				fmt.Sprintf("Could not parse account ID to UUID, unexpected error: %s", err.Error()),
+			)
+
+			return
+		}
+	}
+
+	client, err := r.client.Workspaces(accountID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating workspace client",
@@ -326,7 +356,22 @@ func (r *WorkspaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
-	client, err := r.client.Workspaces(uuid.Nil)
+	accountID := uuid.Nil
+	if !model.AccountID.IsNull() && model.AccountID.ValueString() != "" {
+		var err error
+		accountID, err = uuid.Parse(model.AccountID.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("account_id"),
+				"Error parsing Account ID",
+				fmt.Sprintf("Could not parse account ID to UUID, unexpected error: %s", err.Error()),
+			)
+
+			return
+		}
+	}
+
+	client, err := r.client.Workspaces(accountID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating workspace client",


### PR DESCRIPTION
* Set default headers with a utility function instead of running the full request, so that we can support other http clients (such as test clients) and log requests with Terraform diagnostics
* Update all resources to use getWorkspaceScopedURL for routePrefix
* Read workspace AccountID and WorkspaceID from state to ensure the correct one is updated or destroyed

Closes: #29