### PR TITLE
fix: allow for usage with self-hosted Prefect server (work_pools)

### DIFF
--- a/internal/client/account_memberships.go
+++ b/internal/client/account_memberships.go
@@ -31,7 +31,7 @@ func (c *Client) AccountMemberships(accountID uuid.UUID) (api.AccountMemberships
 	return &AccountMembershipsClient{
 		hc:          c.hc,
 		apiKey:      c.apiKey,
-		routePrefix: fmt.Sprintf("%s/accounts/%s/account_memberships", c.endpoint, accountID.String()),
+		routePrefix: getAccountScopedURL(c.endpoint, accountID, "account_memberships"),
 	}, nil
 }
 

--- a/internal/client/account_roles.go
+++ b/internal/client/account_roles.go
@@ -32,7 +32,7 @@ func (c *Client) AccountRoles(accountID uuid.UUID) (api.AccountRolesClient, erro
 	return &AccountRolesClient{
 		hc:          c.hc,
 		apiKey:      c.apiKey,
-		routePrefix: fmt.Sprintf("%s/accounts/%s/account_roles", c.endpoint, accountID.String()),
+		routePrefix: getAccountScopedURL(c.endpoint, accountID, "account_roles"),
 	}, nil
 }
 

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -36,7 +36,7 @@ func (c *Client) Accounts(accountID uuid.UUID) (api.AccountsClient, error) {
 	return &AccountsClient{
 		hc:          c.hc,
 		apiKey:      c.apiKey,
-		routePrefix: fmt.Sprintf("%s/accounts/%s", c.endpoint, accountID.String()),
+		routePrefix: getAccountScopedURL(c.endpoint, accountID, ""),
 	}, nil
 }
 

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -33,10 +33,6 @@ func (c *Client) Variables(accountID uuid.UUID, workspaceID uuid.UUID) (api.Vari
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if accountID == uuid.Nil || workspaceID == uuid.Nil {
-		return nil, fmt.Errorf("both accountID and workspaceID must be set: accountID is %q and workspaceID is %q", accountID, workspaceID)
-	}
-
 	return &VariablesClient{
 		hc:          c.hc,
 		apiKey:      c.apiKey,

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -32,10 +32,6 @@ func (c *Client) WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (api.Work
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if accountID == uuid.Nil || workspaceID == uuid.Nil {
-		return nil, fmt.Errorf("both accountID and workspaceID must be set: accountID is %q and workspaceID is %q", accountID, workspaceID)
-	}
-
 	return &WorkPoolsClient{
 		hc:          c.hc,
 		apiKey:      c.apiKey,

--- a/internal/client/workspace_roles.go
+++ b/internal/client/workspace_roles.go
@@ -32,7 +32,7 @@ func (c *Client) WorkspaceRoles(accountID uuid.UUID) (api.WorkspaceRolesClient, 
 	return &WorkspaceRolesClient{
 		hc:          c.hc,
 		apiKey:      c.apiKey,
-		routePrefix: fmt.Sprintf("%s/accounts/%s/workspace_roles", c.endpoint, accountID.String()),
+		routePrefix: getAccountScopedURL(c.endpoint, accountID, "workspace_roles"),
 	}, nil
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -187,20 +187,6 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 		}
 	}
 
-	// If the endpoint is pointed to a self-hosted Prefect Server installation,
-	// we will warn the practitioner if an API Key is set, as it's possible that
-	// this is a user misconfiguration.
-	if !isPrefectCloudEndpoint {
-		if apiKey != "" {
-			resp.Diagnostics.AddAttributeWarning(
-				path.Root("api_key"),
-				"Prefect API Key ",
-				"The Prefect API Key is set, however, the Endpoint is set to a Prefect server installation. "+
-					"Potential resolutions: set the endpoint attribute or PREFECT_API_URL environment variable to a Prefect Cloud endpoint, unset the PREFECT_API_KEY environment variable, or remove the api_key attribute.",
-			)
-		}
-	}
-
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/125

also removes the provider init warning, for when an `api_key` attribute is passed when a non-Cloud endpoint is used.  as the creator this ticket states, there are users who front their Prefect server with their own authentication service