### PR TITLE
fix: set default empty string for `prefect_workspace_role.description`

### DIFF
--- a/internal/api/workspace_roles.go
+++ b/internal/api/workspace_roles.go
@@ -28,7 +28,7 @@ type WorkspaceRole struct {
 // when creating or updating a workspace role.
 type WorkspaceRoleUpsert struct {
 	Name            string     `json:"name"`
-	Description     *string    `json:"description"`
+	Description     string     `json:"description"`
 	Scopes          []string   `json:"scopes"`
 	InheritedRoleID *uuid.UUID `json:"inherited_role_id"`
 }

--- a/internal/provider/resources/workspace_role.go
+++ b/internal/provider/resources/workspace_role.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
@@ -99,8 +100,10 @@ func (r *WorkspaceRoleResource) Schema(_ context.Context, _ resource.SchemaReque
 				Description: "Name of the Workspace Role",
 			},
 			"description": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "Description of the Workspace Role",
+				Default:     stringdefault.StaticString(""),
 			},
 			"scopes": schema.ListAttribute{
 				Description: "List of scopes linked to the Workspace Role",
@@ -177,7 +180,7 @@ func (r *WorkspaceRoleResource) Create(ctx context.Context, req resource.CreateR
 
 	role, err := client.Create(ctx, api.WorkspaceRoleUpsert{
 		Name:            model.Name.ValueString(),
-		Description:     model.Description.ValueStringPointer(),
+		Description:     model.Description.ValueString(),
 		Scopes:          scopes,
 		InheritedRoleID: model.InheritedRoleID.ValueUUIDPointer(),
 	})
@@ -289,7 +292,7 @@ func (r *WorkspaceRoleResource) Update(ctx context.Context, req resource.UpdateR
 
 	err = client.Update(ctx, roleID, api.WorkspaceRoleUpsert{
 		Name:            model.Name.ValueString(),
-		Description:     model.Description.ValueStringPointer(),
+		Description:     model.Description.ValueString(),
 		Scopes:          scopes,
 		InheritedRoleID: model.InheritedRoleID.ValueUUIDPointer(),
 	})

--- a/internal/provider/resources/workspace_role.go
+++ b/internal/provider/resources/workspace_role.go
@@ -99,7 +99,7 @@ func (r *WorkspaceRoleResource) Schema(_ context.Context, _ resource.SchemaReque
 				Description: "Name of the Workspace Role",
 			},
 			"description": schema.StringAttribute{
-				Optional:    true,
+				Required:    true,
 				Description: "Description of the Workspace Role",
 			},
 			"scopes": schema.ListAttribute{


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/112

here, we'll modify the `Description` upsert param to be a string (not pointer), so we pass an empty `""` instead of a null - the null causes issues on create/update because of a pydantic failure on the API

we'll set a `Default` configuration so we do not run into an unexpected attribute error, as the API will return a `""` instead of a null -- we want to still give the operator an option to not include a description, which is handled now by defaulting the state plan with `""` if no value is set, which will match the empty value from the API