### PR TITLE
feat: add ability to rotate Service Account API Keys

### DIFF
--- a/examples/service_accounts.tf
+++ b/examples/service_accounts.tf
@@ -1,3 +1,9 @@
+provider "time" {}
+resource "time_rotating" "ninety_days" {
+    rotation_days = 90
+}
+
 resource "prefect_service_account" "sa_example" {
-    name = "beautiful-service-account-example"
+    name = "my-service-account"
+    api_key_expiration = time_rotating.ninety_days.rotation_rfc3339
 }

--- a/internal/api/service_accounts.go
+++ b/internal/api/service_accounts.go
@@ -27,6 +27,10 @@ type ServiceAccountUpdateRequest struct {
 	Name string `json:"name"`
 }
 
+type ServiceAccountRotateKeyRequest struct {
+	APIKeyExpiration string `json:"api_key_expiration"`
+}
+
 type ServiceAccountFilterRequest struct {
 	Any []uuid.UUID `json:"any_"`
 }
@@ -45,8 +49,8 @@ type ServiceAccount struct {
 type ServiceAccountAPIKey struct {
 	ID         string     `json:"id"`
 	Created    *time.Time `json:"created"`
-	Name       string     `json:"name"`
 	Expiration *time.Time `json:"expiration"`
+	Name       string     `json:"name"`
 	Key        string     `json:"key"`
 }
 

--- a/internal/api/service_accounts.go
+++ b/internal/api/service_accounts.go
@@ -10,9 +10,10 @@ import (
 type ServiceAccountsClient interface {
 	Create(ctx context.Context, request ServiceAccountCreateRequest) (*ServiceAccount, error)
 	List(ctx context.Context, filter ServiceAccountFilterRequest) ([]*ServiceAccount, error)
-	Get(ctx context.Context, name string) (*ServiceAccount, error)
-	Update(ctx context.Context, name string, data ServiceAccountUpdateRequest) error
-	Delete(ctx context.Context, name string) error
+	Get(ctx context.Context, id string) (*ServiceAccount, error)
+	Update(ctx context.Context, id string, data ServiceAccountUpdateRequest) error
+	Delete(ctx context.Context, id string) error
+	RotateKey(ctx context.Context, id string, data ServiceAccountRotateKeyRequest) (*ServiceAccount, error)
 }
 
 /*** REQUEST DATA STRUCTS ***/
@@ -28,7 +29,7 @@ type ServiceAccountUpdateRequest struct {
 }
 
 type ServiceAccountRotateKeyRequest struct {
-	APIKeyExpiration string `json:"api_key_expiration"`
+	APIKeyExpiration *time.Time `json:"api_key_expiration"`
 }
 
 type ServiceAccountFilterRequest struct {

--- a/internal/provider/helpers/diagnostics.go
+++ b/internal/provider/helpers/diagnostics.go
@@ -1,0 +1,15 @@
+package helpers
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// https://developer.hashicorp.com/terraform/plugin/framework/diagnostics#custom-diagnostics-types
+func CreateClientErrorDiagnostic(clientName string, err error) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		fmt.Sprintf("Error creating %s client", clientName),
+		fmt.Sprintf("Could not create %s client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", clientName, err.Error()),
+	)
+}

--- a/internal/provider/helpers/diagnostics.go
+++ b/internal/provider/helpers/diagnostics.go
@@ -7,6 +7,11 @@ import (
 )
 
 // https://developer.hashicorp.com/terraform/plugin/framework/diagnostics#custom-diagnostics-types
+
+// CreateClientErrorDiagnostic returns an error diagnostic for when one of the
+// HTTP clients failed to be instantiated.
+//
+//nolint:ireturn // required by Terraform API
 func CreateClientErrorDiagnostic(clientName string, err error) diag.Diagnostic {
 	return diag.NewErrorDiagnostic(
 		fmt.Sprintf("Error creating %s client", clientName),

--- a/internal/provider/resources/service_account.go
+++ b/internal/provider/resources/service_account.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
@@ -38,6 +40,12 @@ type ServiceAccountResourceModel struct {
 	APIKeyCreated    customtypes.TimestampValue `tfsdk:"api_key_created"`
 	APIKeyExpiration customtypes.TimestampValue `tfsdk:"api_key_expiration"`
 	APIKey           types.String               `tfsdk:"api_key"`
+}
+
+// ArePointerTimesEqual is a helper to compare equality of two pointer times
+// as this can get verbose to do inline with the resource logic.
+func ArePointerTimesEqual(t1 *time.Time, t2 *time.Time) bool {
+	return t1 == t2 || (t1 != nil && t2 != nil && t1.Equal(*t2))
 }
 
 // NewServiceAccountResource returns a new AccountResource.
@@ -77,6 +85,9 @@ func (r *ServiceAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Service account UUID",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
@@ -118,13 +129,13 @@ func (r *ServiceAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 			},
 			"api_key_expiration": schema.StringAttribute{
 				Optional:    true,
-				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Date and time that the API Key expires in RFC 3339 format",
 			},
 			"api_key": schema.StringAttribute{
 				Computed:    true,
 				Description: "API Key associated with the service account",
+				Sensitive:   true,
 			},
 		},
 	}
@@ -241,14 +252,14 @@ func (r *ServiceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *ServiceAccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var model ServiceAccountResourceModel
+	var plan ServiceAccountResourceModel
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.ServiceAccounts(model.AccountID.ValueUUID())
+	client, err := r.client.ServiceAccounts(plan.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Service Account", err))
 
@@ -256,8 +267,8 @@ func (r *ServiceAccountResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// Update client method requires context, botID, request args
-	err = client.Update(ctx, model.ID.ValueString(), api.ServiceAccountUpdateRequest{
-		Name: model.Name.ValueString(),
+	err = client.Update(ctx, plan.ID.ValueString(), api.ServiceAccountUpdateRequest{
+		Name: plan.Name.ValueString(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -268,8 +279,7 @@ func (r *ServiceAccountResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	// 'Get' client method requires context, botID args
-	serviceAccount, err := client.Get(ctx, model.ID.ValueString())
+	serviceAccount, err := client.Get(ctx, plan.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error refreshing Service Account state",
@@ -279,18 +289,50 @@ func (r *ServiceAccountResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	// Update the model with latest service account details (from the Get call above)
-	// Note: As with the Create/Read operations, 'account role id' is not part of the response
-	// and does not get set in the model as part of this call to copyServiceAccountResponseToModel
-	copyServiceAccountResponseToModel(serviceAccount, &model)
+	// Here, we'll retrieve the API Key from the previous State, as it's
+	// not included in the Terraform Plan / user configuration, nor is it
+	// returned on any API response other than Create and RotateKey.
+	// Additionally, the Provider framework will throw an exception if we
+	// set the `api_key` property to use stringmodifier.UseStateForUnknown()
+	// during legitimate cases where the API Key State value will be updated
+	// during key rotation.
+	var state ServiceAccountResourceModel
+	req.State.Get(ctx, &state)
+	apiKey := state.APIKey.ValueString()
 
-	// TODO: call rotate-key and use the new key value here
+	// Practitioners can rotate their Service Account API Key my modifying the
+	// `api_key_expiration` attribute. If the provided value is different than the current
+	// value, we'll call the RotateKey method on the client, which returns the
+	// ServiceAccount object with the new API Key value included in the response.
+	providedExpiration := plan.APIKeyExpiration.ValueTimePointer()
+	currentExpiration := serviceAccount.APIKey.Expiration
+	if !ArePointerTimesEqual(providedExpiration, currentExpiration) {
+		serviceAccount, err = client.RotateKey(ctx, plan.ID.ValueString(), api.ServiceAccountRotateKeyRequest{
+			APIKeyExpiration: providedExpiration,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error rotating Service Account key",
+				fmt.Sprintf("Could not rotate Service Account key, unexpected error: %s", err),
+			)
+
+			return
+		}
+
+		// Upon successful key rotation, we'll update this local variable with the new API Key value,
+		// which will be used in the final State update below.
+		apiKey = serviceAccount.APIKey.Key
+	}
+
+	// Update the model with latest service account details (from the Get call above)
+	copyServiceAccountResponseToModel(serviceAccount, &plan)
+
 	// The API Key is only returned on Create or when rotating the key, so we'll attach it to
 	// the model outside of the helper function, so that we can prevent the value from being
 	// overwritten in state when this helper is used on Read operations.
-	// model.APIKey = types.StringValue(serviceAccount.APIKey.Key)
+	plan.APIKey = types.StringValue(apiKey)
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/service_account_test.go
+++ b/internal/provider/resources/service_account_test.go
@@ -1,0 +1,144 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/resources"
+	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
+)
+
+func TestPointerTimeEqualityHelper(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+	pointInTime1 := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	pointInTime2 := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	pointInTime3 := time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		t1, t2 *time.Time
+		want   bool
+	}{
+		{nil, nil, true},
+		{nil, &now, false},
+		{&now, nil, false},
+		{&pointInTime1, &pointInTime2, true},
+		{&pointInTime1, &pointInTime3, false},
+	}
+
+	for _, c := range cases {
+		got := resources.ArePointerTimesEqual(c.t1, c.t2)
+		if got != c.want {
+			t.Fatalf("%v == %v should be %v, but got %v", c.t1, c.t2, c.want, got)
+		}
+	}
+}
+
+func fixtureAccServiceAccountResource(name string) string {
+	return fmt.Sprintf(`
+resource "prefect_service_account" "bot" {
+	name = "%s"
+}`, name)
+}
+
+func fixtureAccServiceAccountResourceUpdatedKey(name string, expiration time.Time) string {
+	return fmt.Sprintf(`
+	resource "prefect_service_account" "bot" {
+		name = "%s"
+		api_key_expiration = "%s"
+	}`, name, expiration.Format(time.RFC3339))
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccResource_service_account(t *testing.T) {
+	resourceName := "prefect_service_account.bot"
+	randomName := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	randomName2 := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	var apiKey string
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				// Check creation + existence of the service account resource
+				Config: fixtureAccServiceAccountResource(randomName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceAccountResourceExists(resourceName, &apiKey),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName),
+				),
+			},
+			{
+				// Ensure non-expiration time change does not trigger a key rotation
+				Config: fixtureAccServiceAccountResource(randomName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceAccountAPIKeyUnchanged(resourceName, &apiKey),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName2),
+				),
+			},
+			{
+				// Ensure that expiration time change does trigger a key rotation
+				Config: fixtureAccServiceAccountResourceUpdatedKey(randomName, time.Now().AddDate(0, 0, 1)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceAccountAPIKeyRotated(resourceName, &apiKey),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckServiceAccountResourceExists(n string, passedKey *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// find the corresponding state object
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		key := rs.Primary.Attributes["api_key"]
+		*passedKey = key
+
+		return nil
+	}
+}
+
+func testAccCheckServiceAccountAPIKeyUnchanged(n string, passedKey *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// find the corresponding state object
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		key := rs.Primary.Attributes["api_key"]
+
+		if *passedKey != key {
+			return fmt.Errorf("key was incorrectly rotated, since the old key=%s is different from new key=%s", *passedKey, key)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckServiceAccountAPIKeyRotated(n string, passedKey *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		key := rs.Primary.Attributes["api_key"]
+
+		if *passedKey == key {
+			return fmt.Errorf("key rotation did not occur correctly, as the old key=%s is the same as the new key=%s", *passedKey, key)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/27

This PR extends #49, specifically on resource `Update()`.  Here, we'll conditionally call `POST /bots/rotate_api_key` if the key's expiration date field is changed, either between two different end dates OR transition to/from `null` (aka a key that never expires)

there were also some fixes done to the resource model, as well as some custom logic to read from State in order to keep the api key from changing without the correct trigger

finally, some acceptance tests and a key rotation example was added