### PR TITLE
minor: typo in workspace resource docs

### DIFF
--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -15,7 +15,7 @@ The resource `workspace` represents a Prefect Cloud Workspace. Workspaces are di
 ```terraform
 resource "prefect_workspace" "example" {
   name   = "My Workspace"
-  Handle = "my-workspace"
+  handle = "my-workspace"
 }
 ```
 

--- a/examples/resources/prefect_workspace/resource.tf
+++ b/examples/resources/prefect_workspace/resource.tf
@@ -1,4 +1,4 @@
 resource "prefect_workspace" "example" {
   name   = "My Workspace"
-  Handle = "my-workspace"
+  handle = "my-workspace"
 }


### PR DESCRIPTION
terraform plan will complain and suggest the right casing, so no biggie

```
$ terraform plan
╷
│ Error: Missing required argument
│
│   on main.tf line 1, in resource "prefect_workspace" "foo":
│    1: resource "prefect_workspace" "foo" {
│
│ The argument "handle" is required, but no definition was found.
╵
╷
│ Error: Unsupported argument
│
│   on main.tf line 3, in resource "prefect_workspace" "foo":
│    3:   Handle = "apr-2-24"
│
│ An argument named "Handle" is not expected here. Did you mean "handle"?
``` 