### PR TITLE
minor: fix docs around authenticating provider with environment variables

### DIFF
--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -98,7 +98,7 @@ will run [TF acceptance tests](https://developer.hashicorp.com/terraform/plugin/
 
 ```shell
 export PREFECT_API_URL=https://api.prefect.cloud
-export PREFECT_CLOUD_API_KEY=<secret>
+export PREFECT_API_KEY=<secret>
 export PREFECT_CLOUD_ACCOUNT_ID=<uuid>
 
 make testacc

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -32,7 +32,7 @@ provider "prefect" {
 You can optionally configure your provider through environment variables in the following way, which implicitly injects the same values as the example above. See our [provider documentation](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs) for the full attribute schema + related environment variable names.
 
 ```shell
-export PREFECT_CLOUD_API_KEY="your API Key"
+export PREFECT_API_KEY="your API Key"
 export PREFECT_CLOUD_ACCOUNT_ID="your Account/Organization ID"
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ provider "prefect" {
 
 # You can also pass in your API key and account ID
 # implicitly via environment variables, such as
-# PREFECT_CLOUD_API_KEY and PREFECT_CLOUD_ACCOUNT_ID.
+# PREFECT_API_KEY and PREFECT_CLOUD_ACCOUNT_ID.
 provider "prefect" {}
 
 # You also have the option to link the provider instance
@@ -56,6 +56,6 @@ provider "prefect" {
 ### Optional
 
 - `account_id` (String) Default Prefect Cloud Account ID. Can also be set via the `PREFECT_CLOUD_ACCOUNT_ID` environment variable.
-- `api_key` (String, Sensitive) Prefect Cloud API Key. Can also be set via the `PREFECT_CLOUD_API_KEY` environment variable.
+- `api_key` (String, Sensitive) Prefect Cloud API Key. Can also be set via the `PREFECT_API_KEY` environment variable.
 - `endpoint` (String) Prefect API URL. Can also be set via the `PREFECT_API_URL` environment variable. Defaults to `https://api.prefect.cloud`
 - `workspace_id` (String) Default Prefect Cloud Workspace ID.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -16,7 +16,7 @@ provider "prefect" {
 
 # You can also pass in your API key and account ID
 # implicitly via environment variables, such as
-# PREFECT_CLOUD_API_KEY and PREFECT_CLOUD_ACCOUNT_ID.
+# PREFECT_API_KEY and PREFECT_CLOUD_ACCOUNT_ID.
 provider "prefect" {}
 
 # You also have the option to link the provider instance

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,7 +43,7 @@ func (p *PrefectProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 				Optional:    true,
 			},
 			"api_key": schema.StringAttribute{
-				Description: "Prefect Cloud API Key. Can also be set via the `PREFECT_CLOUD_API_KEY` environment variable.",
+				Description: "Prefect Cloud API Key. Can also be set via the `PREFECT_API_KEY` environment variable.",
 				Optional:    true,
 				Sensitive:   true,
 			},
@@ -87,7 +87,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 			path.Root("api_key"),
 			"Unknown Prefect API Key",
 			"The Prefect API Key is not known at configuration time. "+
-				"Potential resolutions: target apply the source of the value first, set the value statically in the configuration, set the PREFECT_CLOUD_API_KEY environment variable, or remove the value.",
+				"Potential resolutions: target apply the source of the value first, set the value statically in the configuration, set the PREFECT_API_KEY environment variable, or remove the value.",
 		)
 	}
 
@@ -143,7 +143,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	var apiKey string
 	if !config.APIKey.IsNull() {
 		apiKey = config.APIKey.ValueString()
-	} else if apiKeyEnvVar, ok := os.LookupEnv("PREFECT_CLOUD_API_KEY"); ok {
+	} else if apiKeyEnvVar, ok := os.LookupEnv("PREFECT_API_KEY"); ok {
 		apiKey = apiKeyEnvVar
 	}
 
@@ -173,7 +173,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 				path.Root("api_key"),
 				"Missing Prefect API Key",
 				"The Prefect API Endpoint is configured to Prefect Cloud, however, the Prefect API Key is empty. "+
-					"Potential resolutions: set the endpoint attribute or PREFECT_API_URL environment variable to a Prefect server installation, set the PREFECT_CLOUD_API_KEY environment variable, or configure the api_key attribute.",
+					"Potential resolutions: set the endpoint attribute or PREFECT_API_URL environment variable to a Prefect server installation, set the PREFECT_API_KEY environment variable, or configure the api_key attribute.",
 			)
 		}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -87,7 +87,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 			path.Root("api_key"),
 			"Unknown Prefect API Key",
 			"The Prefect API Key is not known at configuration time. "+
-				"Potential resolutions: target apply the source of the value first, set the value statically in the configuration, set the PREFECT_API_KEY environment variable, or remove the value.",
+				"Potential resolutions: target apply the source of the value first, set the value statically in the configuration, set the PREFECT_CLOUD_API_KEY environment variable, or remove the value.",
 		)
 	}
 
@@ -143,7 +143,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	var apiKey string
 	if !config.APIKey.IsNull() {
 		apiKey = config.APIKey.ValueString()
-	} else if apiKeyEnvVar, ok := os.LookupEnv("PREFECT_API_KEY"); ok {
+	} else if apiKeyEnvVar, ok := os.LookupEnv("PREFECT_CLOUD_API_KEY"); ok {
 		apiKey = apiKeyEnvVar
 	}
 
@@ -173,7 +173,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 				path.Root("api_key"),
 				"Missing Prefect API Key",
 				"The Prefect API Endpoint is configured to Prefect Cloud, however, the Prefect API Key is empty. "+
-					"Potential resolutions: set the endpoint attribute or PREFECT_API_URL environment variable to a Prefect server installation, set the PREFECT_API_KEY environment variable, or configure the api_key attribute.",
+					"Potential resolutions: set the endpoint attribute or PREFECT_API_URL environment variable to a Prefect server installation, set the PREFECT_CLOUD_API_KEY environment variable, or configure the api_key attribute.",
 			)
 		}
 

--- a/templates/guides/getting-started.md
+++ b/templates/guides/getting-started.md
@@ -32,7 +32,7 @@ provider "prefect" {
 You can optionally configure your provider through environment variables in the following way, which implicitly injects the same values as the example above. See our [provider documentation](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs) for the full attribute schema + related environment variable names.
 
 ```shell
-export PREFECT_CLOUD_API_KEY="your API Key"
+export PREFECT_API_KEY="your API Key"
 export PREFECT_CLOUD_ACCOUNT_ID="your Account/Organization ID"
 ```
 


### PR DESCRIPTION
Summary
-------

Spots in the documentation are inconsistent about whether to use PREFECT_API_KEY or PREFECT_CLOUD_API_KEY when passing the provider authentication config via environment variables. This PR consolidates documentation around this to use PREFECT_API_KEY, which is what the provider is currently looking for [here](https://github.com/PrefectHQ/terraform-provider-prefect/blob/a5ca0d39fd2ec3b378525d94f217114fc38580b7/internal/provider/provider.go#L146).