### PR TITLE
chore(hygiene): standardize model variable names + use planmodifiers for `created`

### DIFF
--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -98,6 +98,9 @@ func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Timestamp of when the resource was created (RFC3339)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -82,9 +82,8 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Block ID (UUID)",
-				// attributes which are not configurable + should not show updates from the existing state value
-				// should implement `UseStateForUnknown()`
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -93,8 +92,6 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Timestamp of when the resource was created (RFC3339)",
-				// attributes which are not configurable + should not show updates from the existing state value
-				// should implement `UseStateForUnknown()`
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -93,6 +93,11 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Timestamp of when the resource was created (RFC3339)",
+				// attributes which are not configurable + should not show updates from the existing state value
+				// should implement `UseStateForUnknown()`
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated": schema.StringAttribute{
 				Computed:    true,
@@ -109,6 +114,7 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"data": schema.StringAttribute{
 				Required:    true,
+				Sensitive:   true,
 				CustomType:  jsontypes.NormalizedType{},
 				Description: "The user-inputted Block payload, as a JSON string. The value's schema will depend on the selected `type` slug. Use `prefect block types inspect <slug>` to view the data schema for a given Block type.",
 			},

--- a/internal/provider/resources/service_account.go
+++ b/internal/provider/resources/service_account.go
@@ -107,6 +107,9 @@ func (r *ServiceAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Timestamp of when the resource was created (RFC3339)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -98,6 +98,9 @@ func (r *VariableResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Timestamp of when the resource was created (RFC3339)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -157,21 +157,21 @@ func copyVariableToModel(ctx context.Context, variable *api.Variable, tfModel *V
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *VariableResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var config VariableResourceModel
+	var plan VariableResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	var tags []string
-	resp.Diagnostics.Append(config.Tags.ElementsAs(ctx, &tags, false)...)
+	resp.Diagnostics.Append(plan.Tags.ElementsAs(ctx, &tags, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.Variables(config.AccountID.ValueUUID(), config.WorkspaceID.ValueUUID())
+	client, err := r.client.Variables(plan.AccountID.ValueUUID(), plan.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating variable client",
@@ -182,8 +182,8 @@ func (r *VariableResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	variable, err := client.Create(ctx, api.VariableCreate{
-		Name:  config.Name.ValueString(),
-		Value: config.Value.ValueString(),
+		Name:  plan.Name.ValueString(),
+		Value: plan.Value.ValueString(),
 		Tags:  tags,
 	})
 	if err != nil {
@@ -195,12 +195,12 @@ func (r *VariableResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	resp.Diagnostics.Append(copyVariableToModel(ctx, variable, &config)...)
+	resp.Diagnostics.Append(copyVariableToModel(ctx, variable, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -133,41 +133,42 @@ func (r *VariableResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
-// copyVariableToModel copies an api.Variable to a VariableResourceModel.
-func copyVariableToModel(ctx context.Context, variable *api.Variable, model *VariableResourceModel) diag.Diagnostics {
-	model.ID = types.StringValue(variable.ID.String())
-	model.Created = customtypes.NewTimestampPointerValue(variable.Created)
-	model.Updated = customtypes.NewTimestampPointerValue(variable.Updated)
+// copyVariableToModel maps an API response to a model that is saved in Terraform state.
+// A model can be a Terraform Plan, State, or Config object.
+func copyVariableToModel(ctx context.Context, variable *api.Variable, tfModel *VariableResourceModel) diag.Diagnostics {
+	tfModel.ID = types.StringValue(variable.ID.String())
+	tfModel.Created = customtypes.NewTimestampPointerValue(variable.Created)
+	tfModel.Updated = customtypes.NewTimestampPointerValue(variable.Updated)
 
-	model.Name = types.StringValue(variable.Name)
-	model.Value = types.StringValue(variable.Value)
+	tfModel.Name = types.StringValue(variable.Name)
+	tfModel.Value = types.StringValue(variable.Value)
 
 	tags, diags := types.ListValueFrom(ctx, types.StringType, variable.Tags)
 	if diags.HasError() {
 		return diags
 	}
-	model.Tags = tags
+	tfModel.Tags = tags
 
 	return nil
 }
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *VariableResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var model VariableResourceModel
+	var config VariableResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	var tags []string
-	resp.Diagnostics.Append(model.Tags.ElementsAs(ctx, &tags, false)...)
+	resp.Diagnostics.Append(config.Tags.ElementsAs(ctx, &tags, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.Variables(model.AccountID.ValueUUID(), model.WorkspaceID.ValueUUID())
+	client, err := r.client.Variables(config.AccountID.ValueUUID(), config.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating variable client",
@@ -178,8 +179,8 @@ func (r *VariableResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	variable, err := client.Create(ctx, api.VariableCreate{
-		Name:  model.Name.ValueString(),
-		Value: model.Value.ValueString(),
+		Name:  config.Name.ValueString(),
+		Value: config.Value.ValueString(),
 		Tags:  tags,
 	})
 	if err != nil {
@@ -191,12 +192,12 @@ func (r *VariableResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	resp.Diagnostics.Append(copyVariableToModel(ctx, variable, &model)...)
+	resp.Diagnostics.Append(copyVariableToModel(ctx, variable, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -204,15 +205,15 @@ func (r *VariableResource) Create(ctx context.Context, req resource.CreateReques
 
 // Read refreshes the Terraform state with the latest data.
 func (r *VariableResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var model VariableResourceModel
+	var state VariableResourceModel
 
 	// Populate the model from state and emit diagnostics on error
-	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.Variables(model.AccountID.ValueUUID(), model.WorkspaceID.ValueUUID())
+	client, err := r.client.Variables(state.AccountID.ValueUUID(), state.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating variable client",
@@ -228,9 +229,9 @@ func (r *VariableResource) Read(ctx context.Context, req resource.ReadRequest, r
 	var variable *api.Variable
 
 	switch {
-	case !model.ID.IsNull():
+	case !state.ID.IsNull():
 		var variableID uuid.UUID
-		variableID, err = uuid.Parse(model.ID.ValueString())
+		variableID, err = uuid.Parse(state.ID.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
@@ -241,8 +242,8 @@ func (r *VariableResource) Read(ctx context.Context, req resource.ReadRequest, r
 			return
 		}
 		variable, err = client.Get(ctx, variableID)
-	case !model.Name.IsNull():
-		variable, err = client.GetByName(ctx, model.Name.ValueString())
+	case !state.Name.IsNull():
+		variable, err = client.GetByName(ctx, state.Name.ValueString())
 	default:
 		resp.Diagnostics.AddError(
 			"Both ID and Name are unset",
@@ -261,12 +262,12 @@ func (r *VariableResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	resp.Diagnostics.Append(copyVariableToModel(ctx, variable, &model)...)
+	resp.Diagnostics.Append(copyVariableToModel(ctx, variable, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -274,14 +275,14 @@ func (r *VariableResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *VariableResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var model VariableResourceModel
+	var plan VariableResourceModel
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.Variables(model.AccountID.ValueUUID(), model.WorkspaceID.ValueUUID())
+	client, err := r.client.Variables(plan.AccountID.ValueUUID(), plan.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating variable client",
@@ -292,12 +293,12 @@ func (r *VariableResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	var tags []string
-	resp.Diagnostics.Append(model.Tags.ElementsAs(ctx, &tags, false)...)
+	resp.Diagnostics.Append(plan.Tags.ElementsAs(ctx, &tags, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	variableID, err := uuid.Parse(model.ID.ValueString())
+	variableID, err := uuid.Parse(plan.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("id"),
@@ -309,8 +310,8 @@ func (r *VariableResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	err = client.Update(ctx, variableID, api.VariableUpdate{
-		Name:  model.Name.ValueString(),
-		Value: model.Value.ValueString(),
+		Name:  plan.Name.ValueString(),
+		Value: plan.Value.ValueString(),
 		Tags:  tags,
 	})
 	if err != nil {
@@ -332,12 +333,12 @@ func (r *VariableResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	resp.Diagnostics.Append(copyVariableToModel(ctx, variable, &model)...)
+	resp.Diagnostics.Append(copyVariableToModel(ctx, variable, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -345,14 +346,14 @@ func (r *VariableResource) Update(ctx context.Context, req resource.UpdateReques
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *VariableResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var model VariableResourceModel
+	var state VariableResourceModel
 
-	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.Variables(model.AccountID.ValueUUID(), model.WorkspaceID.ValueUUID())
+	client, err := r.client.Variables(state.AccountID.ValueUUID(), state.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating variable client",
@@ -362,7 +363,7 @@ func (r *VariableResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	variableID, err := uuid.Parse(model.ID.ValueString())
+	variableID, err := uuid.Parse(state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("id"),
@@ -383,7 +384,7 @@ func (r *VariableResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -181,20 +181,21 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
-// copyWorkPoolToModel copies an api.WorkPool to a WorkPoolResourceModel.
-func copyWorkPoolToModel(_ context.Context, pool *api.WorkPool, model *WorkPoolResourceModel) diag.Diagnostics {
+// copyWorkPoolToModel maps an API response to a model that is saved in Terraform state.
+// A model can be a Terraform Plan, State, or Config object.
+func copyWorkPoolToModel(_ context.Context, pool *api.WorkPool, tfModel *WorkPoolResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	model.ID = types.StringValue(pool.ID.String())
-	model.Created = customtypes.NewTimestampPointerValue(pool.Created)
-	model.Updated = customtypes.NewTimestampPointerValue(pool.Updated)
+	tfModel.ID = types.StringValue(pool.ID.String())
+	tfModel.Created = customtypes.NewTimestampPointerValue(pool.Created)
+	tfModel.Updated = customtypes.NewTimestampPointerValue(pool.Updated)
 
-	model.ConcurrencyLimit = types.Int64PointerValue(pool.ConcurrencyLimit)
-	model.DefaultQueueID = customtypes.NewUUIDValue(pool.DefaultQueueID)
-	model.Description = types.StringPointerValue(pool.Description)
-	model.Name = types.StringValue(pool.Name)
-	model.Paused = types.BoolValue(pool.IsPaused)
-	model.Type = types.StringValue(pool.Type)
+	tfModel.ConcurrencyLimit = types.Int64PointerValue(pool.ConcurrencyLimit)
+	tfModel.DefaultQueueID = customtypes.NewUUIDValue(pool.DefaultQueueID)
+	tfModel.Description = types.StringPointerValue(pool.Description)
+	tfModel.Name = types.StringValue(pool.Name)
+	tfModel.Paused = types.BoolValue(pool.IsPaused)
+	tfModel.Type = types.StringValue(pool.Type)
 
 	if pool.BaseJobTemplate != nil {
 		var builder strings.Builder
@@ -211,7 +212,7 @@ func copyWorkPoolToModel(_ context.Context, pool *api.WorkPool, model *WorkPoolR
 			return diags
 		}
 
-		model.BaseJobTemplate = jsontypes.NewNormalizedValue(strings.TrimSuffix(builder.String(), "\n"))
+		tfModel.BaseJobTemplate = jsontypes.NewNormalizedValue(strings.TrimSuffix(builder.String(), "\n"))
 	}
 
 	return nil
@@ -219,17 +220,17 @@ func copyWorkPoolToModel(_ context.Context, pool *api.WorkPool, model *WorkPoolR
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *WorkPoolResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var model WorkPoolResourceModel
+	var config WorkPoolResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	baseJobTemplate := map[string]interface{}{}
-	if !model.BaseJobTemplate.IsNull() {
-		reader := strings.NewReader(model.BaseJobTemplate.ValueString())
+	if !config.BaseJobTemplate.IsNull() {
+		reader := strings.NewReader(config.BaseJobTemplate.ValueString())
 		decoder := json.NewDecoder(reader)
 		err := decoder.Decode(&baseJobTemplate)
 		if err != nil {
@@ -243,7 +244,7 @@ func (r *WorkPoolResource) Create(ctx context.Context, req resource.CreateReques
 		}
 	}
 
-	client, err := r.client.WorkPools(model.AccountID.ValueUUID(), model.WorkspaceID.ValueUUID())
+	client, err := r.client.WorkPools(config.AccountID.ValueUUID(), config.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating work pool client",
@@ -254,12 +255,12 @@ func (r *WorkPoolResource) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	pool, err := client.Create(ctx, api.WorkPoolCreate{
-		Name:             model.Name.ValueString(),
-		Description:      model.Description.ValueStringPointer(),
-		Type:             model.Type.ValueString(),
+		Name:             config.Name.ValueString(),
+		Description:      config.Description.ValueStringPointer(),
+		Type:             config.Type.ValueString(),
 		BaseJobTemplate:  baseJobTemplate,
-		IsPaused:         model.Paused.ValueBool(),
-		ConcurrencyLimit: model.ConcurrencyLimit.ValueInt64Pointer(),
+		IsPaused:         config.Paused.ValueBool(),
+		ConcurrencyLimit: config.ConcurrencyLimit.ValueInt64Pointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -270,12 +271,12 @@ func (r *WorkPoolResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkPoolToModel(ctx, pool, &model)...)
+	resp.Diagnostics.Append(copyWorkPoolToModel(ctx, pool, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -283,15 +284,15 @@ func (r *WorkPoolResource) Create(ctx context.Context, req resource.CreateReques
 
 // Read refreshes the Terraform state with the latest data.
 func (r *WorkPoolResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var model WorkPoolResourceModel
+	var state WorkPoolResourceModel
 
 	// Populate the model from state and emit diagnostics on error
-	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.WorkPools(model.AccountID.ValueUUID(), model.WorkspaceID.ValueUUID())
+	client, err := r.client.WorkPools(state.AccountID.ValueUUID(), state.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating work pool client",
@@ -301,7 +302,7 @@ func (r *WorkPoolResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	pool, err := client.Get(ctx, model.Name.ValueString())
+	pool, err := client.Get(ctx, state.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error refreshing work pool state",
@@ -311,12 +312,12 @@ func (r *WorkPoolResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkPoolToModel(ctx, pool, &model)...)
+	resp.Diagnostics.Append(copyWorkPoolToModel(ctx, pool, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -324,16 +325,16 @@ func (r *WorkPoolResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *WorkPoolResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var model WorkPoolResourceModel
+	var plan WorkPoolResourceModel
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	baseJobTemplate := map[string]interface{}{}
-	if !model.BaseJobTemplate.IsNull() {
-		reader := strings.NewReader(model.BaseJobTemplate.ValueString())
+	if !plan.BaseJobTemplate.IsNull() {
+		reader := strings.NewReader(plan.BaseJobTemplate.ValueString())
 		decoder := json.NewDecoder(reader)
 		err := decoder.Decode(&baseJobTemplate)
 		if err != nil {
@@ -347,7 +348,7 @@ func (r *WorkPoolResource) Update(ctx context.Context, req resource.UpdateReques
 		}
 	}
 
-	client, err := r.client.WorkPools(model.AccountID.ValueUUID(), model.WorkspaceID.ValueUUID())
+	client, err := r.client.WorkPools(plan.AccountID.ValueUUID(), plan.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating work pool client",
@@ -357,11 +358,11 @@ func (r *WorkPoolResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	err = client.Update(ctx, model.Name.ValueString(), api.WorkPoolUpdate{
-		Description:      model.Description.ValueStringPointer(),
-		IsPaused:         model.Paused.ValueBoolPointer(),
+	err = client.Update(ctx, plan.Name.ValueString(), api.WorkPoolUpdate{
+		Description:      plan.Description.ValueStringPointer(),
+		IsPaused:         plan.Paused.ValueBoolPointer(),
 		BaseJobTemplate:  baseJobTemplate,
-		ConcurrencyLimit: model.ConcurrencyLimit.ValueInt64Pointer(),
+		ConcurrencyLimit: plan.ConcurrencyLimit.ValueInt64Pointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -372,7 +373,7 @@ func (r *WorkPoolResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	pool, err := client.Get(ctx, model.Name.ValueString())
+	pool, err := client.Get(ctx, plan.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error refreshing work pool state",
@@ -382,12 +383,12 @@ func (r *WorkPoolResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkPoolToModel(ctx, pool, &model)...)
+	resp.Diagnostics.Append(copyWorkPoolToModel(ctx, pool, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -395,14 +396,14 @@ func (r *WorkPoolResource) Update(ctx context.Context, req resource.UpdateReques
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *WorkPoolResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var model WorkPoolResourceModel
+	var state WorkPoolResourceModel
 
-	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.WorkPools(model.AccountID.ValueUUID(), model.WorkspaceID.ValueUUID())
+	client, err := r.client.WorkPools(state.AccountID.ValueUUID(), state.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating work pool client",
@@ -412,7 +413,7 @@ func (r *WorkPoolResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	err = client.Delete(ctx, model.Name.ValueString())
+	err = client.Delete(ctx, state.Name.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting work pool",
@@ -422,7 +423,7 @@ func (r *WorkPoolResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -103,10 +103,6 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Timestamp of when the resource was created (RFC3339)",
-				// In general, we can use UseStateForUnknown() to avoid unnecessary
-				// cases of `known after apply` states during plans. Mostly, this planmodifier
-				// is suitable for Computed attributes that do not change often and
-				// do not have a default value set here in the Schema.
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -94,6 +94,9 @@ func (r *WorkspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Timestamp of when the resource was created (RFC3339)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -141,15 +141,15 @@ func copyWorkspaceToModel(_ context.Context, workspace *api.Workspace, tfModel *
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var config WorkspaceResourceModel
+	var plan WorkspaceResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.Workspaces(config.AccountID.ValueUUID())
+	client, err := r.client.Workspaces(plan.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating workspace client",
@@ -158,9 +158,9 @@ func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	workspace, err := client.Create(ctx, api.WorkspaceCreate{
-		Name:        config.Name.ValueString(),
-		Handle:      config.Handle.ValueString(),
-		Description: config.Description.ValueStringPointer(),
+		Name:        plan.Name.ValueString(),
+		Handle:      plan.Handle.ValueString(),
+		Description: plan.Description.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -171,12 +171,12 @@ func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkspaceToModel(ctx, workspace, &config)...)
+	resp.Diagnostics.Append(copyWorkspaceToModel(ctx, workspace, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -122,30 +122,31 @@ func (r *WorkspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 	}
 }
 
-// copyWorkspaceToModel copies an api.Workspace to a WorkspaceResourceModel.
-func copyWorkspaceToModel(_ context.Context, workspace *api.Workspace, model *WorkspaceResourceModel) diag.Diagnostics {
-	model.ID = types.StringValue(workspace.ID.String())
-	model.Created = customtypes.NewTimestampPointerValue(workspace.Created)
-	model.Updated = customtypes.NewTimestampPointerValue(workspace.Updated)
+// copyWorkspaceModel maps an API response to a model that is saved in Terraform state.
+// A model can be a Terraform Plan, State, or Config object.
+func copyWorkspaceToModel(_ context.Context, workspace *api.Workspace, tfModel *WorkspaceResourceModel) diag.Diagnostics {
+	tfModel.ID = types.StringValue(workspace.ID.String())
+	tfModel.Created = customtypes.NewTimestampPointerValue(workspace.Created)
+	tfModel.Updated = customtypes.NewTimestampPointerValue(workspace.Updated)
 
-	model.Name = types.StringValue(workspace.Name)
-	model.Handle = types.StringValue(workspace.Handle)
-	model.Description = types.StringValue(*workspace.Description)
+	tfModel.Name = types.StringValue(workspace.Name)
+	tfModel.Handle = types.StringValue(workspace.Handle)
+	tfModel.Description = types.StringValue(*workspace.Description)
 
 	return nil
 }
 
 // Create creates the resource and sets the initial Terraform state.
 func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var model WorkspaceResourceModel
+	var config WorkspaceResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.Workspaces(model.AccountID.ValueUUID())
+	client, err := r.client.Workspaces(config.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating workspace client",
@@ -154,9 +155,9 @@ func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	workspace, err := client.Create(ctx, api.WorkspaceCreate{
-		Name:        model.Name.ValueString(),
-		Handle:      model.Handle.ValueString(),
-		Description: model.Description.ValueStringPointer(),
+		Name:        config.Name.ValueString(),
+		Handle:      config.Handle.ValueString(),
+		Description: config.Description.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -167,12 +168,12 @@ func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkspaceToModel(ctx, workspace, &model)...)
+	resp.Diagnostics.Append(copyWorkspaceToModel(ctx, workspace, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -180,15 +181,15 @@ func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateReque
 
 // Read refreshes the Terraform state with the latest data.
 func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var model WorkspaceResourceModel
+	var state WorkspaceResourceModel
 
 	// Populate the model from state and emit diagnostics on error
-	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if model.ID.IsNull() && model.Handle.IsNull() {
+	if state.ID.IsNull() && state.Handle.IsNull() {
 		resp.Diagnostics.AddError(
 			"Both ID and Handle are unset",
 			"This is a bug in the Terraform provider. Please report it to the maintainers.",
@@ -197,7 +198,7 @@ func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	client, err := r.client.Workspaces(model.AccountID.ValueUUID())
+	client, err := r.client.Workspaces(state.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating workspace client",
@@ -208,9 +209,9 @@ func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 	// A workspace can be imported + read by either ID or Handle
 	// If both are set, we prefer the ID
 	var workspace *api.Workspace
-	if !model.ID.IsNull() {
+	if !state.ID.IsNull() {
 		var workspaceID uuid.UUID
-		workspaceID, err = uuid.Parse(model.ID.ValueString())
+		workspaceID, err = uuid.Parse(state.ID.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("id"),
@@ -222,14 +223,14 @@ func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		}
 
 		workspace, err = client.Get(ctx, workspaceID)
-	} else if !model.Handle.IsNull() {
+	} else if !state.Handle.IsNull() {
 		var workspaces []*api.Workspace
-		workspaces, err = client.List(ctx, []string{model.Handle.ValueString()})
+		workspaces, err = client.List(ctx, []string{state.Handle.ValueString()})
 
 		// The error from the API call should take precedence
 		// followed by this custom error if a specific workspace is not returned
 		if err == nil && len(workspaces) != 1 {
-			err = fmt.Errorf("a workspace with the handle=%s could not be found", model.Handle.ValueString())
+			err = fmt.Errorf("a workspace with the handle=%s could not be found", state.Handle.ValueString())
 		}
 
 		if len(workspaces) == 1 {
@@ -246,12 +247,12 @@ func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkspaceToModel(ctx, workspace, &model)...)
+	resp.Diagnostics.Append(copyWorkspaceToModel(ctx, workspace, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -259,14 +260,14 @@ func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *WorkspaceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var model WorkspaceResourceModel
+	var plan WorkspaceResourceModel
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.Workspaces(model.AccountID.ValueUUID())
+	client, err := r.client.Workspaces(plan.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating workspace client",
@@ -274,7 +275,7 @@ func (r *WorkspaceResource) Update(ctx context.Context, req resource.UpdateReque
 		)
 	}
 
-	workspaceID, err := uuid.Parse(model.ID.ValueString())
+	workspaceID, err := uuid.Parse(plan.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("id"),
@@ -286,9 +287,9 @@ func (r *WorkspaceResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	payload := api.WorkspaceUpdate{
-		Name:        model.Name.ValueStringPointer(),
-		Handle:      model.Handle.ValueStringPointer(),
-		Description: model.Description.ValueStringPointer(),
+		Name:        plan.Name.ValueStringPointer(),
+		Handle:      plan.Handle.ValueStringPointer(),
+		Description: plan.Description.ValueStringPointer(),
 	}
 	err = client.Update(ctx, workspaceID, payload)
 
@@ -311,12 +312,12 @@ func (r *WorkspaceResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkspaceToModel(ctx, workspace, &model)...)
+	resp.Diagnostics.Append(copyWorkspaceToModel(ctx, workspace, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -324,14 +325,14 @@ func (r *WorkspaceResource) Update(ctx context.Context, req resource.UpdateReque
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *WorkspaceResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var model WorkspaceResourceModel
+	var state WorkspaceResourceModel
 
-	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.Workspaces(model.AccountID.ValueUUID())
+	client, err := r.client.Workspaces(state.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating workspace client",
@@ -339,7 +340,7 @@ func (r *WorkspaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		)
 	}
 
-	workspaceID, err := uuid.Parse(model.ID.ValueString())
+	workspaceID, err := uuid.Parse(state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("id"),
@@ -360,7 +361,7 @@ func (r *WorkspaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -115,23 +115,24 @@ func (r *WorkspaceAccessResource) Schema(_ context.Context, _ resource.SchemaReq
 	}
 }
 
-// copyWorkspaceAccessToModel copies the API resource to the Terraform model.
-// Note that api.WorkspaceAccess represents a combined model for all accessor types,
-// meaning accessor-specific attributes like BotID and UserID will be conditionally nil
-// depending on the accessor type.
-func copyWorkspaceAccessToModel(access *api.WorkspaceAccess, model *WorkspaceAccessResourceModel) {
-	model.ID = types.StringValue(access.ID.String())
-	model.WorkspaceRoleID = customtypes.NewUUIDValue(access.WorkspaceRoleID)
-	model.WorkspaceID = customtypes.NewUUIDValue(access.WorkspaceID)
+// copyWorkspaceAccessToModel maps an API response to a model that is saved in Terraform state.
+// A model can be a Terraform Plan, State, or Config object.
+func copyWorkspaceAccessToModel(access *api.WorkspaceAccess, tfModel *WorkspaceAccessResourceModel) {
+	// NOTE: api.WorkspaceAccess represents a combined model for all accessor types,
+	// meaning accessor-specific attributes like BotID and UserID will be conditionally nil
+	// depending on the accessor type.
+	tfModel.ID = types.StringValue(access.ID.String())
+	tfModel.WorkspaceRoleID = customtypes.NewUUIDValue(access.WorkspaceRoleID)
+	tfModel.WorkspaceID = customtypes.NewUUIDValue(access.WorkspaceID)
 
 	if access.BotID != nil {
-		model.AccessorID = customtypes.NewUUIDValue(*access.BotID)
+		tfModel.AccessorID = customtypes.NewUUIDValue(*access.BotID)
 	}
 	if access.UserID != nil {
-		model.AccessorID = customtypes.NewUUIDValue(*access.UserID)
+		tfModel.AccessorID = customtypes.NewUUIDValue(*access.UserID)
 	}
 	if access.TeamID != nil {
-		model.AccessorID = customtypes.NewUUIDValue(*access.TeamID)
+		tfModel.AccessorID = customtypes.NewUUIDValue(*access.TeamID)
 	}
 }
 

--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -78,8 +78,6 @@ func (r *WorkspaceAccessResource) Schema(_ context.Context, _ resource.SchemaReq
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Workspace Access ID (UUID)",
-				// attributes which are not configurable + should not show updates from the existing state value
-				// should implement `UseStateForUnknown()`
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -136,33 +136,33 @@ func copyWorkspaceAccessToModel(access *api.WorkspaceAccess, tfModel *WorkspaceA
 
 // Create will create the Workspace Access resource through the API and insert it into the State.
 func (r *WorkspaceAccessResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var config WorkspaceAccessResourceModel
+	var plan WorkspaceAccessResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.WorkspaceAccess(config.AccountID.ValueUUID(), config.WorkspaceID.ValueUUID())
+	client, err := r.client.WorkspaceAccess(plan.AccountID.ValueUUID(), plan.WorkspaceID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Workspace Access", err))
 
 		return
 	}
 
-	accessorType := config.AccessorType.ValueString()
+	accessorType := plan.AccessorType.ValueString()
 
-	workspaceAccess, err := client.Upsert(ctx, accessorType, config.AccessorID.ValueUUID(), config.WorkspaceRoleID.ValueUUID())
+	workspaceAccess, err := client.Upsert(ctx, accessorType, plan.AccessorID.ValueUUID(), plan.WorkspaceRoleID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace Access", "create", err))
 
 		return
 	}
 
-	copyWorkspaceAccessToModel(workspaceAccess, &config)
+	copyWorkspaceAccessToModel(workspaceAccess, &plan)
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/workspace_role.go
+++ b/internal/provider/resources/workspace_role.go
@@ -162,21 +162,21 @@ func copyWorkspaceRoleToModel(_ context.Context, role *api.WorkspaceRole, tfMode
 }
 
 func (r *WorkspaceRoleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var config WorkspaceRoleResourceModel
+	var plan WorkspaceRoleResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	var scopes []string
-	resp.Diagnostics.Append(config.Scopes.ElementsAs(ctx, &scopes, false)...)
+	resp.Diagnostics.Append(plan.Scopes.ElementsAs(ctx, &scopes, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.WorkspaceRoles(config.AccountID.ValueUUID())
+	client, err := r.client.WorkspaceRoles(plan.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Workspace Role client",
@@ -187,10 +187,10 @@ func (r *WorkspaceRoleResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	role, err := client.Create(ctx, api.WorkspaceRoleUpsert{
-		Name:            config.Name.ValueString(),
-		Description:     config.Description.ValueString(),
+		Name:            plan.Name.ValueString(),
+		Description:     plan.Description.ValueString(),
 		Scopes:          scopes,
-		InheritedRoleID: config.InheritedRoleID.ValueUUIDPointer(),
+		InheritedRoleID: plan.InheritedRoleID.ValueUUIDPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -201,12 +201,12 @@ func (r *WorkspaceRoleResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkspaceRoleToModel(ctx, role, &config)...)
+	resp.Diagnostics.Append(copyWorkspaceRoleToModel(ctx, role, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/workspace_role.go
+++ b/internal/provider/resources/workspace_role.go
@@ -85,8 +85,6 @@ func (r *WorkspaceRoleResource) Schema(_ context.Context, _ resource.SchemaReque
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Workspace Role ID (UUID)",
-				// attributes which are not configurable + should not show updates from the existing state value
-				// should implement `UseStateForUnknown()`
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -95,6 +93,9 @@ func (r *WorkspaceRoleResource) Schema(_ context.Context, _ resource.SchemaReque
 				Computed:    true,
 				CustomType:  customtypes.TimestampType{},
 				Description: "Timestamp of when the resource was created (RFC3339)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resources/workspace_role.go
+++ b/internal/provider/resources/workspace_role.go
@@ -130,16 +130,17 @@ func (r *WorkspaceRoleResource) Schema(_ context.Context, _ resource.SchemaReque
 	}
 }
 
-// copyWorkspaceRoleToModel copies an api.WorkspaceRole to a WorkspaceRoleDataSourceModel.
-func copyWorkspaceRoleToModel(_ context.Context, role *api.WorkspaceRole, model *WorkspaceRoleResourceModel) diag.Diagnostics {
-	model.ID = types.StringValue(role.ID.String())
-	model.Created = customtypes.NewTimestampPointerValue(role.Created)
-	model.Updated = customtypes.NewTimestampPointerValue(role.Updated)
+// copyWorkspaceRoleToModel maps an API response to a model that is saved in Terraform state.
+// A model can be a Terraform Plan, State, or Config object.
+func copyWorkspaceRoleToModel(_ context.Context, role *api.WorkspaceRole, tfModel *WorkspaceRoleResourceModel) diag.Diagnostics {
+	tfModel.ID = types.StringValue(role.ID.String())
+	tfModel.Created = customtypes.NewTimestampPointerValue(role.Created)
+	tfModel.Updated = customtypes.NewTimestampPointerValue(role.Updated)
 
-	model.Name = types.StringValue(role.Name)
-	model.Description = types.StringPointerValue(role.Description)
-	model.AccountID = customtypes.NewUUIDPointerValue(role.AccountID)
-	model.InheritedRoleID = customtypes.NewUUIDPointerValue(role.InheritedRoleID)
+	tfModel.Name = types.StringValue(role.Name)
+	tfModel.Description = types.StringPointerValue(role.Description)
+	tfModel.AccountID = customtypes.NewUUIDPointerValue(role.AccountID)
+	tfModel.InheritedRoleID = customtypes.NewUUIDPointerValue(role.InheritedRoleID)
 
 	// NOTE: here, we'll omit updating the TF state with the scopes returned from the API
 	// as scopes in Prefect Cloud have a hierarchical structure. For example, setting `manage_blocks`
@@ -160,21 +161,21 @@ func copyWorkspaceRoleToModel(_ context.Context, role *api.WorkspaceRole, model 
 }
 
 func (r *WorkspaceRoleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var model WorkspaceRoleResourceModel
+	var config WorkspaceRoleResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	var scopes []string
-	resp.Diagnostics.Append(model.Scopes.ElementsAs(ctx, &scopes, false)...)
+	resp.Diagnostics.Append(config.Scopes.ElementsAs(ctx, &scopes, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.WorkspaceRoles(model.AccountID.ValueUUID())
+	client, err := r.client.WorkspaceRoles(config.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Workspace Role client",
@@ -185,10 +186,10 @@ func (r *WorkspaceRoleResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	role, err := client.Create(ctx, api.WorkspaceRoleUpsert{
-		Name:            model.Name.ValueString(),
-		Description:     model.Description.ValueString(),
+		Name:            config.Name.ValueString(),
+		Description:     config.Description.ValueString(),
 		Scopes:          scopes,
-		InheritedRoleID: model.InheritedRoleID.ValueUUIDPointer(),
+		InheritedRoleID: config.InheritedRoleID.ValueUUIDPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -199,12 +200,12 @@ func (r *WorkspaceRoleResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkspaceRoleToModel(ctx, role, &model)...)
+	resp.Diagnostics.Append(copyWorkspaceRoleToModel(ctx, role, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -212,15 +213,15 @@ func (r *WorkspaceRoleResource) Create(ctx context.Context, req resource.CreateR
 
 // Read refreshes the Terraform state with the latest data.
 func (r *WorkspaceRoleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var model WorkspaceRoleResourceModel
+	var state WorkspaceRoleResourceModel
 
 	// Populate the model from state and emit diagnostics on error
-	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.WorkspaceRoles(model.AccountID.ValueUUID())
+	client, err := r.client.WorkspaceRoles(state.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Workspace Role client",
@@ -230,7 +231,7 @@ func (r *WorkspaceRoleResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	roleID, err := uuid.Parse(model.ID.ValueString())
+	roleID, err := uuid.Parse(state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("id"),
@@ -249,12 +250,12 @@ func (r *WorkspaceRoleResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkspaceRoleToModel(ctx, role, &model)...)
+	resp.Diagnostics.Append(copyWorkspaceRoleToModel(ctx, role, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -262,14 +263,14 @@ func (r *WorkspaceRoleResource) Read(ctx context.Context, req resource.ReadReque
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *WorkspaceRoleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var model WorkspaceRoleResourceModel
+	var plan WorkspaceRoleResourceModel
 
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.WorkspaceRoles(model.AccountID.ValueUUID())
+	client, err := r.client.WorkspaceRoles(plan.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Workspace Role client",
@@ -280,12 +281,12 @@ func (r *WorkspaceRoleResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	var scopes []string
-	resp.Diagnostics.Append(model.Scopes.ElementsAs(ctx, &scopes, false)...)
+	resp.Diagnostics.Append(plan.Scopes.ElementsAs(ctx, &scopes, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	roleID, err := uuid.Parse(model.ID.ValueString())
+	roleID, err := uuid.Parse(plan.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("id"),
@@ -297,10 +298,10 @@ func (r *WorkspaceRoleResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	err = client.Update(ctx, roleID, api.WorkspaceRoleUpsert{
-		Name:            model.Name.ValueString(),
-		Description:     model.Description.ValueString(),
+		Name:            plan.Name.ValueString(),
+		Description:     plan.Description.ValueString(),
 		Scopes:          scopes,
-		InheritedRoleID: model.InheritedRoleID.ValueUUIDPointer(),
+		InheritedRoleID: plan.InheritedRoleID.ValueUUIDPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -321,12 +322,12 @@ func (r *WorkspaceRoleResource) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 
-	resp.Diagnostics.Append(copyWorkspaceRoleToModel(ctx, role, &model)...)
+	resp.Diagnostics.Append(copyWorkspaceRoleToModel(ctx, role, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -334,14 +335,14 @@ func (r *WorkspaceRoleResource) Update(ctx context.Context, req resource.UpdateR
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *WorkspaceRoleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var model WorkspaceRoleResourceModel
+	var state WorkspaceRoleResourceModel
 
-	resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	client, err := r.client.WorkspaceRoles(model.AccountID.ValueUUID())
+	client, err := r.client.WorkspaceRoles(state.AccountID.ValueUUID())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Workspace Role client",
@@ -351,7 +352,7 @@ func (r *WorkspaceRoleResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	roleID, err := uuid.Parse(model.ID.ValueString())
+	roleID, err := uuid.Parse(state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("id"),
@@ -372,7 +373,7 @@ func (r *WorkspaceRoleResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/195
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/200

high-level changes:
1. all `copy<Resource>ToModel()` helpers will use the `tfModel` variable name to disambiguate which model (plan, config, state) is being written to.  But still be clear about what it is
2. all resource model variables are renamed to be standardized, so that something like `req.State()` will be called `state`, `req.Plan()` will be a `plan`, and `req.Config()` will be a `config`
3. use a [UseStateForUnknown](https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#usestateforunknown) for `created` attributes, to reduce `(known after apply)` outputs for immutable attributes