### PR TITLE
chore: add acceptance tests for `account` and `variable` resources

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -48,5 +48,5 @@ Import is supported using the following syntax:
 
 ```shell
 # Prefect Accounts can be imported using the account's UUID
-terraform import prefect_account.example account-uuid
+terraform import prefect_account.example 00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -48,5 +48,5 @@ Import is supported using the following syntax:
 terraform import prefect_variable.example name/name-of-variable
 
 # Prefect Variables can also be imported via UUID
-terraform import prefect_variable.example variable-uuid
+terraform import prefect_variable.example 00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -47,5 +47,5 @@ Import is supported using the following syntax:
 terraform import prefect_workspace.example handle/workspace-handle
 
 # Prefect Workspaces can also be imported via UUID
-terraform import prefect_workspace.example workspace-uuid
+terraform import prefect_workspace.example 00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/workspace_role.md
+++ b/docs/resources/workspace_role.md
@@ -48,5 +48,5 @@ Import is supported using the following syntax:
 
 ```shell
 # Prefect Workspace Roles can be imported using the workspace role's UUID
-terraform import prefect_workspace_role.example workspace-role-uuid
+terraform import prefect_workspace_role.example 00000000-0000-0000-0000-000000000000
 ```

--- a/examples/resources/prefect_account/import.sh
+++ b/examples/resources/prefect_account/import.sh
@@ -1,2 +1,2 @@
 # Prefect Accounts can be imported using the account's UUID
-terraform import prefect_account.example account-uuid
+terraform import prefect_account.example 00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_variable/import.sh
+++ b/examples/resources/prefect_variable/import.sh
@@ -2,4 +2,4 @@
 terraform import prefect_variable.example name/name-of-variable
 
 # Prefect Variables can also be imported via UUID
-terraform import prefect_variable.example variable-uuid
+terraform import prefect_variable.example 00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_workspace/import.sh
+++ b/examples/resources/prefect_workspace/import.sh
@@ -2,4 +2,4 @@
 terraform import prefect_workspace.example handle/workspace-handle
 
 # Prefect Workspaces can also be imported via UUID
-terraform import prefect_workspace.example workspace-uuid
+terraform import prefect_workspace.example 00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_workspace_role/import.sh
+++ b/examples/resources/prefect_workspace_role/import.sh
@@ -1,2 +1,2 @@
 # Prefect Workspace Roles can be imported using the workspace role's UUID
-terraform import prefect_workspace_role.example workspace-role-uuid
+terraform import prefect_workspace_role.example 00000000-0000-0000-0000-000000000000

--- a/internal/provider/datasources/account_test.go
+++ b/internal/provider/datasources/account_test.go
@@ -1,0 +1,37 @@
+package datasources_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
+)
+
+func fixtureAccAccount() string {
+	return fmt.Sprintf(`
+data "prefect_account" "test" {
+	id = "%s"
+}
+	`, os.Getenv("PREFECT_CLOUD_ACCOUNT_ID"))
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccDatasource_account(t *testing.T) {
+	datasourceName := "data.prefect_account.test"
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fixtureAccAccount(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "id", os.Getenv("PREFECT_CLOUD_ACCOUNT_ID")),
+					resource.TestCheckResourceAttrSet(datasourceName, "name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "handle"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/datasources/variable_test.go
+++ b/internal/provider/datasources/variable_test.go
@@ -1,0 +1,42 @@
+package datasources_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
+)
+
+func fixtureAccVariableByName(name string) string {
+	return fmt.Sprintf(`
+	data "prefect_workspace" "evergreen" {
+		handle = "evergreen-workspace"
+	}
+	data "prefect_variable" "test" {
+		name = "%s"
+		workspace_id = data.prefect_workspace.evergreen.id
+	}
+	`, name)
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccDatasource_variable(t *testing.T) {
+	datasourceName := "data.prefect_variable.test"
+	variableName := "my_variable"
+	variableValue := "variable value goes here"
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fixtureAccVariableByName(variableName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(datasourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "name", variableName),
+					resource.TestCheckResourceAttr(datasourceName, "value", variableValue),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/resources/account_test.go
+++ b/internal/provider/resources/account_test.go
@@ -1,0 +1,1 @@
+package resources_test

--- a/internal/provider/resources/account_test.go
+++ b/internal/provider/resources/account_test.go
@@ -1,1 +1,35 @@
 package resources_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
+)
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccResource_account(t *testing.T) {
+	resourceName := "prefect_account.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			// Import State checks - import by ID (from environment)
+			// NOTE: the prefect_account resource is a little special in that
+			// we cannot create an account via API, meaning the TF lifecycle
+			// will be challenging to test. Instead, we'll ensure that the
+			// resource can be found and properly imported. Note that
+			// ImportStateVerify is set to false, as the resource can't be
+			// saved to state after a Create.
+			{
+				Config:            `resource "prefect_account" "test" {}`,
+				ImportStateId:     os.Getenv("PREFECT_CLOUD_ACCOUNT_ID"),
+				ImportState:       true,
+				ResourceName:      resourceName,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}

--- a/internal/provider/resources/service_account.go
+++ b/internal/provider/resources/service_account.go
@@ -492,6 +492,6 @@ func (r *ServiceAccountResource) ImportState(ctx context.Context, req resource.I
 		name := strings.TrimPrefix(req.ID, "name/")
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
 	} else {
-		resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+		resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 	}
 }

--- a/internal/provider/resources/service_account_test.go
+++ b/internal/provider/resources/service_account_test.go
@@ -128,6 +128,27 @@ func TestAccResource_service_account(t *testing.T) {
 					resource.TestCheckResourceAttr(botResourceName, "name", botRandomName2),
 				),
 			},
+			// Import State checks
+			{
+				ImportState:                          true,
+				ImportStateId:                        botRandomName2,
+				ImportStateIdPrefix:                  "name/",
+				ResourceName:                         botResourceName,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+				ImportStateVerifyIgnore:              []string{"api_key"},
+			},
+			// Not entirely sure why, but `bot` shows up un-initialized here
+			// even if we're successfully assigning it to the fetched resource above.
+			// I suspect this has something to do with closures / order of when
+			// the custom TestCheckFunc functions are run.
+			// {
+			// 	ImportState:             true,
+			// 	ImportStateId:           bot.ID.String(),
+			// 	ResourceName:            "prefect_service_account.bot",
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{"api_key"},
+			// },
 		},
 	})
 }

--- a/internal/provider/resources/service_account_test.go
+++ b/internal/provider/resources/service_account_test.go
@@ -128,7 +128,7 @@ func TestAccResource_service_account(t *testing.T) {
 					resource.TestCheckResourceAttr(botResourceName, "name", botRandomName2),
 				),
 			},
-			// Import State checks
+			// Import State checks - import by name
 			{
 				ImportState:                          true,
 				ImportStateId:                        botRandomName2,
@@ -138,17 +138,13 @@ func TestAccResource_service_account(t *testing.T) {
 				ImportStateVerifyIdentifierAttribute: "name",
 				ImportStateVerifyIgnore:              []string{"api_key"},
 			},
-			// Not entirely sure why, but `bot` shows up un-initialized here
-			// even if we're successfully assigning it to the fetched resource above.
-			// I suspect this has something to do with closures / order of when
-			// the custom TestCheckFunc functions are run.
-			// {
-			// 	ImportState:             true,
-			// 	ImportStateId:           bot.ID.String(),
-			// 	ResourceName:            "prefect_service_account.bot",
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{"api_key"},
-			// },
+			// Import State checks - import by ID (default)
+			{
+				ImportState:             true,
+				ResourceName:            botResourceName,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"api_key"},
+			},
 		},
 	})
 }

--- a/internal/provider/resources/variable_test.go
+++ b/internal/provider/resources/variable_test.go
@@ -1,0 +1,1 @@
+package resources_test

--- a/internal/provider/resources/variable_test.go
+++ b/internal/provider/resources/variable_test.go
@@ -1,1 +1,143 @@
 package resources_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
+)
+
+func fixtureAccVariableResource(name string, value string, workspaceDatsourceName string) string {
+	return fmt.Sprintf(`
+data "prefect_workspace" "evergreen" {
+	handle = "evergreen-workspace"
+}
+resource "prefect_variable" "test" {
+	workspace_id = %s.id
+	name = "%s"
+	value = "%s"
+}
+	`, workspaceDatsourceName, name, value)
+}
+
+func fixtureAccVariableResourceWithTags(name string, value string, workspaceDatsourceName string) string {
+	return fmt.Sprintf(`
+data "prefect_workspace" "evergreen" {
+	handle = "evergreen-workspace"
+}
+resource "prefect_variable" "test" {
+	workspace_id = %s.id
+	name = "%s"
+	value = "%s"
+	tags = ["foo", "bar"]
+}
+	`, workspaceDatsourceName, name, value)
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccResource_variable(t *testing.T) {
+	resourceName := "prefect_variable.test"
+	const workspaceDatsourceName = "data.prefect_workspace.evergreen"
+
+	randomName := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	randomName2 := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	randomValue := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	randomValue2 := testutils.TestAccPrefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	// We use this variable to store the fetched resource from the API
+	// and it will be shared between TestSteps via a pointer.
+	var variable api.Variable
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				// Check creation + existence of the variable resource
+				Config: fixtureAccVariableResource(randomName, randomValue, workspaceDatsourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVariableExists(resourceName, workspaceDatsourceName, &variable),
+					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName, Value: randomValue}),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName),
+					resource.TestCheckResourceAttr(resourceName, "value", randomValue),
+				),
+			},
+			{
+				// Check updating name + value of the variable resource
+				Config: fixtureAccVariableResource(randomName2, randomValue2, workspaceDatsourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVariableExists(resourceName, workspaceDatsourceName, &variable),
+					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: randomValue2}),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName2),
+					resource.TestCheckResourceAttr(resourceName, "value", randomValue2),
+				),
+			},
+			{
+				// Check adding tags
+				Config: fixtureAccVariableResourceWithTags(randomName2, randomValue2, workspaceDatsourceName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVariableExists(resourceName, workspaceDatsourceName, &variable),
+					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: randomValue2}),
+					resource.TestCheckResourceAttr(resourceName, "name", randomName2),
+					resource.TestCheckResourceAttr(resourceName, "value", randomValue2),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "foo"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVariableExists(variableResourceName string, workspaceDatasourceName string, variable *api.Variable) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		variableResource, exists := state.RootModule().Resources[variableResourceName]
+		if !exists {
+			return fmt.Errorf("Resource not found in state: %s", variableResourceName)
+		}
+		variableResourceID, _ := uuid.Parse(variableResource.Primary.ID)
+
+		workspaceDatsource, exists := state.RootModule().Resources[workspaceDatasourceName]
+		if !exists {
+			return fmt.Errorf("Resource not found in state: %s", workspaceDatasourceName)
+		}
+		workspaceID, _ := uuid.Parse(workspaceDatsource.Primary.ID)
+
+		// Create a new client, and use the default configurations from the environment
+		c, _ := testutils.NewTestClient()
+		variablesClient, _ := c.Variables(uuid.Nil, workspaceID)
+
+		variableName := variableResource.Primary.Attributes["name"]
+
+		fetchedVariable, err := variablesClient.Get(context.Background(), variableResourceID)
+		if err != nil {
+			return fmt.Errorf("Error fetching variable: %w", err)
+		}
+		if fetchedVariable == nil {
+			return fmt.Errorf("Variable not found for name: %s", variableName)
+		}
+
+		*variable = *fetchedVariable
+
+		return nil
+	}
+}
+func testAccCheckVariableValues(fetchedVariable *api.Variable, valuesToCheck *api.Variable) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		if fetchedVariable.Name != valuesToCheck.Name {
+			return fmt.Errorf("Expected variable name to be %s, got %s", valuesToCheck.Name, fetchedVariable.Name)
+		}
+		if fetchedVariable.Value != valuesToCheck.Value {
+			return fmt.Errorf("Expected variable value to be %s, got %s", valuesToCheck.Name, fetchedVariable.Name)
+		}
+
+		return nil
+	}
+}

--- a/internal/provider/resources/variable_test.go
+++ b/internal/provider/resources/variable_test.go
@@ -13,31 +13,31 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccVariableResource(name string, value string, workspaceDatsourceName string) string {
+func fixtureAccVariableResource(name string, value string) string {
 	return fmt.Sprintf(`
 data "prefect_workspace" "evergreen" {
 	handle = "evergreen-workspace"
 }
 resource "prefect_variable" "test" {
-	workspace_id = %s.id
+	workspace_id = data.prefect_workspace.evergreen.id
 	name = "%s"
 	value = "%s"
 }
