### PR TITLE
feat: `prefect_workspace_access` Resource

### DIFF
--- a/examples/workspace_access.tf
+++ b/examples/workspace_access.tf
@@ -8,7 +8,7 @@ resource "prefect_service_account" "bot" {
 	name = "a-cool-bot"
 }
 resource "prefect_workspace_access" "bot_access" {
-	accessor_type = "SERVICE ACCOUNT"
+	accessor_type = "SERVICE_ACCOUNT"
 	accessor_id = prefect_service_account.bot.id
 	workspace_id = data.prefect_workspace.prd.id
 	workspace_role_id = data.prefect_workspace_role.developer.id

--- a/examples/workspace_access.tf
+++ b/examples/workspace_access.tf
@@ -1,0 +1,15 @@
+data "prefect_workspace_role" "developer" {
+	name = "Developer"
+}
+data "prefect_workspace" "prd" {
+	id = "<workspace uuid>"
+}
+resource "prefect_service_account" "bot" {
+	name = "a-cool-bot"
+}
+resource "prefect_workspace_access" "bot_access" {
+	accessor_type = "SERVICE ACCOUNT"
+	accessor_id = prefect_service_account.bot.id
+	workspace_id = data.prefect_workspace.prd.id
+	workspace_role_id = data.prefect_workspace_role.developer.id
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
+	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.19.0
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-plugin-framework v1.4.2 h1:P7a7VP1GZbjc4rv921Xy5OckzhoiO3ig6SGxwelD2sI=
 github.com/hashicorp/terraform-plugin-framework v1.4.2/go.mod h1:GWl3InPFZi2wVQmdVnINPKys09s9mLmTZr95/ngLnbY=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.19.0 h1:BuZx/6Cp+lkmiG0cOBk6Zps0Cb2tmqQpDM3iAtnhDQU=
 github.com/hashicorp/terraform-plugin-go v0.19.0/go.mod h1:EhRSkEPNoylLQntYsk5KrDHTZJh9HQoumZXbOGOXmec=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -6,6 +6,7 @@ import "github.com/google/uuid"
 type PrefectClient interface {
 	Accounts() (AccountsClient, error)
 	Workspaces(accountID uuid.UUID) (WorkspacesClient, error)
+	WorkspaceAccess(accountID uuid.UUID, workspaceID uuid.UUID) (WorkspaceAccessClient, error)
 	WorkspaceRoles(accountID uuid.UUID) (WorkspaceRolesClient, error)
 	WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (WorkPoolsClient, error)
 	Variables(accountID uuid.UUID, workspaceID uuid.UUID) (VariablesClient, error)

--- a/internal/api/workspace_access.go
+++ b/internal/api/workspace_access.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type WorkspaceAccessClient interface {
+	UpsertServiceAccountAccess(ctx context.Context, payload WorkspaceAccessUpsert) (*WorkspaceServiceAccountAccess, error)
+	UpsertUserAccess(ctx context.Context, payload WorkspaceAccessUpsert) (*WorkspaceUserAccess, error)
+
+	GetServiceAccountAccess(ctx context.Context, accessID uuid.UUID) (*WorkspaceServiceAccountAccess, error)
+	GetUserAccess(ctx context.Context, accessID uuid.UUID) (*WorkspaceUserAccess, error)
+
+	DeleteServiceAccountAccess(ctx context.Context, accessID uuid.UUID) error
+	DeleteUserAccess(ctx context.Context, accessID uuid.UUID) error
+}
+
+// WorkspaceAccessBaseModel sets the shared attributes
+// for different workspace accessor responses, such as
+// users, service accounts, and teams.
+type WorkspaceAccessBaseModel struct {
+	BaseModel
+	WorkspaceID     uuid.UUID `json:"workspace_id"`
+	WorkspaceRoleID uuid.UUID `json:"workspace_role_id"`
+}
+
+// WorkspaceServiceAccountAccess is a representation of a workspace service account access.
+type WorkspaceServiceAccountAccess struct {
+	WorkspaceAccessBaseModel
+	ActorID uuid.UUID `json:"actor_id"`
+	BotID   uuid.UUID `json:"bot_id"`
+
+	BotName string `json:"bot_name"`
+}
+
+// WorkspaceUserAccess is a representation of a workspace user access.
+type WorkspaceUserAccess struct {
+	WorkspaceAccessBaseModel
+	ActorID uuid.UUID `json:"actor_id"`
+	UserID  uuid.UUID `json:"user_id"`
+
+	Email     string `json:"email"`
+	Handle    string `json:"handle"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+}
+
+// WorkspaceAccessUpsert defines the payload
+// when upserting a workspace access request.
+type WorkspaceAccessUpsert struct {
+	WorkspaceRoleID uuid.UUID  `json:"workspace_role_id"`
+	UserID          *uuid.UUID `json:"user_id,omitempty"`
+	BotID           *uuid.UUID `json:"bot_id,omitempty"`
+}

--- a/internal/api/workspace_access.go
+++ b/internal/api/workspace_access.go
@@ -32,6 +32,9 @@ type WorkspaceAccessUpsert struct {
 
 	// Only one of the follow IDs should be set on each call
 	// depending on the resource's AccessorType
-	UserID uuid.UUID `json:"user_id,omitempty"`
-	BotID  uuid.UUID `json:"bot_id,omitempty"`
+	// NOTE: omitempty normally excludes any zero value,
+	// for primitives, but complex types like structs
+	// and uuid.UUID require a pointer type to be omitted.
+	UserID *uuid.UUID `json:"user_id,omitempty"`
+	BotID  *uuid.UUID `json:"bot_id,omitempty"`
 }

--- a/internal/api/workspace_access.go
+++ b/internal/api/workspace_access.go
@@ -7,50 +7,31 @@ import (
 )
 
 type WorkspaceAccessClient interface {
-	UpsertServiceAccountAccess(ctx context.Context, payload WorkspaceAccessUpsert) (*WorkspaceServiceAccountAccess, error)
-	UpsertUserAccess(ctx context.Context, payload WorkspaceAccessUpsert) (*WorkspaceUserAccess, error)
-
-	GetServiceAccountAccess(ctx context.Context, accessID uuid.UUID) (*WorkspaceServiceAccountAccess, error)
-	GetUserAccess(ctx context.Context, accessID uuid.UUID) (*WorkspaceUserAccess, error)
-
-	DeleteServiceAccountAccess(ctx context.Context, accessID uuid.UUID) error
-	DeleteUserAccess(ctx context.Context, accessID uuid.UUID) error
+	Upsert(ctx context.Context, accessorType string, accessorID uuid.UUID, roleID uuid.UUID) (*WorkspaceAccess, error)
+	Get(ctx context.Context, accessorType string, accessID uuid.UUID) (*WorkspaceAccess, error)
+	Delete(ctx context.Context, accessorType string, accessID uuid.UUID) error
 }
 
-// WorkspaceAccessBaseModel sets the shared attributes
-// for different workspace accessor responses, such as
-// users, service accounts, and teams.
-type WorkspaceAccessBaseModel struct {
+// WorkspaceAccess is a representation of a workspace access.
+// This is used for multiple accessor types (user, service account, team),
+// which dictates the presence of the specific accessor's ID.
+type WorkspaceAccess struct {
 	BaseModel
 	WorkspaceID     uuid.UUID `json:"workspace_id"`
 	WorkspaceRoleID uuid.UUID `json:"workspace_role_id"`
-}
 
-// WorkspaceServiceAccountAccess is a representation of a workspace service account access.
-type WorkspaceServiceAccountAccess struct {
-	WorkspaceAccessBaseModel
-	ActorID uuid.UUID `json:"actor_id"`
-	BotID   uuid.UUID `json:"bot_id"`
-
-	BotName string `json:"bot_name"`
-}
-
-// WorkspaceUserAccess is a representation of a workspace user access.
-type WorkspaceUserAccess struct {
-	WorkspaceAccessBaseModel
-	ActorID uuid.UUID `json:"actor_id"`
-	UserID  uuid.UUID `json:"user_id"`
-
-	Email     string `json:"email"`
-	Handle    string `json:"handle"`
-	FirstName string `json:"first_name"`
-	LastName  string `json:"last_name"`
+	ActorID *uuid.UUID `json:"actor_id"`
+	BotID   *uuid.UUID `json:"bot_id"`
+	UserID  *uuid.UUID `json:"user_id"`
 }
 
 // WorkspaceAccessUpsert defines the payload
 // when upserting a workspace access request.
 type WorkspaceAccessUpsert struct {
-	WorkspaceRoleID uuid.UUID  `json:"workspace_role_id"`
-	UserID          *uuid.UUID `json:"user_id,omitempty"`
-	BotID           *uuid.UUID `json:"bot_id,omitempty"`
+	WorkspaceRoleID uuid.UUID `json:"workspace_role_id"`
+
+	// Only one of the follow IDs should be set on each call
+	// depending on the resource's AccessorType
+	UserID uuid.UUID `json:"user_id,omitempty"`
+	BotID  uuid.UUID `json:"bot_id,omitempty"`
 }

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -50,6 +50,7 @@ func (c *AccountsClient) Get(ctx context.Context, accountID uuid.UUID) (*api.Acc
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -84,6 +85,7 @@ func (c *AccountsClient) Update(ctx context.Context, accountID uuid.UUID, data a
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -108,6 +110,7 @@ func (c *AccountsClient) Delete(ctx context.Context, accountID uuid.UUID) error 
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -48,7 +49,8 @@ func (c *AccountsClient) Get(ctx context.Context, accountID uuid.UUID) (*api.Acc
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var account api.AccountResponse
@@ -81,7 +83,8 @@ func (c *AccountsClient) Update(ctx context.Context, accountID uuid.UUID, data a
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil
@@ -104,7 +107,8 @@ func (c *AccountsClient) Delete(ctx context.Context, accountID uuid.UUID) error 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil

--- a/internal/client/service_accounts.go
+++ b/internal/client/service_accounts.go
@@ -64,6 +64,7 @@ func (sa *ServiceAccountsClient) Create(ctx context.Context, request api.Service
 
 	if resp.StatusCode != http.StatusCreated {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -96,6 +97,7 @@ func (sa *ServiceAccountsClient) List(ctx context.Context, filter api.ServiceAcc
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -160,6 +162,7 @@ func (sa *ServiceAccountsClient) Update(ctx context.Context, botID string, reque
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -181,6 +184,7 @@ func (sa *ServiceAccountsClient) Delete(ctx context.Context, botID string) error
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -207,6 +211,7 @@ func (sa *ServiceAccountsClient) RotateKey(ctx context.Context, serviceAccountID
 
 	if resp.StatusCode != http.StatusCreated {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 

--- a/internal/client/service_accounts.go
+++ b/internal/client/service_accounts.go
@@ -63,11 +63,8 @@ func (sa *ServiceAccountsClient) Create(ctx context.Context, request api.Service
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		// Read the response body
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		bodyString := string(bodyBytes)
-
-		return nil, fmt.Errorf("status code: %s, response body: %s", resp.Status, bodyString)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var response api.ServiceAccount
@@ -98,7 +95,8 @@ func (sa *ServiceAccountsClient) List(ctx context.Context, filter api.ServiceAcc
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var serviceAccounts []*api.ServiceAccount
@@ -161,7 +159,8 @@ func (sa *ServiceAccountsClient) Update(ctx context.Context, botID string, reque
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil
@@ -181,7 +180,8 @@ func (sa *ServiceAccountsClient) Delete(ctx context.Context, botID string) error
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil
@@ -206,7 +206,8 @@ func (sa *ServiceAccountsClient) RotateKey(ctx context.Context, serviceAccountID
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var serviceAccount api.ServiceAccount

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -68,7 +69,8 @@ func (c *VariablesClient) Create(ctx context.Context, data api.VariableCreate) (
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var variable api.Variable
@@ -103,7 +105,8 @@ func (c *VariablesClient) Get(ctx context.Context, variableID uuid.UUID) (*api.V
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var variable api.Variable
@@ -130,7 +133,8 @@ func (c *VariablesClient) GetByName(ctx context.Context, name string) (*api.Vari
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var variable api.Variable
@@ -162,7 +166,8 @@ func (c *VariablesClient) Update(ctx context.Context, variableID uuid.UUID, data
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil
@@ -184,7 +189,8 @@ func (c *VariablesClient) Delete(ctx context.Context, variableID uuid.UUID) erro
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -70,6 +70,7 @@ func (c *VariablesClient) Create(ctx context.Context, data api.VariableCreate) (
 
 	if resp.StatusCode != http.StatusCreated {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -106,6 +107,7 @@ func (c *VariablesClient) Get(ctx context.Context, variableID uuid.UUID) (*api.V
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -134,6 +136,7 @@ func (c *VariablesClient) GetByName(ctx context.Context, name string) (*api.Vari
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -167,6 +170,7 @@ func (c *VariablesClient) Update(ctx context.Context, variableID uuid.UUID, data
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -190,6 +194,7 @@ func (c *VariablesClient) Delete(ctx context.Context, variableID uuid.UUID) erro
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -69,6 +69,7 @@ func (c *WorkPoolsClient) Create(ctx context.Context, data api.WorkPoolCreate) (
 
 	if resp.StatusCode != http.StatusCreated {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -102,6 +103,7 @@ func (c *WorkPoolsClient) List(ctx context.Context, filter api.WorkPoolFilter) (
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -130,6 +132,7 @@ func (c *WorkPoolsClient) Get(ctx context.Context, name string) (*api.WorkPool, 
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -163,6 +166,7 @@ func (c *WorkPoolsClient) Update(ctx context.Context, name string, data api.Work
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -186,6 +190,7 @@ func (c *WorkPoolsClient) Delete(ctx context.Context, name string) error {
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -67,7 +68,8 @@ func (c *WorkPoolsClient) Create(ctx context.Context, data api.WorkPoolCreate) (
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var pool api.WorkPool
@@ -99,7 +101,8 @@ func (c *WorkPoolsClient) List(ctx context.Context, filter api.WorkPoolFilter) (
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var pools []*api.WorkPool
@@ -126,7 +129,8 @@ func (c *WorkPoolsClient) Get(ctx context.Context, name string) (*api.WorkPool, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var pool api.WorkPool
@@ -158,7 +162,8 @@ func (c *WorkPoolsClient) Update(ctx context.Context, name string, data api.Work
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil
@@ -180,7 +185,8 @@ func (c *WorkPoolsClient) Delete(ctx context.Context, name string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil

--- a/internal/client/workspace_access.go
+++ b/internal/client/workspace_access.go
@@ -77,6 +77,7 @@ func (c *WorkspaceAccessClient) Upsert(ctx context.Context, accessorType string,
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -112,6 +113,7 @@ func (c *WorkspaceAccessClient) Get(ctx context.Context, accessorType string, ac
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -147,6 +149,7 @@ func (c *WorkspaceAccessClient) Delete(ctx context.Context, accessorType string,
 
 	if resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 

--- a/internal/client/workspace_access.go
+++ b/internal/client/workspace_access.go
@@ -1,0 +1,198 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+)
+
+// type assertion ensures that this client implements the interface.
+var _ = api.WorkspaceAccessClient(&WorkspaceAccessClient{})
+
+type WorkspaceAccessClient struct {
+	hc          *http.Client
+	apiKey      string
+	routePrefix string
+}
+
+// WorkspaceAccess is a factory that initializes and returns a WorkspaceAccessClient.
+//
+//nolint:ireturn // required to support PrefectClient mocking
+func (c *Client) WorkspaceAccess(accountID uuid.UUID, workspaceID uuid.UUID) (api.WorkspaceAccessClient, error) {
+	if accountID == uuid.Nil {
+		accountID = c.defaultAccountID
+	}
+	if workspaceID == uuid.Nil {
+		workspaceID = c.defaultWorkspaceID
+	}
+	if accountID == uuid.Nil || workspaceID == uuid.Nil {
+		return nil, fmt.Errorf("both accountID and workspaceID must be defined")
+	}
+
+	return &WorkspaceAccessClient{
+		hc:          c.hc,
+		apiKey:      c.apiKey,
+		routePrefix: fmt.Sprintf("%s/accounts/%s/workspaces/%s", c.endpoint, accountID.String(), workspaceID.String()),
+	}, nil
+}
+
+// UpsertServiceAccountAccess creates or updates a service account's access to a workspace.
+func (c *WorkspaceAccessClient) UpsertServiceAccountAccess(ctx context.Context, payload api.WorkspaceAccessUpsert) (*api.WorkspaceServiceAccountAccess, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&payload); err != nil {
+		return nil, fmt.Errorf("failed to encode create payload data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/bot_access/", c.routePrefix), &buf)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code %s", resp.Status)
+	}
+
+	var workspaceServiceAccountAccess api.WorkspaceServiceAccountAccess
+	if err := json.NewDecoder(resp.Body).Decode(&workspaceServiceAccountAccess); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &workspaceServiceAccountAccess, nil
+}
+
+// UpsertUserAccess creates or updates a user's access to a workspace.
+func (c *WorkspaceAccessClient) UpsertUserAccess(ctx context.Context, payload api.WorkspaceAccessUpsert) (*api.WorkspaceUserAccess, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&payload); err != nil {
+		return nil, fmt.Errorf("failed to encode create payload data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/user_access/", c.routePrefix), &buf)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code %s", resp.Status)
+	}
+
+	var workspaceUserAccess api.WorkspaceUserAccess
+	if err := json.NewDecoder(resp.Body).Decode(&workspaceUserAccess); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &workspaceUserAccess, nil
+}
+
+// GetServiceAccountAccess fetches a service account's workspace access via accessID.
+func (c *WorkspaceAccessClient) GetServiceAccountAccess(ctx context.Context, accessID uuid.UUID) (*api.WorkspaceServiceAccountAccess, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/bot_access/%s", c.routePrefix, accessID.String()), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code %s", resp.Status)
+	}
+
+	var workspaceServiceAccountAccess api.WorkspaceServiceAccountAccess
+	if err := json.NewDecoder(resp.Body).Decode(&workspaceServiceAccountAccess); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &workspaceServiceAccountAccess, nil
+}
+
+// GetUserAccess fetches a user's workspace access via accessID.
+func (c *WorkspaceAccessClient) GetUserAccess(ctx context.Context, accessID uuid.UUID) (*api.WorkspaceUserAccess, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/user_access/%s", c.routePrefix, accessID.String()), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code %s", resp.Status)
+	}
+
+	var workspaceUserAccess api.WorkspaceUserAccess
+	if err := json.NewDecoder(resp.Body).Decode(&workspaceUserAccess); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &workspaceUserAccess, nil
+}
+
+// DeleteServiceAccountAccess deletes a service account's workspace access via accessID.
+func (c *WorkspaceAccessClient) DeleteServiceAccountAccess(ctx context.Context, accessID uuid.UUID) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf("%s/bot_access/%s", c.routePrefix, accessID.String()), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("status code %s", resp.Status)
+	}
+
+	return nil
+}
+
+// DeleteUserAccess deletes a service account's workspace access via accessID.
+func (c *WorkspaceAccessClient) DeleteUserAccess(ctx context.Context, accessID uuid.UUID) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf("%s/user_access/%s", c.routePrefix, accessID.String()), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("status code %s", resp.Status)
+	}
+
+	return nil
+}

--- a/internal/client/workspace_roles.go
+++ b/internal/client/workspace_roles.go
@@ -58,6 +58,7 @@ func (c *WorkspaceRolesClient) Create(ctx context.Context, data api.WorkspaceRol
 
 	if resp.StatusCode != http.StatusCreated {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -91,6 +92,7 @@ func (c *WorkspaceRolesClient) Update(ctx context.Context, workspaceRoleID uuid.
 
 	if resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -114,6 +116,7 @@ func (c *WorkspaceRolesClient) Delete(ctx context.Context, id uuid.UUID) error {
 
 	if resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -145,6 +148,7 @@ func (c *WorkspaceRolesClient) List(ctx context.Context, roleNames []string) ([]
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -173,6 +177,7 @@ func (c *WorkspaceRolesClient) Get(ctx context.Context, id uuid.UUID) (*api.Work
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 

--- a/internal/client/workspace_roles.go
+++ b/internal/client/workspace_roles.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -56,7 +57,8 @@ func (c *WorkspaceRolesClient) Create(ctx context.Context, data api.WorkspaceRol
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var workspaceRole api.WorkspaceRole
@@ -88,7 +90,8 @@ func (c *WorkspaceRolesClient) Update(ctx context.Context, workspaceRoleID uuid.
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil
@@ -110,7 +113,8 @@ func (c *WorkspaceRolesClient) Delete(ctx context.Context, id uuid.UUID) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil
@@ -140,7 +144,8 @@ func (c *WorkspaceRolesClient) List(ctx context.Context, roleNames []string) ([]
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var workspaceRoles []*api.WorkspaceRole
@@ -167,7 +172,8 @@ func (c *WorkspaceRolesClient) Get(ctx context.Context, id uuid.UUID) (*api.Work
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var workspaceRole api.WorkspaceRole

--- a/internal/client/workspaces.go
+++ b/internal/client/workspaces.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -57,7 +58,8 @@ func (c *WorkspacesClient) Create(ctx context.Context, data api.WorkspaceCreate)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var workspace api.Workspace
@@ -84,7 +86,8 @@ func (c *WorkspacesClient) Get(ctx context.Context, workspaceID uuid.UUID) (*api
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	var workspace api.Workspace
@@ -116,7 +119,8 @@ func (c *WorkspacesClient) Update(ctx context.Context, workspaceID uuid.UUID, da
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil
@@ -138,7 +142,8 @@ func (c *WorkspacesClient) Delete(ctx context.Context, workspaceID uuid.UUID) er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("status code %s", resp.Status)
+		errorBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
 	return nil

--- a/internal/client/workspaces.go
+++ b/internal/client/workspaces.go
@@ -59,6 +59,7 @@ func (c *WorkspacesClient) Create(ctx context.Context, data api.WorkspaceCreate)
 
 	if resp.StatusCode != http.StatusCreated {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -87,6 +88,7 @@ func (c *WorkspacesClient) Get(ctx context.Context, workspaceID uuid.UUID) (*api
 
 	if resp.StatusCode != http.StatusOK {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -120,6 +122,7 @@ func (c *WorkspacesClient) Update(ctx context.Context, workspaceID uuid.UUID, da
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
@@ -143,6 +146,7 @@ func (c *WorkspacesClient) Delete(ctx context.Context, workspaceID uuid.UUID) er
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		errorBody, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 

--- a/internal/provider/helpers/diagnostics.go
+++ b/internal/provider/helpers/diagnostics.go
@@ -18,3 +18,14 @@ func CreateClientErrorDiagnostic(clientName string, err error) diag.Diagnostic {
 		fmt.Sprintf("Could not create %s client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", clientName, err.Error()),
 	)
 }
+
+// ResourceClientErrorDiagnostic returns an error diagnostic for when a
+// client call fails during any resource operations (CRUD).
+//
+//nolint:ireturn // required by Terraform API
+func ResourceClientErrorDiagnostic(resourceName string, operation string, err error) diag.Diagnostic {
+	return diag.NewErrorDiagnostic(
+		fmt.Sprintf("Error during %s %s", operation, resourceName),
+		fmt.Sprintf("Could not %s %s, unexpected error: %s", operation, resourceName, err),
+	)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -235,11 +235,11 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 func (p *PrefectProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		datasources.NewAccountDataSource,
+		datasources.NewServiceAccountDataSource,
 		datasources.NewVariableDataSource,
 		datasources.NewWorkPoolDataSource,
 		datasources.NewWorkPoolsDataSource,
 		datasources.NewWorkspaceDataSource,
-		datasources.NewServiceAccountDataSource,
 		datasources.NewWorkspaceRoleDataSource,
 	}
 }
@@ -248,10 +248,11 @@ func (p *PrefectProvider) DataSources(_ context.Context) []func() datasource.Dat
 func (p *PrefectProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		resources.NewAccountResource,
+		resources.NewServiceAccountResource,
 		resources.NewVariableResource,
 		resources.NewWorkPoolResource,
+		resources.NewWorkspaceAccessResource,
 		resources.NewWorkspaceResource,
-		resources.NewServiceAccountResource,
 		resources.NewWorkspaceRoleResource,
 	}
 }

--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
+	"github.com/prefecthq/terraform-provider-prefect/internal/utils"
 )
 
 var _ = resource.ResourceWithConfigure(&WorkspaceAccessResource{})
@@ -83,7 +84,7 @@ func (r *WorkspaceAccessResource) Schema(_ context.Context, _ resource.SchemaReq
 				Required:    true,
 				Description: "USER or SERVICE_ACCOUNT",
 				Validators: []validator.String{
-					stringvalidator.OneOf("USER", "SERVICE_ACCOUNT"),
+					stringvalidator.OneOf(utils.ServiceAccount, utils.User),
 				},
 			},
 			"accessor_id": schema.StringAttribute{

--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -1,0 +1,279 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
+)
+
+var _ = resource.ResourceWithConfigure(&WorkspaceAccessResource{})
+
+type WorkspaceAccessResource struct {
+	client api.PrefectClient
+}
+
+type WorkspaceAccessResourceModel struct {
+	ID              types.String          `tfsdk:"id"`
+	AccessorType    types.String          `tfsdk:"accessor_type"`
+	AccessorID      customtypes.UUIDValue `tfsdk:"accessor_id"`
+	WorkspaceRoleID customtypes.UUIDValue `tfsdk:"workspace_role_id"`
+
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+}
+
+// NewWorkspaceAccessResource returns a new WorkspaceAccessResource.
+//
+//nolint:ireturn // required by Terraform API
+func NewWorkspaceAccessResource() resource.Resource {
+	return &WorkspaceAccessResource{}
+}
+
+// Metadata returns the resource type name.
+func (r *WorkspaceAccessResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_workspace_access"
+}
+
+// Configure initializes runtime state for the resource.
+func (r *WorkspaceAccessResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(api.PrefectClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected api.PrefectClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *WorkspaceAccessResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Resource representing Prefect Workspace Access for a User or Service Account",
+		Version:     0,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Workspace Access UUID",
+				// attributes which are not configurable + should not show updates from the existing state value
+				// should implement `UseStateForUnknown()`
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"accessor_type": schema.StringAttribute{
+				Required:    true,
+				Description: "USER or SERVICE_ACCOUNT",
+				Validators: []validator.String{
+					stringvalidator.OneOf("USER", "SERVICE_ACCOUNT"),
+				},
+			},
+			"accessor_id": schema.StringAttribute{
+				Required:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "ID of accessor to the workspace",
+			},
+			"account_id": schema.StringAttribute{
+				Optional:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "Account ID where the workspace is located",
+			},
+			"workspace_id": schema.StringAttribute{
+				Optional:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "Workspace ID to grant access to",
+			},
+			"workspace_role_id": schema.StringAttribute{
+				Required:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "Workspace Role ID to grant to accessor",
+			},
+		},
+	}
+}
+
+// copyWorkspaceAccessToModel copies the API resource to the Terraform model.
+// Note that api.WorkspaceAccess represents a combined model for all accessor types,
+// meaning accessory-specific attributes like BotID and UserID will be conditionally nil
+// depending on the accessor type.
+func copyWorkspaceAccessToModel(access *api.WorkspaceAccess, model *WorkspaceAccessResourceModel) {
+	model.ID = types.StringValue(access.ID.String())
+	model.WorkspaceRoleID = customtypes.NewUUIDValue(access.WorkspaceRoleID)
+	model.WorkspaceID = customtypes.NewUUIDValue(access.WorkspaceID)
+
+	if access.BotID != nil {
+		model.AccessorID = customtypes.NewUUIDValue(*access.BotID)
+	}
+	if access.UserID != nil {
+		model.AccessorID = customtypes.NewUUIDValue(*access.UserID)
+	}
+}
+
+// Create will create the Workspace Access resource through the API and insert it into the State.
+func (r *WorkspaceAccessResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var config WorkspaceAccessResourceModel
+
+	// Populate the model from resource configuration and emit diagnostics on error
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := r.client.WorkspaceAccess(config.AccountID.ValueUUID(), config.WorkspaceID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Workspace Access", err))
+
+		return
+	}
+
+	accessorType := config.AccessorType.ValueString()
+
+	workspaceAccess, err := client.Upsert(ctx, accessorType, config.AccessorID.ValueUUID(), config.WorkspaceRoleID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace Access", "create", err))
+
+		return
+	}
+
+	copyWorkspaceAccessToModel(workspaceAccess, &config)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *WorkspaceAccessResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state WorkspaceAccessResourceModel
+
+	// Populate the model from state and emit diagnostics on error
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := r.client.WorkspaceAccess(state.AccountID.ValueUUID(), state.WorkspaceID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Workspace Access", err))
+
+		return
+	}
+
+	accessID, err := uuid.Parse(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Workspace Role ID",
+			fmt.Sprintf("Could not parse Workspace Access ID to UUID, unexpected error: %s", err.Error()),
+		)
+	}
+
+	accessorType := state.AccessorType.ValueString()
+
+	workspaceAccess, err := client.Get(ctx, accessorType, accessID)
+	if err != nil {
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace Access", "read", err))
+
+		return
+	}
+
+	copyWorkspaceAccessToModel(workspaceAccess, &state)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *WorkspaceAccessResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan WorkspaceAccessResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := r.client.WorkspaceAccess(plan.AccountID.ValueUUID(), plan.WorkspaceID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Workspace Access", err))
+
+		return
+	}
+
+	accessorType := plan.AccessorType.ValueString()
+
+	workspaceAccess, err := client.Upsert(ctx, accessorType, plan.AccessorID.ValueUUID(), plan.WorkspaceRoleID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace Access", "update", err))
+
+		return
+	}
+
+	copyWorkspaceAccessToModel(workspaceAccess, &plan)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *WorkspaceAccessResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state WorkspaceAccessResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	client, err := r.client.WorkspaceAccess(state.AccountID.ValueUUID(), state.WorkspaceID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Workspace Access", err))
+
+		return
+	}
+
+	accessID, err := uuid.Parse(state.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing Workspace Access ID",
+			fmt.Sprintf("Could not parse Workspace Access ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	accessorType := state.AccessorType.ValueString()
+
+	err = client.Delete(ctx, accessorType, accessID)
+	if err != nil {
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace Access", "delete", err))
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/internal/provider/resources/workspace_access_test.go
+++ b/internal/provider/resources/workspace_access_test.go
@@ -28,6 +28,7 @@ resource "prefect_workspace_access" "bot_access" {
 }`, botName)
 }
 
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_bot_workspace_access(t *testing.T) {
 	resourceName := "prefect_workspace_access.bot_access"
 	randomName := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)

--- a/internal/provider/resources/workspace_access_test.go
+++ b/internal/provider/resources/workspace_access_test.go
@@ -1,0 +1,49 @@
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
+)
+
+func fixtureAccWorkspaceAccessResource(botName string) string {
+	return fmt.Sprintf(`
+data "prefect_workspace_role" "developer" {
+	name = "Developer"
+}
+data "prefect_workspace" "evergreen" {
+	id = "45cfa7c6-e136-471c-859b-3be89d0a99ce"
+}
+resource "prefect_service_account" "bot" {
+	name = "%s"
+}
+resource "prefect_workspace_access" "bot_access" {
+	accessor_type = "SERVICE_ACCOUNT"
+	accessor_id = prefect_service_account.bot.id
+	workspace_id = data.prefect_workspace.evergreen.id
+	workspace_role_id = data.prefect_workspace_role.developer.id
+}`, botName)
+}
+
+func TestAccResource_bot_workspace_access(t *testing.T) {
+	resourceName := "prefect_workspace_access.bot_access"
+	randomName := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fixtureAccWorkspaceAccessResource(randomName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check creation + existence of the workspace access resource, with matching linked attributes
+					resource.TestCheckResourceAttrPair(resourceName, "accessor_id", "prefect_service_account.bot", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", "data.prefect_workspace.evergreen", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_role_id", "data.prefect_workspace_role.developer", "id"),
+				),
+			},
+		},
+	})
+}

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -1,0 +1,5 @@
+package utils
+
+// Workspace Accessor Types.
+const ServiceAccount string = "SERVICE_ACCOUNT"
+const User string = "USER"


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/74

