### PR TITLE
Pin tool versions with 'mise'

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,9 @@
+[tools]
+golangci-lint = '1.59.0'
+goreleaser = '1.26.2'
+pre-commit = '3.7.1'
+terraform = '1.8.4'
+
+# Installing Golang seems to be broken at the moment.
+# For now, install with `brew` per ./_about/CONTRIBUTING.md.
+# go-sdk = '1.21.10'

--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -14,17 +14,20 @@ This project also uses the following tools to build and test:
 - `goreleaser` to generate release binaries (optional for development)
 - `go-imports` to automatically update missing or unused imports
 
-On MacOS, you can use `brew` and `go install` to install necessary dependencies:
+On MacOS, you can use `brew`, `mise` and `go install` to install necessary dependencies:
 
 ```shell
 brew install \
   go \
   gotestsum \
-  golangci-lint \
-  goreleaser
+  mise
 
 go install golang.org/x/tools/cmd/goimports@latest
+
+mise install
 ```
+
+We use [`mise`](https://github.com/jdx/mise) to manage as many dependencies as possible based on the supported plugins in its [registry](https://mise.jdx.dev/registry.html).
 
 ## Local Development
 


### PR DESCRIPTION
    Manage tool versions with mise

    Manages the tool versions used for development by adding .mise.toml and
    pinning the tool versions there. This will help keep the tool versions
    aligned between developer machines (and potentially CI in the future).

    https://mise.jdx.dev

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/184