### PR TITLE
fix: set default empty list for `prefect_variable.tags`

### DIFF
--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -6,13 +6,16 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
@@ -74,6 +77,8 @@ func (r *VariableResource) Configure(_ context.Context, req resource.ConfigureRe
 
 // Schema defines the schema for the resource.
 func (r *VariableResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	defaultEmptyTagList, _ := basetypes.NewListValue(types.StringType, []attr.Value{})
+
 	resp.Schema = schema.Schema{
 		Description: "Resource representing a Prefect variable",
 		Version:     0,
@@ -120,6 +125,8 @@ func (r *VariableResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Description: "Tags associated with the variable",
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				Default:     listdefault.StaticValue(defaultEmptyTagList),
 			},
 		},
 	}


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/110

with this configuration:
```terraform
resource "prefect_variable" "example" {
  name  = "my_variable"
  value = "variable value goes here"
  workspace_id = data.prefect_workspace.evergreen.id
}
```

this is the plan that is generated (and applies successfully)

![image](https://github.com/PrefectHQ/terraform-provider-prefect/assets/19556538/b70a757b-3f45-4f18-b7e9-dede8ad000af)

adding new tags, modifying tags, and resetting the resource to be tag-less all apply correctly
