### PR TITLE
Add Docker Compose file for local testing

### DIFF
--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -130,7 +130,9 @@ provider_installation {
 }
 ```
 
-Next, start the server:
+You only need to do this once, but if you will need to comment this out any time you want to use the provider from the official Terraform registry instead.
+
+Next, start the Prefect server:
 
 ```shell
 docker-compose up -d

--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -107,6 +107,42 @@ export PREFECT_CLOUD_ACCOUNT_ID=<uuid>
 make testacc
 ```
 
+You can also test against a local instance of Prefect. An example of this setup using Docker Compose is available in the [Terraform Provider tutorial](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider).
+
+First, you'll need to create or modify `~/.terraformrc` on your machine:
+
+```terraform
+provider_installation {
+  dev_overrides {
+    "registry.terraform.io/prefecthq/prefect" = "/Users/<username>/go/bin/"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
+```
+
+Next, start the server:
+
+```shell
+docker-compose up -d
+```
+
+You can confirm the server is running by either:
+
+1. Checking the logs with `docker-compose logs -f`, or
+2. Navigating to the UI in your browser at [localhost:4200](http://localhost:4200).
+
+When you're ready to test your changes, compile the provider and install it to your path:
+
+```shell
+go install .
+```
+
+You can now run `terraform plan` and `terraform apply` to test features in the provider.
+
 ## Build Documentation
 
 This provider repository uses the [`tfplugindocs`](https://github.com/hashicorp/terraform-plugin-docs) CLI utility to generate markdown documentation.

--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -81,19 +81,23 @@ though in general, running `make install` will be sufficient in the course of de
 
 ## Testing
 
-There are two `make` commands regarding automated tests:
+There are a few options for running tests depending on the type.
+
+### Unit tests
+
+The following command will run any regular unit tests. These are typically for helper or utility logic, such as data flatteners or equality checks.
 
 ```shell
 make test
 ```
 
-will run any regular unit tests. These are typically for helper or utility logic, such as data flatteners or equality checks.
+### Terraform acceptance tests
+
+The following command will run [TF acceptance tests](https://developer.hashicorp.com/terraform/plugin/testing/acceptance-tests), by prefixing the test run with `TF_ACC=1`.
 
 ```shell
 make testacc
 ```
-
-will run [TF acceptance tests](https://developer.hashicorp.com/terraform/plugin/testing/acceptance-tests), by prefixing the test run with `TF_ACC=1`
 
 **NOTE:** Acceptance tests create real Prefect Cloud resources, and require a Prefect Cloud account when running locally
 
@@ -106,6 +110,8 @@ export PREFECT_CLOUD_ACCOUNT_ID=<uuid>
 
 make testacc
 ```
+
+### Integration tests
 
 You can also test against a local instance of Prefect. An example of this setup using Docker Compose is available in the [Terraform Provider tutorial](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider).
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,19 @@
+# This file is used to run a local instance of
+# Prefect for testing our Terraform Provider.
+#
+# See ./_about/CONTRIBUTING.md.
+services:
+  prefect:
+    image: prefecthq/prefect:2-latest
+    ports:
+      - "4200:4200"
+    environment:
+      PREFECT_LOGGING_LEVEL: debug
+    command:
+      - prefect
+      - server
+      - start
+      - --host
+      - "0.0.0.0"
+      - --port
+      - "4200"

--- a/examples/provider-install-verification/main.tf
+++ b/examples/provider-install-verification/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    prefect = {
+      source = "registry.terraform.io/prefecthq/prefect"
+    }
+  }
+}
+
+provider "prefect" {
+  endpoint = "http://localhost:4200/api"
+}
+
+resource "prefect_work_pool" "example" {
+  name        = "my-work-pool"
+  type        = "kubernetes"
+  description = "example work pool"
+  paused      = true
+}


### PR DESCRIPTION
## Summary

Adds a local Docker Compose file to start an instance of Prefect that we can reach with `terraform` commands.

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/186

## Testing

<details>
<summary>Click to expand</summary>

```
$ terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/mitch/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
│ published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # prefect_work_pool.example will be created
  + resource "prefect_work_pool" "example" {
      + base_job_template = jsonencode({})
      + created           = (known after apply)
      + default_queue_id  = (known after apply)
      + id                = (known after apply)
      + name              = "my-work-pool"
      + paused            = true
      + type              = "kubernetes"
      + updated           = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply"
now.

~/code/github.com/prefecthq/terraform-provider-prefect/add-testing-in-docker/examples/provider-install-verification on  add-testing-in-docker *?!
$ terraform apply
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/mitch/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
│ published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # prefect_work_pool.example will be created
  + resource "prefect_work_pool" "example" {
      + base_job_template = jsonencode({})
      + created           = (known after apply)
      + default_queue_id  = (known after apply)
      + id                = (known after apply)
      + name              = "my-work-pool"
      + paused            = true
      + type              = "kubernetes"
      + updated           = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

prefect_work_pool.example: Creating...
prefect_work_pool.example: Creation complete after 0s [id=c088c80f-9612-4912-b03b-d5bea4facac7]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

<img width="1266" alt="image" src="https://github.com/PrefectHQ/terraform-provider-prefect/assets/7725815/530cbb1e-2d1d-4641-9b3a-ece3ea8af975">


</details>
