### PR TITLE
fix: separate singular/multiple work pool datsource attributes

### DIFF
--- a/internal/provider/datasources/work_pool_test.go
+++ b/internal/provider/datasources/work_pool_test.go
@@ -1,0 +1,72 @@
+package datasources_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
+)
+
+func fixtureAccSingleWorkPool() string {
+	return `
+data "prefect_workspace" "evergreen" {
+	handle = "evergreen-workspace"
+}
+data "prefect_work_pool" "evergreen" {
+	name = "evergreen-pool"
+	workspace_id = data.prefect_workspace.evergreen.id
+}
+`
+}
+func fixtureAccMultipleWorkPools() string {
+	return `
+data "prefect_workspace" "evergreen" {
+	handle = "evergreen-workspace"
+}
+data "prefect_work_pools" "evergreen" {
+	workspace_id = data.prefect_workspace.evergreen.id
+}
+`
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccDatasource_work_pool(t *testing.T) {
+	singleWorkPoolDatasourceName := "data.prefect_work_pool.evergreen"
+	multipleWorkPoolDatasourceName := "data.prefect_work_pools.evergreen"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				// Check that we can query a single work pool
+				Config: fixtureAccSingleWorkPool(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(singleWorkPoolDatasourceName, "name", "evergreen-pool"),
+					resource.TestCheckResourceAttrSet(singleWorkPoolDatasourceName, "id"),
+					resource.TestCheckResourceAttrSet(singleWorkPoolDatasourceName, "created"),
+					resource.TestCheckResourceAttrSet(singleWorkPoolDatasourceName, "updated"),
+					resource.TestCheckResourceAttrSet(singleWorkPoolDatasourceName, "type"),
+					resource.TestCheckResourceAttrSet(singleWorkPoolDatasourceName, "paused"),
+					resource.TestCheckResourceAttrSet(singleWorkPoolDatasourceName, "default_queue_id"),
+					resource.TestCheckResourceAttrSet(singleWorkPoolDatasourceName, "base_job_template"),
+				),
+			},
+			{
+				// Check that we can query multiple work pools
+				Config: fixtureAccMultipleWorkPools(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(multipleWorkPoolDatasourceName, "work_pools.#", "1"),
+					resource.TestCheckResourceAttr(multipleWorkPoolDatasourceName, "work_pools.0.name", "evergreen-pool"),
+					resource.TestCheckResourceAttrSet(multipleWorkPoolDatasourceName, "work_pools.0.id"),
+					resource.TestCheckResourceAttrSet(multipleWorkPoolDatasourceName, "work_pools.0.created"),
+					resource.TestCheckResourceAttrSet(multipleWorkPoolDatasourceName, "work_pools.0.updated"),
+					resource.TestCheckResourceAttrSet(multipleWorkPoolDatasourceName, "work_pools.0.type"),
+					resource.TestCheckResourceAttrSet(multipleWorkPoolDatasourceName, "work_pools.0.paused"),
+					resource.TestCheckResourceAttrSet(multipleWorkPoolDatasourceName, "work_pools.0.default_queue_id"),
+					resource.TestCheckResourceAttrSet(multipleWorkPoolDatasourceName, "work_pools.0.base_job_template"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/datasources/work_pools.go
+++ b/internal/provider/datasources/work_pools.go
@@ -87,7 +87,7 @@ func (d *WorkPoolsDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				Computed:    true,
 				Description: "Work pools returned by the server",
 				NestedObject: schema.NestedAttributeObject{
-					Attributes: workPoolAttributes,
+					Attributes: workPoolAttributesBase,
 				},
 			},
 		},
@@ -150,7 +150,7 @@ func (d *WorkPoolsDataSource) Read(ctx context.Context, req datasource.ReadReque
 			"type":              types.StringValue(pool.Type),
 			"paused":            types.BoolValue(pool.IsPaused),
 			"concurrency_limit": types.Int64PointerValue(pool.ConcurrencyLimit),
-			"default_queue_id":  types.StringValue(pool.DefaultQueueID.String()),
+			"default_queue_id":  customtypes.NewUUIDValue(pool.DefaultQueueID),
 		}
 
 		if pool.BaseJobTemplate == nil {


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/98

Two issues:
1. default_queue_id had an incorrect string type, as it should be a uuid
2. the `work_pool` and `work_pools` (plural) datasources were sharing an attribute map, but there were some conflicting attributes; eg. account/workspace IDs don't belong in the plural version's `work_pools` list attribute.  so, we separate them

also adds acceptance tests for `work_pool` datasources, per https://github.com/PrefectHQ/terraform-provider-prefect/issues/81