### PR TITLE
feat: `prefect_account_role` Datasource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
     hooks:
     - id: golangci-lint
       name: golangci-lint
-      description: Fast linters runner for Go. Note that only modified files are linted, so linters like 'unused' that need to scan all files won't work as expected.
       entry: golangci-lint run
       types: [go]
       language: golang

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,7 @@ repos:
       language: golang
       require_serial: true
       pass_filenames: false
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.83.5
+    hooks:
+      - id: terraform_fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,13 @@
 fail_fast: false
 
 repos:
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
+  - repo: local
     hooks:
-      - id: golangci-lint
+    - id: golangci-lint
+      name: golangci-lint
+      description: Fast linters runner for Go. Note that only modified files are linted, so linters like 'unused' that need to scan all files won't work as expected.
+      entry: golangci-lint run --new-from-rev HEAD --fix
+      types: [go]
+      language: golang
+      require_serial: true
+      pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     - id: golangci-lint
       name: golangci-lint
       description: Fast linters runner for Go. Note that only modified files are linted, so linters like 'unused' that need to scan all files won't work as expected.
-      entry: golangci-lint run --new-from-rev HEAD --fix
+      entry: golangci-lint run
       types: [go]
       language: golang
       require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+---
+fail_fast: false
+
+repos:
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: golangci-lint

--- a/examples/account_roles.tf
+++ b/examples/account_roles.tf
@@ -1,0 +1,6 @@
+data "prefect_account_role" "owner" {
+  name = "Owner"
+}
+data "prefect_account_role" "member" {
+  name = "Member"
+}

--- a/examples/account_roles.tf
+++ b/examples/account_roles.tf
@@ -1,6 +1,7 @@
 data "prefect_account_role" "owner" {
   name = "Owner"
 }
+
 data "prefect_account_role" "member" {
   name = "Member"
 }

--- a/examples/local.tfvars
+++ b/examples/local.tfvars
@@ -1,3 +1,3 @@
-PREFECT_API_KEY=""
-PREFECT_ACCOUNT_ID=""
-PREFECT_API_URL="https://api.prefect.cloud/api"
+PREFECT_API_KEY    = ""
+PREFECT_ACCOUNT_ID = ""
+PREFECT_API_URL    = "https://api.prefect.cloud/api"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -8,6 +8,6 @@ terraform {
 }
 
 provider "prefect" {
-  api_key = var.PREFECT_API_KEY
+  api_key    = var.PREFECT_API_KEY
   account_id = var.PREFECT_ACCOUNT_ID
 }

