### PR TITLE
fix: use terraform JSON types, for semantic equality checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.19.0 // indirect
 	github.com/hashicorp/terraform-json v0.17.1 // indirect
+	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/hashicorp/terraform-plugin-docs v0.16.0 h1:UmxFr3AScl6Wged84jndJIfFcc
 github.com/hashicorp/terraform-plugin-docs v0.16.0/go.mod h1:M3ZrlKBJAbPMtNOPwHicGi1c+hZUh7/g0ifT/z7TVfA=
 github.com/hashicorp/terraform-plugin-framework v1.4.2 h1:P7a7VP1GZbjc4rv921Xy5OckzhoiO3ig6SGxwelD2sI=
 github.com/hashicorp/terraform-plugin-framework v1.4.2/go.mod h1:GWl3InPFZi2wVQmdVnINPKys09s9mLmTZr95/ngLnbY=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0 h1:b8vZYB/SkXJT4YPbT3trzE6oJ7dPyMy68+9dEDKsJjE=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0/go.mod h1:tP9BC3icoXBz72evMS5UTFvi98CiKhPdXF6yLs1wS8A=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.19.0 h1:BuZx/6Cp+lkmiG0cOBk6Zps0Cb2tmqQpDM3iAtnhDQU=

--- a/internal/provider/datasources/work_pools.go
+++ b/internal/provider/datasources/work_pools.go
@@ -2,14 +2,11 @@ package datasources
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
@@ -127,50 +124,50 @@ func (d *WorkPoolsDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	attributeTypes := map[string]attr.Type{
-		"id":                customtypes.UUIDType{},
-		"created":           customtypes.TimestampType{},
-		"updated":           customtypes.TimestampType{},
-		"name":              types.StringType,
-		"description":       types.StringType,
-		"type":              types.StringType,
-		"paused":            types.BoolType,
-		"concurrency_limit": types.Int64Type,
-		"default_queue_id":  customtypes.UUIDType{},
-		"base_job_template": types.StringType,
+		// "id":                customtypes.UUIDType{},
+		// "created":           customtypes.TimestampType{},
+		// "updated":           customtypes.TimestampType{},
+		// "name":              types.StringType,
+		// "description":       types.StringType,
+		// "type":              types.StringType,
+		// "paused":            types.BoolType,
+		// "concurrency_limit": types.Int64Type,
+		"default_queue_id": customtypes.UUIDType{},
+		// "base_job_template": types.StringType,
 	}
 
 	poolObjects := make([]attr.Value, 0, len(pools))
 	for _, pool := range pools {
 		attributeValues := map[string]attr.Value{
-			"id":                customtypes.NewUUIDValue(pool.ID),
-			"created":           customtypes.NewTimestampPointerValue(pool.Created),
-			"updated":           customtypes.NewTimestampPointerValue(pool.Updated),
-			"name":              types.StringValue(pool.Name),
-			"description":       types.StringPointerValue(pool.Description),
-			"type":              types.StringValue(pool.Type),
-			"paused":            types.BoolValue(pool.IsPaused),
-			"concurrency_limit": types.Int64PointerValue(pool.ConcurrencyLimit),
-			"default_queue_id":  types.StringValue(pool.DefaultQueueID.String()),
+			// "id":                customtypes.NewUUIDValue(pool.ID),
+			// "created":           customtypes.NewTimestampPointerValue(pool.Created),
+			// "updated":           customtypes.NewTimestampPointerValue(pool.Updated),
+			// "name":              types.StringValue(pool.Name),
+			// "description":       types.StringPointerValue(pool.Description),
+			// "type":              types.StringValue(pool.Type),
+			// "paused":            types.BoolValue(pool.IsPaused),
+			// "concurrency_limit": types.Int64PointerValue(pool.ConcurrencyLimit),
+			"default_queue_id": types.StringValue(pool.DefaultQueueID.String()),
 		}
 
-		if pool.BaseJobTemplate == nil {
-			attributeValues["base_job_template"] = types.StringNull()
-		} else {
-			var builder strings.Builder
-			encoder := json.NewEncoder(&builder)
-			encoder.SetIndent("", "  ")
-			if err := encoder.Encode(pool.BaseJobTemplate); err != nil {
-				resp.Diagnostics.AddAttributeError(
-					path.Root("base_job_template"),
-					"Failed to serialize Base Job Template",
-					fmt.Sprintf("Failed to serialize Base Job Template as JSON string: %s", err),
-				)
+		// if pool.BaseJobTemplate == nil {
+		// 	attributeValues["base_job_template"] = types.StringNull()
+		// } else {
+		// 	var builder strings.Builder
+		// 	encoder := json.NewEncoder(&builder)
+		// 	encoder.SetIndent("", "  ")
+		// 	if err := encoder.Encode(pool.BaseJobTemplate); err != nil {
+		// 		resp.Diagnostics.AddAttributeError(
+		// 			path.Root("base_job_template"),
+		// 			"Failed to serialize Base Job Template",
+		// 			fmt.Sprintf("Failed to serialize Base Job Template as JSON string: %s", err),
+		// 		)
 
-				return
-			}
+		// 		return
+		// 	}
 
-			attributeValues["base_job_template"] = types.StringValue(builder.String())
-		}
+		// 	attributeValues["base_job_template"] = types.StringValue(builder.String())
+		// }
 
 		poolObject, diag := types.ObjectValue(attributeTypes, attributeValues)
 		resp.Diagnostics.Append(diag...)

--- a/internal/provider/datasources/work_pools.go
+++ b/internal/provider/datasources/work_pools.go
@@ -2,11 +2,14 @@ package datasources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
@@ -124,50 +127,50 @@ func (d *WorkPoolsDataSource) Read(ctx context.Context, req datasource.ReadReque
 	}
 
 	attributeTypes := map[string]attr.Type{
-		// "id":                customtypes.UUIDType{},
-		// "created":           customtypes.TimestampType{},
-		// "updated":           customtypes.TimestampType{},
-		// "name":              types.StringType,
-		// "description":       types.StringType,
-		// "type":              types.StringType,
-		// "paused":            types.BoolType,
-		// "concurrency_limit": types.Int64Type,
-		"default_queue_id": customtypes.UUIDType{},
-		// "base_job_template": types.StringType,
+		"id":                customtypes.UUIDType{},
+		"created":           customtypes.TimestampType{},
+		"updated":           customtypes.TimestampType{},
+		"name":              types.StringType,
+		"description":       types.StringType,
+		"type":              types.StringType,
+		"paused":            types.BoolType,
+		"concurrency_limit": types.Int64Type,
+		"default_queue_id":  customtypes.UUIDType{},
+		"base_job_template": types.StringType,
 	}
 
 	poolObjects := make([]attr.Value, 0, len(pools))
 	for _, pool := range pools {
 		attributeValues := map[string]attr.Value{
-			// "id":                customtypes.NewUUIDValue(pool.ID),
-			// "created":           customtypes.NewTimestampPointerValue(pool.Created),
-			// "updated":           customtypes.NewTimestampPointerValue(pool.Updated),
-			// "name":              types.StringValue(pool.Name),
-			// "description":       types.StringPointerValue(pool.Description),
-			// "type":              types.StringValue(pool.Type),
-			// "paused":            types.BoolValue(pool.IsPaused),
-			// "concurrency_limit": types.Int64PointerValue(pool.ConcurrencyLimit),
-			"default_queue_id": types.StringValue(pool.DefaultQueueID.String()),
+			"id":                customtypes.NewUUIDValue(pool.ID),
+			"created":           customtypes.NewTimestampPointerValue(pool.Created),
+			"updated":           customtypes.NewTimestampPointerValue(pool.Updated),
+			"name":              types.StringValue(pool.Name),
+			"description":       types.StringPointerValue(pool.Description),
+			"type":              types.StringValue(pool.Type),
+			"paused":            types.BoolValue(pool.IsPaused),
+			"concurrency_limit": types.Int64PointerValue(pool.ConcurrencyLimit),
+			"default_queue_id":  types.StringValue(pool.DefaultQueueID.String()),
 		}
 
-		// if pool.BaseJobTemplate == nil {
-		// 	attributeValues["base_job_template"] = types.StringNull()
-		// } else {
-		// 	var builder strings.Builder
-		// 	encoder := json.NewEncoder(&builder)
-		// 	encoder.SetIndent("", "  ")
-		// 	if err := encoder.Encode(pool.BaseJobTemplate); err != nil {
-		// 		resp.Diagnostics.AddAttributeError(
-		// 			path.Root("base_job_template"),
-		// 			"Failed to serialize Base Job Template",
-		// 			fmt.Sprintf("Failed to serialize Base Job Template as JSON string: %s", err),
-		// 		)
+		if pool.BaseJobTemplate == nil {
+			attributeValues["base_job_template"] = types.StringNull()
+		} else {
+			var builder strings.Builder
+			encoder := json.NewEncoder(&builder)
+			encoder.SetIndent("", "  ")
+			if err := encoder.Encode(pool.BaseJobTemplate); err != nil {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("base_job_template"),
+					"Failed to serialize Base Job Template",
+					fmt.Sprintf("Failed to serialize Base Job Template as JSON string: %s", err),
+				)
 
-		// 		return
-		// 	}
+				return
+			}
 
-		// 	attributeValues["base_job_template"] = types.StringValue(builder.String())
-		// }
+			attributeValues["base_job_template"] = types.StringValue(builder.String())
+		}
 
 		poolObject, diag := types.ObjectValue(attributeTypes, attributeValues)
 		resp.Diagnostics.Append(diag...)

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -141,6 +141,9 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Default:     stringdefault.StaticString("prefect-agent"),
 				Description: "Type of the work pool",
 				Optional:    true,
+				// Work Pool types are also only set on create, and
+				// we do not support modifying this value. Therefore, any changes
+				// to this attribute will force a replacement.
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -44,7 +45,7 @@ type WorkPoolResourceModel struct {
 	Paused           types.Bool            `tfsdk:"paused"`
 	ConcurrencyLimit types.Int64           `tfsdk:"concurrency_limit"`
 	DefaultQueueID   customtypes.UUIDValue `tfsdk:"default_queue_id"`
-	BaseJobTemplate  types.String          `tfsdk:"base_job_template"`
+	BaseJobTemplate  jsontypes.Normalized  `tfsdk:"base_job_template"`
 }
 
 // NewWorkPoolResource returns a new WorkPoolResource.
@@ -98,6 +99,13 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Date and time of the work pool creation in RFC 3339 format",
+				// In general, we can use UseStateForUnknown() to avoid unnecessary
+				// cases of `known after apply` states during plans. Mostly, this planmodifier
+				// is suitable for Computed attributes that do not change often and
+				// do not have a default value set here in the Schema.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated": schema.StringAttribute{
 				Computed:    true,
@@ -117,6 +125,12 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Name of the work pool",
+				// Work Pool names are the identifier on the API side, so
+				// we do not support modifying this value. Therefore, any changes
+				// to this attribute will force a replacement.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -127,6 +141,9 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Default:     stringdefault.StaticString("prefect-agent"),
 				Description: "Type of the work pool",
 				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"paused": schema.BoolAttribute{
 				Computed:    true,
@@ -142,10 +159,14 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed:    true,
 				CustomType:  customtypes.UUIDType{},
 				Description: "The UUID of the default queue associated with this work pool",
-				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"base_job_template": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  jsontypes.NormalizedType{},
+				Default:     stringdefault.StaticString("{}"),
 				Description: "The base job template for the work pool, as a JSON string",
 				Optional:    true,
 			},
@@ -183,7 +204,7 @@ func copyWorkPoolToModel(_ context.Context, pool *api.WorkPool, model *WorkPoolR
 			return diags
 		}
 
-		model.BaseJobTemplate = types.StringValue(strings.TrimSuffix(builder.String(), "\n"))
+		model.BaseJobTemplate = jsontypes.NewNormalizedValue(strings.TrimSuffix(builder.String(), "\n"))
 	}
 
 	return nil

--- a/internal/provider/resources/work_pool_test.go
+++ b/internal/provider/resources/work_pool_test.go
@@ -1,0 +1,175 @@
+package resources_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
+)
+
+func fixtureAccWorkPoolCreate(name string, poolType string, paused bool) string {
+	return fmt.Sprintf(`
+data "prefect_workspace" "evergreen" {
+	handle = "evergreen-workspace"
+}
+resource "prefect_work_pool" "test" {
+	name = "%s"
+	type = "%s"
+	workspace_id = data.prefect_workspace.evergreen.id
+	paused = %t
+}
+`, name, poolType, paused)
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccResource_work_pool(t *testing.T) {
+	resourceName := "prefect_work_pool.test"
+	workspaceDatsourceName := "data.prefect_workspace.evergreen"
+	randomName := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	randomName2 := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	poolType := "kubernetes"
+	poolType2 := "ecs"
+
+	// We use this variable to store the fetched resource from the API
+	// and it will be shared between TestSteps via a pointer.
+	var workPool api.WorkPool
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				// Check creation + existence of the work pool resource
+				Config: fixtureAccWorkPoolCreate(randomName, poolType, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkPoolExists(resourceName, workspaceDatsourceName, &workPool),
+					testAccCheckWorkPoolValues(&workPool, &api.WorkPool{Name: randomName, Type: poolType, IsPaused: true}),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName),
+					resource.TestCheckResourceAttr(resourceName, "type", poolType),
+					resource.TestCheckResourceAttr(resourceName, "paused", "true"),
+				),
+			},
+			{
+				// Check that changing the paused state will update the resource in place
+				Config: fixtureAccWorkPoolCreate(randomName, poolType, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIDAreEqual(resourceName, &workPool),
+					testAccCheckWorkPoolExists(resourceName, workspaceDatsourceName, &workPool),
+					testAccCheckWorkPoolValues(&workPool, &api.WorkPool{Name: randomName, Type: poolType, IsPaused: false}),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName),
+					resource.TestCheckResourceAttr(resourceName, "type", poolType),
+					resource.TestCheckResourceAttr(resourceName, "paused", "false"),
+				),
+			},
+			{
+				// Check that changing the name will re-create the resource
+				Config: fixtureAccWorkPoolCreate(randomName2, poolType, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIDsNotEqual(resourceName, &workPool),
+					testAccCheckWorkPoolExists(resourceName, workspaceDatsourceName, &workPool),
+					testAccCheckWorkPoolValues(&workPool, &api.WorkPool{Name: randomName2, Type: poolType, IsPaused: false}),
+				),
+			},
+			{
+				// Check that changing the poolType will re-create the resource
+				Config: fixtureAccWorkPoolCreate(randomName2, poolType2, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckIDsNotEqual(resourceName, &workPool),
+					testAccCheckWorkPoolExists(resourceName, workspaceDatsourceName, &workPool),
+					testAccCheckWorkPoolValues(&workPool, &api.WorkPool{Name: randomName2, Type: poolType2, IsPaused: false}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckWorkPoolExists(workPoolResourceName string, workspaceDatasourceName string, workPool *api.WorkPool) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		workPoolResource, exists := state.RootModule().Resources[workPoolResourceName]
+		if !exists {
+			return fmt.Errorf("Resource not found in state: %s", workPoolResourceName)
+		}
+
+		workspaceDatsource, exists := state.RootModule().Resources[workspaceDatasourceName]
+		if !exists {
+			return fmt.Errorf("Resource not found in state: %s", workspaceDatasourceName)
+		}
+		workspaceID, _ := uuid.Parse(workspaceDatsource.Primary.ID)
+
+		// Create a new client, and use the default configurations from the environment
+		c, _ := testutils.NewTestClient()
+		workPoolsClient, _ := c.WorkPools(uuid.Nil, workspaceID)
+
+		workPoolName := workPoolResource.Primary.Attributes["name"]
+
+		fetchedWorkPool, err := workPoolsClient.Get(context.Background(), workPoolName)
+		if err != nil {
+			return fmt.Errorf("Error fetching work pool: %w", err)
+		}
+		if fetchedWorkPool == nil {
+			return fmt.Errorf("Work Pool not found for name: %s", workPoolName)
+		}
+
+		*workPool = *fetchedWorkPool
+
+		return nil
+	}
+}
+
+func testAccCheckWorkPoolValues(fetchedWorkPool *api.WorkPool, valuesToCheck *api.WorkPool) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		if fetchedWorkPool.Name != valuesToCheck.Name {
+			return fmt.Errorf("Expected work pool name to be %s, got %s", valuesToCheck.Name, fetchedWorkPool.Name)
+		}
+
+		if fetchedWorkPool.Type != valuesToCheck.Type {
+			return fmt.Errorf("Expected work pool type to be %s, got %s", valuesToCheck.Type, fetchedWorkPool.Type)
+		}
+
+		if fetchedWorkPool.IsPaused != valuesToCheck.IsPaused {
+			return fmt.Errorf("Expected work pool paused to be %t, got %t", valuesToCheck.IsPaused, fetchedWorkPool.IsPaused)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIDAreEqual(resourceName string, fetchedWorkPool *api.WorkPool) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		workPoolResource, exists := state.RootModule().Resources[resourceName]
+		if !exists {
+			return fmt.Errorf("Resource not found in state: %s", resourceName)
+		}
+
+		id := fetchedWorkPool.ID.String()
+
+		if workPoolResource.Primary.ID != id {
+			return fmt.Errorf("Expected %s and %s to be equal", workPoolResource.Primary.ID, id)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckIDsNotEqual(resourceName string, fetchedWorkPool *api.WorkPool) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		workPoolResource, exists := state.RootModule().Resources[resourceName]
+		if !exists {
+			return fmt.Errorf("Resource not found in state: %s", resourceName)
+		}
+
+		id := fetchedWorkPool.ID.String()
+
+		if workPoolResource.Primary.ID == id {
+			return fmt.Errorf("Expected %s and %s to be different", workPoolResource.Primary.ID, id)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/102

Previously, the `base_job_template` attribute was set to a StringValue -- this caused issues with state refresh, as the Provider failed equality checks due to non-semantic differences in the byte slice (aka ordering of keys, likely differences in indentation, etc.)

Instead, we use the terraform-plugin-framework `jsontype` package, which exposes a `Normalized` type that does exactly this -- checks for semantic equality between two valid JSON strings

github.com/hashicorp/terraform-plugin-framework-jsontypes

also, adds acceptance tests for the work-pools resource, per https://github.com/PrefectHQ/terraform-provider-prefect/issues/81