-	`, workspaceDatsourceName, name, value)
+	`, name, value)
 }
 
-func fixtureAccVariableResourceWithTags(name string, value string, workspaceDatsourceName string) string {
+func fixtureAccVariableResourceWithTags(name string, value string) string {
 	return fmt.Sprintf(`
 data "prefect_workspace" "evergreen" {
 	handle = "evergreen-workspace"
 }
 resource "prefect_variable" "test" {
-	workspace_id = %s.id
+	workspace_id = data.prefect_workspace.evergreen.id
 	name = "%s"
 	value = "%s"
 	tags = ["foo", "bar"]
 }
-	`, workspaceDatsourceName, name, value)
+	`, name, value)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -61,7 +61,7 @@ func TestAccResource_variable(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Check creation + existence of the variable resource
-				Config: fixtureAccVariableResource(randomName, randomValue, workspaceDatsourceName),
+				Config: fixtureAccVariableResource(randomName, randomValue),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, workspaceDatsourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName, Value: randomValue}),
@@ -71,7 +71,7 @@ func TestAccResource_variable(t *testing.T) {
 			},
 			{
 				// Check updating name + value of the variable resource
-				Config: fixtureAccVariableResource(randomName2, randomValue2, workspaceDatsourceName),
+				Config: fixtureAccVariableResource(randomName2, randomValue2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, workspaceDatsourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: randomValue2}),
@@ -81,7 +81,7 @@ func TestAccResource_variable(t *testing.T) {
 			},
 			{
 				// Check adding tags
-				Config: fixtureAccVariableResourceWithTags(randomName2, randomValue2, workspaceDatsourceName),
+				Config: fixtureAccVariableResourceWithTags(randomName2, randomValue2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, workspaceDatsourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: randomValue2}),

--- a/internal/provider/resources/workspace_role_test.go
+++ b/internal/provider/resources/workspace_role_test.go
@@ -73,6 +73,13 @@ func TestAccResource_workspace_role(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scopes.2", "see_work_queues"),
 				),
 			},
+			// Import State checks - import by ID (default)
+			{
+				ImportState:             true,
+				ResourceName:            resourceName,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"scopes"},
+			},
 		},
 	})
 }

--- a/internal/provider/resources/workspace_test.go
+++ b/internal/provider/resources/workspace_test.go
@@ -69,6 +69,20 @@ func TestAccResource_workspace(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", randomDescription),
 				),
 			},
+			// Import State checks - import by handle
+			{
+				ImportState:         true,
+				ResourceName:        resourceName,
+				ImportStateId:       randomName2,
+				ImportStateIdPrefix: "handle/",
+				ImportStateVerify:   true,
+			},
+			// Import State checks - import by ID (default)
+			{
+				ImportState:       true,
+				ResourceName:      resourceName,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/81

also: 
* makes some minor doc tweaks, like using nil uuids instead of real ones
* small fix to `service_account` ImportState after #107, where we introduced allowing import by name OR ID.  the ID path was still setting the ImportStateID to the `name` attribute