--- a/examples/service_accounts.tf
+++ b/examples/service_accounts.tf
@@ -1,9 +1,9 @@
 provider "time" {}
 resource "time_rotating" "ninety_days" {
-    rotation_days = 90
+  rotation_days = 90
 }
 
 resource "prefect_service_account" "sa_example" {
-    name = "my-service-account"
-    api_key_expiration = time_rotating.ninety_days.rotation_rfc3339
+  name               = "my-service-account"
+  api_key_expiration = time_rotating.ninety_days.rotation_rfc3339
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
+	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.19.0
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-plugin-framework v1.4.2 h1:P7a7VP1GZbjc4rv921Xy5OckzhoiO3ig6SGxwelD2sI=
 github.com/hashicorp/terraform-plugin-framework v1.4.2/go.mod h1:GWl3InPFZi2wVQmdVnINPKys09s9mLmTZr95/ngLnbY=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.19.0 h1:BuZx/6Cp+lkmiG0cOBk6Zps0Cb2tmqQpDM3iAtnhDQU=
 github.com/hashicorp/terraform-plugin-go v0.19.0/go.mod h1:EhRSkEPNoylLQntYsk5KrDHTZJh9HQoumZXbOGOXmec=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/api/account_roles.go
+++ b/internal/api/account_roles.go
@@ -16,6 +16,9 @@ type AccountRole struct {
 	BaseModel
 	Name        string   `json:"name"`
 	Permissions []string `json:"permissions"`
+
+	AccountID    *uuid.UUID `json:"account_id"`
+	IsSystemRole bool       `json:"is_system_role"`
 }
 
 // AccountRoleFilter defines the search filter payload

--- a/internal/api/account_roles.go
+++ b/internal/api/account_roles.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type AccountRolesClient interface {
+	Get(ctx context.Context, roleID uuid.UUID) (*AccountRole, error)
+	List(ctx context.Context, roleNames []string) ([]*AccountRole, error)
+}
+
+// AccountRole is a representation of an account role.
+type AccountRole struct {
+	BaseModel
+	Name        string   `json:"name"`
+	Permissions []string `json:"permissions"`
+}
+
+// AccountRoleFilter defines the search filter payload
+// when searching for workspace roles by name.
+// example request payload:
+// {"account_roles": {"name": {"any_": ["test"]}}}.
+type AccountRoleFilter struct {
+	AccountRoles struct {
+		Name struct {
+			Any []string `json:"any_"`
+		} `json:"name"`
+	} `json:"account_roles"`
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,6 +5,7 @@ import "github.com/google/uuid"
 // PrefectClient returns clients for different aspects of our API.
 type PrefectClient interface {
 	Accounts() (AccountsClient, error)
+	AccountRoles(accountID uuid.UUID) (AccountRolesClient, error)
 	Workspaces(accountID uuid.UUID) (WorkspacesClient, error)
 	WorkspaceRoles(accountID uuid.UUID) (WorkspaceRolesClient, error)
 	WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (WorkPoolsClient, error)

--- a/internal/api/service_accounts.go
+++ b/internal/api/service_accounts.go
@@ -19,9 +19,9 @@ type ServiceAccountsClient interface {
 /*** REQUEST DATA STRUCTS ***/
 
 type ServiceAccountCreateRequest struct {
-	Name             string `json:"name"`
-	APIKeyExpiration string `json:"api_key_expiration,omitempty"`
-	AccountRoleID    string `json:"account_role_id,omitempty"`
+	Name             string     `json:"name"`
+	APIKeyExpiration string     `json:"api_key_expiration,omitempty"`
+	AccountRoleID    *uuid.UUID `json:"account_role_id,omitempty"`
 }
 
 type ServiceAccountUpdateRequest struct {

--- a/internal/client/account_roles.go
+++ b/internal/client/account_roles.go
@@ -36,7 +36,7 @@ func (c *Client) AccountRoles(accountID uuid.UUID) (api.AccountRolesClient, erro
 	}, nil
 }
 
-// List returns a list of account roles, based on the provided filter.
+// list returns a list of account roles, based on the provided filter.
 func (c *AccountRolesClient) List(ctx context.Context, roleNames []string) ([]*api.AccountRole, error) {
 	var buf bytes.Buffer
 	filterQuery := api.AccountRoleFilter{}

--- a/internal/client/account_roles.go
+++ b/internal/client/account_roles.go
@@ -21,7 +21,7 @@ type AccountRolesClient struct {
 	routePrefix string
 }
 
-// AccountRoles is a factory that initializes and returns a AccountRolesClient.
+// accountRoles is a factory that initializes and returns a AccountRolesClient.
 //
 //nolint:ireturn // required to support PrefectClient mocking
 func (c *Client) AccountRoles(accountID uuid.UUID) (api.AccountRolesClient, error) {

--- a/internal/client/account_roles.go
+++ b/internal/client/account_roles.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+)
+
+// type assertion ensures that this client implements the interface.
+var _ = api.AccountRolesClient(&AccountRolesClient{})
+
+type AccountRolesClient struct {
+	hc          *http.Client
+	apiKey      string
+	routePrefix string
+}
+
+// AccountRoles is a factory that initializes and returns a AccountRolesClient.
+//
+//nolint:ireturn // required to support PrefectClient mocking
+func (c *Client) AccountRoles(accountID uuid.UUID) (api.AccountRolesClient, error) {
+	if accountID == uuid.Nil {
+		accountID = c.defaultAccountID
+	}
+
+	return &AccountRolesClient{
+		hc:          c.hc,
+		apiKey:      c.apiKey,
+		routePrefix: fmt.Sprintf("%s/accounts/%s/account_roles", c.endpoint, accountID.String()),
+	}, nil
+}
+
+// List returns a list of account roles, based on the provided filter.
+func (c *AccountRolesClient) List(ctx context.Context, roleNames []string) ([]*api.AccountRole, error) {
+	var buf bytes.Buffer
+	filterQuery := api.AccountRoleFilter{}
+	filterQuery.AccountRoles.Name.Any = roleNames
+
+	if err := json.NewEncoder(&buf).Encode(&filterQuery); err != nil {
+		return nil, fmt.Errorf("failed to encode filter payload data: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/filter", c.routePrefix), &buf)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errorBody, _ := io.ReadAll(resp.Body)
+
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
+	}
+
+	var accountRoles []*api.AccountRole
+	if err := json.NewDecoder(resp.Body).Decode(&accountRoles); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return accountRoles, nil
+}
+
+// Get returns an account role by ID.
+func (c *AccountRolesClient) Get(ctx context.Context, roleID uuid.UUID) (*api.AccountRole, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/%s", c.routePrefix, roleID.String()), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errorBody, _ := io.ReadAll(resp.Body)
+
+		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
+	}
+
+	var accountRole api.AccountRole
+	if err := json.NewDecoder(resp.Body).Decode(&accountRole); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &accountRole, nil
+}

--- a/internal/client/account_roles.go
+++ b/internal/client/account_roles.go
@@ -21,7 +21,7 @@ type AccountRolesClient struct {
 	routePrefix string
 }
 
-// accountRoles is a factory that initializes and returns a AccountRolesClient.
+// AccountRoles is a factory that initializes and returns a AccountRolesClient.
 //
 //nolint:ireturn // required to support PrefectClient mocking
 func (c *Client) AccountRoles(accountID uuid.UUID) (api.AccountRolesClient, error) {
@@ -36,7 +36,7 @@ func (c *Client) AccountRoles(accountID uuid.UUID) (api.AccountRolesClient, erro
 	}, nil
 }
 
-// List returns a list of account roles, based on the provided filter.
+// list returns a list of account roles, based on the provided filter.
 func (c *AccountRolesClient) List(ctx context.Context, roleNames []string) ([]*api.AccountRole, error) {
 	var buf bytes.Buffer
 	filterQuery := api.AccountRoleFilter{}

--- a/internal/client/account_roles.go
+++ b/internal/client/account_roles.go
@@ -36,7 +36,7 @@ func (c *Client) AccountRoles(accountID uuid.UUID) (api.AccountRolesClient, erro
 	}, nil
 }
 
-// list returns a list of account roles, based on the provided filter.
+// List returns a list of account roles, based on the provided filter.
 func (c *AccountRolesClient) List(ctx context.Context, roleNames []string) ([]*api.AccountRole, error) {
 	var buf bytes.Buffer
 	filterQuery := api.AccountRoleFilter{}

--- a/internal/provider/datasources/account_role.go
+++ b/internal/provider/datasources/account_role.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
@@ -68,6 +70,9 @@ func (d *AccountRoleDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Name of the Account Role",
+				Validators: []validator.String{
+					stringvalidator.OneOf("Admin", "Member"),
+				},
 			},
 			"permissions": schema.ListAttribute{
 				Computed:    true,

--- a/internal/provider/datasources/account_role.go
+++ b/internal/provider/datasources/account_role.go
@@ -1,0 +1,167 @@
+package datasources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var _ datasource.DataSource = &AccountRoleDataSource{}
+var _ datasource.DataSourceWithConfigure = &AccountRoleDataSource{}
+
+type AccountRoleDataSource struct {
+	client api.PrefectClient
+}
+
+// AccountRoleDataSource defines the Terraform data source model
+// the TF data source configuration will be unmarshalled into this struct.
+type AccountRoleDataSourceModel struct {
+	ID      customtypes.UUIDValue      `tfsdk:"id"`
+	Created customtypes.TimestampValue `tfsdk:"created"`
+	Updated customtypes.TimestampValue `tfsdk:"updated"`
+
+	Name         types.String          `tfsdk:"name"`
+	Permissions  types.List            `tfsdk:"permissions"`
+	AccountID    customtypes.UUIDValue `tfsdk:"account_id"`
+	IsSystemRole types.Bool            `tfsdk:"is_system_role"`
+}
+
+// NewWorkspaceRoleDataSource returns a new WorkspaceRoleDataSource.
+//
+//nolint:ireturn // required by Terraform API
+func NewAccountRoleDataSource() datasource.DataSource {
+	return &AccountRoleDataSource{}
+}
+
+// Metadata returns the data source type name.
+func (d *AccountRoleDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_account_role"
+}
+
+// Schema defines the schema for the data source.
+func (d *AccountRoleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Data Source representing a Prefect Workspace Role",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "Account Role UUID",
+			},
+			"created": schema.StringAttribute{
+				Computed:    true,
+				CustomType:  customtypes.TimestampType{},
+				Description: "Date and time of the Account Role creation in RFC 3339 format",
+			},
+			"updated": schema.StringAttribute{
+				Computed:    true,
+				CustomType:  customtypes.TimestampType{},
+				Description: "Date and time that the Account Role was last updated in RFC 3339 format",
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the Account Role",
+			},
+			"permissions": schema.ListAttribute{
+				Computed:    true,
+				Description: "List of permissions linked to the Account Role",
+				ElementType: types.StringType,
+			},
+			"account_id": schema.StringAttribute{
+				Optional:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "Account UUID where Account Role resides",
+			},
+			"is_system_role": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Account UUID where Account Role resides",
+			},
+		},
+	}
+}
+
+// Configure adds the provider-configured client to the data source.
+func (d *AccountRoleDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(api.PrefectClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected api.PrefectClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *AccountRoleDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var config AccountRoleDataSourceModel
+
+	// Populate the model from data source configuration and emit diagnostics on error
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := d.client.AccountRoles(config.AccountID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Account Roles", err))
+
+		return
+	}
+
+	// Fetch an existing Account Role by name
+	// Here, we'd expect only 1 Role (or none) to be returned
+	// as we are querying a single Role name, not a list of names
+	accountRoles, err := client.List(ctx, []string{config.Name.ValueString()})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error refreshing Workspace Role state",
+			fmt.Sprintf("Could not read Workspace Role, unexpected error: %s", err.Error()),
+		)
+	}
+
+	if len(accountRoles) != 1 {
+		resp.Diagnostics.AddError(
+			"Could not find Workspace Role",
+			fmt.Sprintf("Could not find Workspace Role with name %s", config.Name.String()),
+		)
+
+		return
+	}
+
+	fetchedRole := accountRoles[0]
+
+	config.ID = customtypes.NewUUIDValue(fetchedRole.ID)
+	config.Created = customtypes.NewTimestampPointerValue(fetchedRole.Created)
+	config.Updated = customtypes.NewTimestampPointerValue(fetchedRole.Updated)
+
+	config.Name = types.StringValue(fetchedRole.Name)
+	config.AccountID = customtypes.NewUUIDPointerValue(fetchedRole.AccountID)
+	config.IsSystemRole = types.BoolValue(fetchedRole.IsSystemRole)
+
+	list, diags := types.ListValueFrom(ctx, types.StringType, fetchedRole.Permissions)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	config.Permissions = list
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/internal/provider/datasources/account_role_test.go
+++ b/internal/provider/datasources/account_role_test.go
@@ -1,0 +1,50 @@
+package datasources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
+)
+
+func fixtureAccAccountRoleDataSource(name string) string {
+	return fmt.Sprintf(`
+data "prefect_account_role" "test" {
+	name = "%s"
+}
+	`, name)
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccDatasource_account_role_defaults(t *testing.T) {
+	dataSourceName := "data.prefect_account_role.test"
+
+	type defaultAccountRole struct {
+		name            string
+		permissionCount string
+	}
+
+	// Default account role names - these exist in every account
+	defaultAccountRoles := []defaultAccountRole{{"Admin", "39"}, {"Member", "10"}}
+
+	testSteps := []resource.TestStep{}
+
+	for _, role := range defaultAccountRoles {
+		testSteps = append(testSteps, resource.TestStep{
+			Config: fixtureAccAccountRoleDataSource(role.name),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(dataSourceName, "name", role.name),
+				resource.TestCheckResourceAttr(dataSourceName, "permissions.#", role.permissionCount),
+				// Default roles should not be associated with an account
+				resource.TestCheckNoResourceAttr(dataSourceName, "account_id"),
+			),
+		})
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps:                    testSteps,
+	})
+}

