### PR TITLE
chore: error messaging for missing workspaceID + improved work pool import parameter

### DIFF
--- a/docs/resources/work_pool.md
+++ b/docs/resources/work_pool.md
@@ -74,6 +74,9 @@ resource "prefect_work_pool" "example" {
 Import is supported using the following syntax:
 
 ```shell
-# Prefect Work Pools can be imported using the work pool's name
-terraform import prefect_work_pool.example name-of-work-pool
+# Prefect Work Pools can be imported using the format `workspace_id,name`
+terraform import prefect_work_pool.example 00000000-0000-0000-0000-000000000000,kubernetes-work-pool
+
+# You can also import by name only if you have a workspace_id set in your provider
+terraform import prefect_work_pool.example kubernetes-work-pool
 ```

--- a/examples/resources/prefect_work_pool/import.sh
+++ b/examples/resources/prefect_work_pool/import.sh
@@ -1,2 +1,5 @@
-# Prefect Work Pools can be imported using the work pool's name
-terraform import prefect_work_pool.example name-of-work-pool
+# Prefect Work Pools can be imported using the format `workspace_id,name`
+terraform import prefect_work_pool.example 00000000-0000-0000-0000-000000000000,kubernetes-work-pool
+
+# You can also import by name only if you have a workspace_id set in your provider
+terraform import prefect_work_pool.example kubernetes-work-pool

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -88,7 +88,7 @@ func WithAPIKey(apiKey string) Option {
 func WithDefaults(accountID uuid.UUID, workspaceID uuid.UUID) Option {
 	return func(client *Client) error {
 		if accountID == uuid.Nil && workspaceID != uuid.Nil {
-			return fmt.Errorf("accountID and workspaceID are inconsistent: accountID is nil and workspaceID is %q", workspaceID)
+			return fmt.Errorf("an accountID must be set if a workspaceID is set: accountID is %q and workspaceID is %q", accountID, workspaceID)
 		}
 
 		client.defaultAccountID = accountID

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -26,20 +26,15 @@ type VariablesClient struct {
 //
 //nolint:ireturn // required to support PrefectClient mocking
 func (c *Client) Variables(accountID uuid.UUID, workspaceID uuid.UUID) (api.VariablesClient, error) {
-	if accountID != uuid.Nil && workspaceID == uuid.Nil {
-		return nil, fmt.Errorf("accountID and workspaceID are inconsistent: accountID is %q and workspaceID is nil", accountID)
-	}
-
 	if accountID == uuid.Nil {
 		accountID = c.defaultAccountID
 	}
-
-	if accountID != uuid.Nil && workspaceID == uuid.Nil {
-		if c.defaultWorkspaceID == uuid.Nil {
-			return nil, fmt.Errorf("accountID and workspaceID are inconsistent: accountID is %q and supplied/default workspaceID are both nil", accountID)
-		}
-
+	if workspaceID == uuid.Nil {
 		workspaceID = c.defaultWorkspaceID
+	}
+
+	if accountID != uuid.Nil || workspaceID != uuid.Nil {
+		return nil, fmt.Errorf("both accountID and workspaceID must be set: accountID is %q and workspaceID is %q", accountID, workspaceID)
 	}
 
 	return &VariablesClient{

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -33,7 +33,7 @@ func (c *Client) Variables(accountID uuid.UUID, workspaceID uuid.UUID) (api.Vari
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if accountID != uuid.Nil || workspaceID != uuid.Nil {
+	if accountID == uuid.Nil || workspaceID == uuid.Nil {
 		return nil, fmt.Errorf("both accountID and workspaceID must be set: accountID is %q and workspaceID is %q", accountID, workspaceID)
 	}
 

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -25,20 +25,15 @@ type WorkPoolsClient struct {
 //
 //nolint:ireturn // required to support PrefectClient mocking
 func (c *Client) WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (api.WorkPoolsClient, error) {
-	if accountID != uuid.Nil && workspaceID == uuid.Nil {
-		return nil, fmt.Errorf("accountID and workspaceID are inconsistent: accountID is %q and workspaceID is nil", accountID)
-	}
-
 	if accountID == uuid.Nil {
 		accountID = c.defaultAccountID
 	}
-
-	if accountID != uuid.Nil && workspaceID == uuid.Nil {
-		if c.defaultWorkspaceID == uuid.Nil {
-			return nil, fmt.Errorf("accountID and workspaceID are inconsistent: accountID is %q and supplied/default workspaceID are both nil", accountID)
-		}
-
+	if workspaceID == uuid.Nil {
 		workspaceID = c.defaultWorkspaceID
+	}
+
+	if accountID != uuid.Nil || workspaceID != uuid.Nil {
+		return nil, fmt.Errorf("both accountID and workspaceID must be set: accountID is %q and workspaceID is %q", accountID, workspaceID)
 	}
 
 	return &WorkPoolsClient{

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -32,7 +32,7 @@ func (c *Client) WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (api.Work
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if accountID != uuid.Nil || workspaceID != uuid.Nil {
+	if accountID == uuid.Nil || workspaceID == uuid.Nil {
 		return nil, fmt.Errorf("both accountID and workspaceID must be set: accountID is %q and workspaceID is %q", accountID, workspaceID)
 	}
 

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -430,5 +430,39 @@ func (r *WorkPoolResource) Delete(ctx context.Context, req resource.DeleteReques
 
 // ImportState imports the resource into Terraform state.
 func (r *WorkPoolResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	// we'll allow input values in the form of:
+	// - "workspace_id,name"
+	// - "name"
+	maxInputCount := 2
+	inputParts := strings.Split(req.ID, ",")
+
+	// eg. "foo,bar,baz"
+	if len(inputParts) > maxInputCount {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `workspace_id,name`. Got %q", req.ID),
+		)
+
+		return
+	}
+
+	// eg. ",foo" or "foo,"
+	if len(inputParts) == maxInputCount && (inputParts[0] == "" || inputParts[1] == "") {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected non-empty import identifiers, in the form of `workspace_id,name`. Got %q", req.ID),
+		)
+
+		return
+	}
+
+	if len(inputParts) == maxInputCount {
+		workspaceID := inputParts[0]
+		name := inputParts[1]
+
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
+	} else {
+		resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	}
 }


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/99

1. Makes clearer error messages around when a `workspaceID` or `accountID` is not passed into a client
2. extends the `work_pool` import interface, so that we can import on the command line by passing an optional `workspace_id`. [Comma separate example taken from the TF docs](https://developer.hashicorp.com/terraform/plugin/framework/resources/import#multiple-attributes)


```sh
# workspace_id,name
terraform import prefect_work_pool.example 00000000-0000-0000-0000-000000000000,kubernetes-work-pool

# name only
terraform import prefect_work_pool.example kubernetes-work-pool
```

The reason for adding this is that the provider makes `workspace_id` optional.  This makes sense for use cases where an operator does not want the provider to be tied to a specific workspace (eg. it has account-level permissions and scope).  However, in the previous implementation, an import would fail if the provider was not configured with a workspace_id.  This change offers an optional import path for those who want to keep the provider account-level only