### PR TITLE
feat(blocks): add update resource operation

### DIFF
--- a/internal/api/block_documents.go
+++ b/internal/api/block_documents.go
@@ -37,7 +37,7 @@ type BlockDocumentCreate struct {
 }
 
 type BlockDocumentUpdate struct {
-	BlockSchemaID     *uuid.UUID             `json:"block_schema_id"`
+	BlockSchemaID     uuid.UUID              `json:"block_schema_id"`
 	Data              map[string]interface{} `json:"data"`
 	MergeExistingData bool                   `json:"merge_existing_data"`
 }

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -256,6 +256,8 @@ func (r *BlockResource) Read(ctx context.Context, req resource.ReadRequest, resp
 			"Error creating block client",
 			fmt.Sprintf("Could not create block client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
 		)
+
+		return
 	}
 
 	var blockID uuid.UUID
@@ -411,6 +413,8 @@ func (r *BlockResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			"Failed to serialize Block Data",
 			fmt.Sprintf("Could not serialize Block Data as JSON string: %s", err.Error()),
 		)
+
+		return
 	}
 	plan.Data = jsontypes.NewNormalizedValue(string(byteSlice))
 

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -106,6 +106,9 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"type_slug": schema.StringAttribute{
 				Required:    true,
 				Description: "Block Type slug, which determines the schema of the `data` JSON attribute. Use `prefect block types ls` to view all available Block type slugs.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"data": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -306,9 +306,119 @@ func (r *BlockResource) Read(ctx context.Context, req resource.ReadRequest, resp
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
-//
-//nolint:revive // TODO: remove this comment when method is implemented
 func (r *BlockResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan BlockResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	blockTypeClient, err := r.client.BlockTypes(plan.AccountID.ValueUUID(), plan.WorkspaceID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Block Types", err))
+
+		return
+	}
+
+	blockSchemaClient, err := r.client.BlockSchemas(plan.AccountID.ValueUUID(), plan.WorkspaceID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Block Schema", err))
+
+		return
+	}
+
+	blockDocumentClient, err := r.client.BlockDocuments(plan.AccountID.ValueUUID(), plan.WorkspaceID.ValueUUID())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Block Document", err))
+
+		return
+	}
+
+	blockType, err := blockTypeClient.GetBySlug(ctx, plan.TypeSlug.ValueString())
+	if err != nil {
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Block Type", "get_by_slug", err))
+
+		return
+	}
+
+	blockSchemas, err := blockSchemaClient.List(ctx, []uuid.UUID{blockType.ID})
+	if err != nil {
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Block Schema", "list", err))
+
+		return
+	}
+
+	if len(blockSchemas) == 0 {
+		resp.Diagnostics.AddError(
+			"No block schemas found",
+			fmt.Sprintf("No block schemas found for %s block type slug", plan.TypeSlug.ValueString()),
+		)
+
+		return
+	}
+
+	latestBlockSchema := blockSchemas[0]
+
+	blockID, err := uuid.Parse(plan.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("id"),
+			"Error parsing block ID",
+			fmt.Sprintf("Could not parse block ID to UUID, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	var data map[string]interface{}
+	resp.Diagnostics.Append(plan.Data.Unmarshal(&data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err = blockDocumentClient.Update(ctx, blockID, api.BlockDocumentUpdate{
+		BlockSchemaID:     latestBlockSchema.ID,
+		Data:              data,
+		MergeExistingData: true,
+	})
+
+	if err != nil {
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Block Document", "update", err))
+
+		return
+	}
+
+	block, err := blockDocumentClient.Get(ctx, blockID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error refreshing block state",
+			fmt.Sprintf("Could not read block, unexpected error: %s", err.Error()),
+		)
+
+		return
+	}
+
+	diags := copyBlockToModel(block, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	byteSlice, err := json.Marshal(block.Data)
+	if err != nil {
+		diags.AddAttributeError(
+			path.Root("data"),
+			"Failed to serialize Block Data",
+			fmt.Sprintf("Could not serialize Block Data as JSON string: %s", err.Error()),
+		)
+	}
+	plan.Data = jsontypes.NewNormalizedValue(string(byteSlice))
+
+	diags = resp.State.Set(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 // Delete deletes the resource and removes the Terraform state on success.


### PR DESCRIPTION
## Summary

Closes #182.

<details>
<summary>Testing (click to expand)</summary>

## Testing - OSS

### Setup

First, run `docker-compose up -d` to start a local Prefect instance.

Next, create a block resource to use with the local instance, and enable the provider:

```diff
diff --git a/examples/provider-install-verification/main.tf b/examples/provider-install-verification/main.tf
index 7799578..f1119ee 100644
--- a/examples/provider-install-verification/main.tf
+++ b/examples/provider-install-verification/main.tf
@@ -10,9 +10,14 @@ provider "prefect" {
   endpoint = "http://localhost:4200/api"
 }
 
-resource "prefect_work_pool" "example" {
-  name        = "my-work-pool"
-  type        = "kubernetes"
-  description = "example work pool"
-  paused      = true
+resource "prefect_block" "secret" {
+  name      = "foo"
+  type_slug = "secret"
+
+  data = jsonencode({
+    "value" : "bar"
+  })
+
+  # set the workpace_id attribute on the provider OR the resource
+  # workspace_id = "<workspace UUID>"
 }
diff --git a/internal/provider/provider.go b/internal/provider/provider.go
index f7f4ef4..5f95b51 100644
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -242,6 +242,6 @@ func (p *PrefectProvider) Resources(_ context.Context) []func() resource.Resourc
 		resources.NewWorkspaceAccessResource,
 		resources.NewWorkspaceResource,
 		resources.NewWorkspaceRoleResource,
-		// resources.NewBlockResource,
+		resources.NewBlockResource,
 	}
 }
```

Apply it with Terraform:

```
Terraform will perform the following actions:

  # prefect_block.secret will be created
  + resource "prefect_block" "secret" {
      + created   = (known after apply)
      + data      = jsonencode(
            {
              + value = "bar"
            }
        )
      + id        = (known after apply)
      + name      = "foo"
      + type_slug = "secret"
      + updated   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

prefect_block.secret: Creating...
prefect_block.secret: Creation complete after 0s [id=5e1f535d-ff3c-4164-9117-e1ecba53a122]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Now that it's created, try to read the value. We can use a quick Python script in `test.py`:

```python
from prefect.blocks.system import Secret

print(Secret.load("foo").get())
```

```
$ python test.py
bar
```

Now let's change it so we can test `Update`. Change the value in `main.tf` to `baz`.

Next, run `terraform plan`:

```
prefect_block.secret: Refreshing state... [id=5e1f535d-ff3c-4164-9117-e1ecba53a122]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # prefect_block.secret will be updated in-place
  ~ resource "prefect_block" "secret" {
      ~ created   = "2024-06-06T21:05:27Z" -> (known after apply)
      ~ data      = jsonencode(
          ~ {
              ~ value = "bar" -> "baz"
            }
        )
        id        = "5e1f535d-ff3c-4164-9117-e1ecba53a122"
        name      = "foo"
      ~ updated   = "2024-06-06T21:05:27Z" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Apply the change with `terraform apply` and then check the value again:

```
$ python test.py
baz
```

The value was successfully updated.

## Testing - Cloud

First, update the `main.tf` file to point to Staging and reset the block value to `bar`:

```diff
diff --git a/examples/provider-install-verification/main.tf b/examples/provider-install-verification/main.tf
index 7799578..55db778 100644
--- a/examples/provider-install-verification/main.tf
+++ b/examples/provider-install-verification/main.tf
@@ -7,12 +7,19 @@ terraform {
 }
 
 provider "prefect" {
-  endpoint = "http://localhost:4200/api"
+  endpoint     = "https://api.prefect.cloud"
+  account_id   = "<my account ID>"
+  workspace_id = "<my workspace ID>"
 }
 
-resource "prefect_work_pool" "example" {
-  name        = "my-work-pool"
-  type        = "kubernetes"
-  description = "example work pool"
-  paused      = true
+resource "prefect_block" "secret" {
+  name      = "foo"
+  type_slug = "secret"
+
+  data = jsonencode({
+    "value" : "bar"
+  })
+
+  # set the workpace_id attribute on the provider OR the resource
+  # workspace_id = "<workspace UUID>"
 }
```

Apply it with Terraform:

```
$ terraform plan
...

Terraform will perform the following actions:

  # prefect_block.secret will be created
  + resource "prefect_block" "secret" {
      + created   = (known after apply)
      + data      = jsonencode(
            {
              + value = "bar"
            }
        )
      + id        = (known after apply)
      + name      = "foo"
      + type_slug = "secret"
      + updated   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

prefect_block.secret: Creating...
prefect_block.secret: Creation complete after 0s [id=d8ae1c60-1248-407b-9ad8-ddb412ac6b1a]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Let's test it with Python:

```
$ python test.py
bar
```

And let's change it to `baz` in `main.tf` and apply it to confirm `Update`:

```
$ terraform apply
...
Terraform will perform the following actions:

  # prefect_block.secret will be updated in-place
  ~ resource "prefect_block" "secret" {
      ~ created   = "2024-06-06T21:40:55Z" -> (known after apply)
      ~ data      = jsonencode(
          ~ {
              ~ value = "bar" -> "baz"
            }
        )
        id        = "4f308f8f-cb19-4823-aabc-bbd8debe4af1"
        name      = "foo"
      ~ updated   = "2024-06-06T21:40:55Z" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

prefect_block.secret: Modifying... [id=4f308f8f-cb19-4823-aabc-bbd8debe4af1]
prefect_block.secret: Modifications complete after 1s [id=4f308f8f-cb19-4823-aabc-bbd8debe4af1]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

And get the new value with Python:

```
$ python test.py
baz
```

</details>
