### PR TITLE
fix: team_access endpoint is a PUT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ local.tfvars
 
 # Built artifacts
 build/*
+
+.envrc

--- a/internal/api/workspace_access.go
+++ b/internal/api/workspace_access.go
@@ -9,7 +9,7 @@ import (
 type WorkspaceAccessClient interface {
 	Upsert(ctx context.Context, accessorType string, accessorID uuid.UUID, roleID uuid.UUID) (*WorkspaceAccess, error)
 	Get(ctx context.Context, accessorType string, accessID uuid.UUID) (*WorkspaceAccess, error)
-	Delete(ctx context.Context, accessorType string, accessID uuid.UUID) error
+	Delete(ctx context.Context, accessorType string, accessID uuid.UUID, accessorID uuid.UUID) error
 }
 
 // WorkspaceAccess is a representation of a workspace access.

--- a/internal/client/workspace_access.go
+++ b/internal/client/workspace_access.go
@@ -99,12 +99,12 @@ func (c *WorkspaceAccessClient) Upsert(ctx context.Context, accessorType string,
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
 	}
 
-	var workspaceAccess api.WorkspaceAccess
-	if err := json.NewDecoder(resp.Body).Decode(&workspaceAccess); err != nil {
+	var workspaceAccesses []api.WorkspaceAccess
+	if err := json.NewDecoder(resp.Body).Decode(&workspaceAccesses); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return &workspaceAccess, nil
+	return &workspaceAccesses[0], nil
 }
 
 // Get fetches workspace access for various accessor types via accessID.

--- a/internal/client/workspace_access.go
+++ b/internal/client/workspace_access.go
@@ -49,6 +49,8 @@ func (c *WorkspaceAccessClient) Upsert(ctx context.Context, accessorType string,
 		WorkspaceRoleID: roleID,
 	}
 	var requestPath string
+	requestMethod := http.MethodPost
+
 	if accessorType == utils.User {
 		requestPath = fmt.Sprintf("%s/user_access/", c.routePrefix)
 		payload.UserID = &accessorID
@@ -58,6 +60,7 @@ func (c *WorkspaceAccessClient) Upsert(ctx context.Context, accessorType string,
 		payload.BotID = &accessorID
 	}
 	if accessorType == utils.Team {
+		requestMethod = http.MethodPut
 		requestPath = fmt.Sprintf("%s/team_access/", c.routePrefix)
 		payload.TeamID = &accessorID
 	}
@@ -67,7 +70,7 @@ func (c *WorkspaceAccessClient) Upsert(ctx context.Context, accessorType string,
 		return nil, fmt.Errorf("failed to encode upsert payload data: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestPath, &buf)
+	req, err := http.NewRequestWithContext(ctx, requestMethod, requestPath, &buf)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}

--- a/internal/client/workspace_access.go
+++ b/internal/client/workspace_access.go
@@ -49,18 +49,25 @@ func (c *WorkspaceAccessClient) Upsert(ctx context.Context, accessorType string,
 		WorkspaceRoleID: roleID,
 	}
 	var requestPath string
-	requestMethod := http.MethodPost
+
+	// NOTE: this is a quirk of our <entity>_access API at the moment
+	// where user_access and bot_access were originally set up as a POST.
+	// Semantically, they should be a PUT, which the newer team_access API is set up as.
+	// At a later point, we will migrate the user/bot API variants over to a PUT
+	// in a breaking change.
+	requestMethod := http.MethodPut
 
 	if accessorType == utils.User {
 		requestPath = fmt.Sprintf("%s/user_access/", c.routePrefix)
 		payload.UserID = &accessorID
+		requestMethod = http.MethodPost
 	}
 	if accessorType == utils.ServiceAccount {
 		requestPath = fmt.Sprintf("%s/bot_access/", c.routePrefix)
 		payload.BotID = &accessorID
+		requestMethod = http.MethodPost
 	}
 	if accessorType == utils.Team {
-		requestMethod = http.MethodPut
 		requestPath = fmt.Sprintf("%s/team_access/", c.routePrefix)
 		payload.TeamID = &accessorID
 	}

--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -269,9 +269,10 @@ func (r *WorkspaceAccessResource) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
+	accessorID := state.AccessorID.ValueUUID()
 	accessorType := state.AccessorType.ValueString()
 
-	err = client.Delete(ctx, accessorType, accessID)
+	err = client.Delete(ctx, accessorType, accessID, accessorID)
 	if err != nil {
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace Access", "delete", err))
 

--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -118,7 +118,7 @@ func (r *WorkspaceAccessResource) Schema(_ context.Context, _ resource.SchemaReq
 
 // copyWorkspaceAccessToModel copies the API resource to the Terraform model.
 // Note that api.WorkspaceAccess represents a combined model for all accessor types,
-// meaning accessory-specific attributes like BotID and UserID will be conditionally nil
+// meaning accessor-specific attributes like BotID and UserID will be conditionally nil
 // depending on the accessor type.
 func copyWorkspaceAccessToModel(access *api.WorkspaceAccess, model *WorkspaceAccessResourceModel) {
 	model.ID = types.StringValue(access.ID.String())
@@ -130,6 +130,9 @@ func copyWorkspaceAccessToModel(access *api.WorkspaceAccess, model *WorkspaceAcc
 	}
 	if access.UserID != nil {
 		model.AccessorID = customtypes.NewUUIDValue(*access.UserID)
+	}
+	if access.TeamID != nil {
+		model.AccessorID = customtypes.NewUUIDValue(*access.TeamID)
 	}
 }
 

--- a/internal/provider/resources/workspace_access_test.go
+++ b/internal/provider/resources/workspace_access_test.go
@@ -105,7 +105,7 @@ data "prefect_workspace_role" "viewer" {
 data "prefect_workspace" "evergreen" {
 	handle = "github-ci-tests"
 }
-data "prefect_team" my_team" {
+data "prefect_team" "my_team" {
 	name = "my-team"
 }
 resource "prefect_workspace_access" "team_access" {

--- a/internal/provider/resources/workspace_access_test.go
+++ b/internal/provider/resources/workspace_access_test.go
@@ -75,7 +75,7 @@ func TestAccResource_bot_workspace_access(t *testing.T) {
 				Config: fixtureAccWorkspaceAccessResourceForBot(randomName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Check creation + existence of the workspace access resource, with matching linked attributes
-					testAccCheckWorkspaceAccessExists(accessResourceName, workspaceDatsourceName, utils.ServiceAccount, &workspaceAccess),
+					testAccCheckWorkspaceAccessExists(utils.ServiceAccount, accessResourceName, workspaceDatsourceName, &workspaceAccess),
 					testAccCheckWorkspaceAccessValuesForAccessor(utils.ServiceAccount, &workspaceAccess, botResourceName, developerRoleDatsourceName),
 					resource.TestCheckResourceAttrPair(accessResourceName, "accessor_id", botResourceName, "id"),
 					resource.TestCheckResourceAttrPair(accessResourceName, "workspace_id", workspaceDatsourceName, "id"),
@@ -86,7 +86,7 @@ func TestAccResource_bot_workspace_access(t *testing.T) {
 				Config: fixtureAccWorkspaceAccessResourceUpdateForBot(randomName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Check updating the role of the workspace access resource, with matching linked attributes
-					testAccCheckWorkspaceAccessExists(accessResourceName, workspaceDatsourceName, utils.ServiceAccount, &workspaceAccess),
+					testAccCheckWorkspaceAccessExists(utils.ServiceAccount, accessResourceName, workspaceDatsourceName, &workspaceAccess),
 					testAccCheckWorkspaceAccessValuesForAccessor(utils.ServiceAccount, &workspaceAccess, botResourceName, runnerRoleDatsourceName),
 					resource.TestCheckResourceAttrPair(accessResourceName, "accessor_id", botResourceName, "id"),
 					resource.TestCheckResourceAttrPair(accessResourceName, "workspace_id", workspaceDatsourceName, "id"),
@@ -154,7 +154,7 @@ func TestAccResource_team_workspace_access(t *testing.T) {
 				Config: fixtureAccWorkspaceAccessResourceForTeam(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Check creation + existence of the workspace access resource, with matching linked attributes
-					testAccCheckWorkspaceAccessExists(accessResourceName, workspaceDatsourceName, utils.ServiceAccount, &workspaceAccess),
+					testAccCheckWorkspaceAccessExists(utils.Team, accessResourceName, workspaceDatsourceName, &workspaceAccess),
 					testAccCheckWorkspaceAccessValuesForAccessor(utils.Team, &workspaceAccess, teamResourceName, viewerRoleDatsourceName),
 					resource.TestCheckResourceAttrPair(accessResourceName, "accessor_id", teamResourceName, "id"),
 					resource.TestCheckResourceAttrPair(accessResourceName, "workspace_id", workspaceDatsourceName, "id"),
@@ -165,7 +165,7 @@ func TestAccResource_team_workspace_access(t *testing.T) {
 				Config: fixtureAccWorkspaceAccessResourceUpdateForTeam(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Check updating the role of the workspace access resource, with matching linked attributes
-					testAccCheckWorkspaceAccessExists(accessResourceName, workspaceDatsourceName, utils.ServiceAccount, &workspaceAccess),
+					testAccCheckWorkspaceAccessExists(utils.Team, accessResourceName, workspaceDatsourceName, &workspaceAccess),
 					testAccCheckWorkspaceAccessValuesForAccessor(utils.Team, &workspaceAccess, teamResourceName, runnerRoleDatsourceName),
 					resource.TestCheckResourceAttrPair(accessResourceName, "accessor_id", teamResourceName, "id"),
 					resource.TestCheckResourceAttrPair(accessResourceName, "workspace_id", workspaceDatsourceName, "id"),
@@ -176,7 +176,7 @@ func TestAccResource_team_workspace_access(t *testing.T) {
 	})
 }
 
-func testAccCheckWorkspaceAccessExists(accessResourceName string, workspaceDatasourceName string, accessorType string, access *api.WorkspaceAccess) resource.TestCheckFunc {
+func testAccCheckWorkspaceAccessExists(accessorType string, accessResourceName string, workspaceDatasourceName string, access *api.WorkspaceAccess) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		workspaceAccessResource, exists := state.RootModule().Resources[accessResourceName]
 		if !exists {
@@ -196,6 +196,7 @@ func testAccCheckWorkspaceAccessExists(accessResourceName string, workspaceDatas
 		workspaceAccessClient, _ := c.WorkspaceAccess(uuid.Nil, workspaceID)
 
 		fetchedWorkspaceAccess, err := workspaceAccessClient.Get(context.Background(), accessorType, workspaceAccessID)
+
 		if err != nil {
 			return fmt.Errorf("Error fetching Workspace Access: %w", err)
 		}

--- a/internal/provider/resources/workspace_access_test.go
+++ b/internal/provider/resources/workspace_access_test.go
@@ -124,7 +124,7 @@ data "prefect_workspace_role" "runner" {
 data "prefect_workspace" "evergreen" {
 	handle = "github-ci-tests"
 }
-resource "prefect_team" "my_team" {
+data "prefect_team" "my_team" {
 	name = "my-team"
 }
 resource "prefect_workspace_access" "team_access" {

--- a/internal/provider/resources/workspace_access_test.go
+++ b/internal/provider/resources/workspace_access_test.go
@@ -127,7 +127,7 @@ data "prefect_workspace" "evergreen" {
 resource "prefect_team" "my_team" {
 	name = "my-team"
 }
-resource "prefect_workspace_access" "bot_access" {
+resource "prefect_workspace_access" "team_access" {
 	accessor_type = "TEAM"
 	accessor_id = data.prefect_team.my_team.id
 	workspace_id = data.prefect_workspace.evergreen.id


### PR DESCRIPTION
fixes #169 
original PR: #146 

our existing API for `bot_access` and `user_access` are POST endpoints, so we copied that same method to the newer `team_access` client call in #146.  but we actually use the more semantically accurate PUT for `team_access`, so we'll handle these differently until we consolidate on the API side