--- a/internal/provider/datasources/workspace_role.go
+++ b/internal/provider/datasources/workspace_role.go
@@ -86,7 +86,7 @@ var workspaceRoleAttributes = map[string]schema.Attribute{
 	},
 }
 
-// Schema defines the schema fro the data source.
+// Schema defines the schema for the data source.
 func (d *WorkspaceRoleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Data Source representing a Prefect Workspace Role",

--- a/internal/provider/datasources/workspace_role_test.go
+++ b/internal/provider/datasources/workspace_role_test.go
@@ -8,78 +8,39 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-//nolint:paralleltest // we use the resource.ParallelTest helper instead
-func TestAccDatasource_workspace_role_defaults(t *testing.T) {
-	dataSourceName := "data.prefect_workspace_role.test"
-	// Default workspace role names - these exist in every account
-	owner := "Owner"
-	worker := "Worker"
-	developer := "Developer"
-	viewer := "Viewer"
-	runner := "Runner"
-
-	resource.ParallelTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
-		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
-		Steps: []resource.TestStep{
-			{
-				Config: fixtureAccWorkspaceRoleDataSource(owner),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "name", owner),
-					resource.TestCheckResourceAttrSet(dataSourceName, "created"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "updated"),
-					// Default roles should not be associated with an account
-					resource.TestCheckNoResourceAttr(dataSourceName, "account_id"),
-				),
-			},
-			{
-				Config: fixtureAccWorkspaceRoleDataSource(worker),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "name", worker),
-					resource.TestCheckResourceAttrSet(dataSourceName, "created"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "updated"),
-					// Default roles should not be associated with an account
-					resource.TestCheckNoResourceAttr(dataSourceName, "account_id"),
-				),
-			},
-			{
-				Config: fixtureAccWorkspaceRoleDataSource(developer),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "name", developer),
-					resource.TestCheckResourceAttrSet(dataSourceName, "created"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "updated"),
-					// Default roles should not be associated with an account
-					resource.TestCheckNoResourceAttr(dataSourceName, "account_id"),
-				),
-			},
-			{
-				Config: fixtureAccWorkspaceRoleDataSource(viewer),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "name", viewer),
-					resource.TestCheckResourceAttrSet(dataSourceName, "created"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "updated"),
-					// Default roles should not be associated with an account
-					resource.TestCheckNoResourceAttr(dataSourceName, "account_id"),
-				),
-			},
-			{
-				Config: fixtureAccWorkspaceRoleDataSource(runner),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "name", runner),
-					resource.TestCheckResourceAttrSet(dataSourceName, "created"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "updated"),
-					// Default roles should not be associated with an account
-					resource.TestCheckNoResourceAttr(dataSourceName, "account_id"),
-				),
-			},
-		},
-	})
-}
-
 func fixtureAccWorkspaceRoleDataSource(name string) string {
 	return fmt.Sprintf(`
 data "prefect_workspace_role" "test" {
 	name = "%s"
 }
 	`, name)
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccDatasource_workspace_role_defaults(t *testing.T) {
+	dataSourceName := "data.prefect_workspace_role.test"
+
+	// Default workspace role names - these exist in every account
+	defaultWorkspaceRoles := []string{"Owner", "Worker", "Developer", "Viewer", "Runner"}
+
+	testSteps := []resource.TestStep{}
+
+	for _, role := range defaultWorkspaceRoles {
+		testSteps = append(testSteps, resource.TestStep{
+			Config: fixtureAccWorkspaceRoleDataSource(role),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(dataSourceName, "name", role),
+				resource.TestCheckResourceAttrSet(dataSourceName, "created"),
+				resource.TestCheckResourceAttrSet(dataSourceName, "updated"),
+				// Default roles should not be associated with an account
+				resource.TestCheckNoResourceAttr(dataSourceName, "account_id"),
+			),
+		})
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps:                    testSteps,
+	})
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -241,6 +241,7 @@ func (p *PrefectProvider) DataSources(_ context.Context) []func() datasource.Dat
 		datasources.NewWorkspaceDataSource,
 		datasources.NewServiceAccountDataSource,
 		datasources.NewWorkspaceRoleDataSource,