This PR adds a new resource called `prefect_workspace_access`, which links an `accessor` (can be a user, service account, or any future type) with a workspace role

this resource / client are slightly different from the rest in that it's polymorphic in nature, so there are some shared data models (eg. `api.WorkspaceAccess`), which will conditionally present a non-nil value for `userID` or `botID` depending on the `accessorType`.  

Additionally, we've opted to skip supporting a datasource or resource state import in this instance; the workspace access API takes upserting as the primary write path via the combination of an accessor <> workspace, so any future practitioner can just redefine an existing access relationship in TF without worrying about having to import anything

The `accessorType` is restricted on the resource schema by a `OneOf()` string validator - therefore, this PR also introduces a new go dependency called [terraform-plugin-framework-validators](github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator)

Usage example (included in the PR)
```hcl
data "prefect_workspace_role" "developer" {
	name = "Developer"
}
data "prefect_workspace" "prd" {
	id = "<workspace uuid>"
}
resource "prefect_service_account" "bot" {
	name = "a-cool-bot"
}
resource "prefect_workspace_access" "bot_access" {
	accessor_type = "SERVICE ACCOUNT"
	accessor_id = prefect_service_account.bot.id
	workspace_id = data.prefect_workspace.prd.id
	workspace_role_id = data.prefect_workspace_role.developer.id
}
```

Applying this to our acceptance testing environment shows the link between the workspace and Service Account in the `Workspace Sharing` section

<img width="1039" alt="image" src="https://github.com/PrefectHQ/terraform-provider-prefect/assets/19556538/188b2530-b6c4-4031-bdb7-9e951edc92eb">