+		datasources.NewAccountRoleDataSource,
 	}
 }
 

--- a/internal/provider/resources/service_account_test.go
+++ b/internal/provider/resources/service_account_test.go
@@ -55,18 +55,19 @@ resource "prefect_service_account" "bot" {
 
 func fixtureAccServiceAccountResourceAccountRole(name string) string {
 	return fmt.Sprintf(`
-data "prefect_account_role" "member" {
-	name = "Member"
+data "prefect_account_role" "admin" {
+	name = "Admin"
 }
-resource "prefect_service_account" "bot" {
+resource "prefect_service_account" "bot2" {
 	name = "%s"
-	account_role_name = "Member"
+	account_role_name = "Admin"
 }`, name)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_service_account(t *testing.T) {
 	resourceName := "prefect_service_account.bot"
+	resourceName2 := "prefect_service_account.bot2"
 	randomName := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	randomName2 := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
@@ -101,11 +102,11 @@ func TestAccResource_service_account(t *testing.T) {
 				),
 			},
 			{
-				Config: fixtureAccServiceAccountResourceAccountRole(randomName),
+				Config: fixtureAccServiceAccountResourceAccountRole(randomName2),
 				Check: resource.ComposeTestCheckFunc(
 					// @TODO: This is a superficial test, until we can pull in the provider client
 					// and actually test the API call to Prefect Cloud
-					resource.TestCheckResourceAttrPair(resourceName, "account_role_name", "data.prefect_account_role.member", "name"),
+					resource.TestCheckResourceAttrPair(resourceName2, "account_role_name", "data.prefect_account_role.admin", "name"),
 				),
 			},
 		},


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/39
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/76

This PR adds a new datasource for `prefect_account_role`.  Currently, there are no plans to allow practitioners to create custom Account Roles (there is no create endpoint), and we do not allow modifying the default system roles.  As such, we will just support reading down either the `Admin` or `Member` account roles by name - practitioners can then use the fetched `data.prefect_account_role.foobar.id` in order to set account membership in a followup resource