### PR TITLE
Add Terraform logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.22.1
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.7.0
 )
 
@@ -46,7 +47,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/prefecthq/terraform-provider-prefect/internal/client"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
@@ -192,6 +193,13 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
+	ctx = tflog.SetField(ctx, "prefect_endpoint", endpoint)
+	ctx = tflog.SetField(ctx, "prefect_api_key", apiKey)
+	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "prefect_api_key")
+	ctx = tflog.SetField(ctx, "prefect_account_id", accountID)
+	ctx = tflog.SetField(ctx, "prefect_workspace_id", config.WorkspaceID.ValueString())
+	tflog.Debug(ctx, "Creating Prefect client")
+
 	prefectClient, err := client.New(
 		client.WithEndpoint(endpoint),
 		client.WithAPIKey(apiKey),
@@ -211,6 +219,8 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	// Pass client to DataSource and Resource type Configure methods
 	resp.DataSourceData = prefectClient
 	resp.ResourceData = prefectClient
+
+	tflog.Info(ctx, "Configured Prefect client", map[string]any{"success": true})
 }
 
 // DataSources defines the data sources implemented in the provider.


### PR DESCRIPTION
## Summary

Adds Terraform logging across the provider for debugging and informational purposes.

- [x] Implement logging in the top-level provider
- [ ] Implement logging in datasources
- [ ] Implement logging in resources

I'm keeping this PR focused on logging as that's more of an `enhancement`, and will do Diagnostics consistency separately as part of https://github.com/PrefectHQ/terraform-provider-prefect/issues/212 which will be `maintenance`. 

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/42

## Testing

With an example config:

```
terraform {
  required_providers {
    prefect = {
      source = "registry.terraform.io/prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint     = "http://localhost:4200/api"
  api_key      = "myapikey"
  account_id   = "11111111-2222-3333-4444-555555555555"
  workspace_id = "11111111-2222-3333-4444-555555555555"
}

resource "prefect_variable" "myvar" {
  name  = "myvar"
  value = "foobar"
}
```

```
$ TF_LOG_PROVIDER=INFO terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/mitch/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with
│ published releases.
╵
...

2024-06-13T14:53:07.574-0500 [INFO]  provider.terraform-provider-prefect: configuring server automatic mTLS: timestamp=2024-06-13T14:53:07.574-0500
2024-06-13T14:53:07.585-0500 [INFO]  provider.terraform-provider-prefect: Configured Prefect client: success=true tf_provider_addr=registry.terraform.io/prefecthq/prefect tf_req_id=1d9c4b96-5569-9fde-7190-4555f1a5ff33 @caller=/Users/mitch/code/github.com/prefecthq/terraform-provider-prefect/add-logging/internal/provider/provider.go:223 @module=prefect prefect_account_id=11111111-2222-3333-4444-555555555555 prefect_api_key="***" prefect_endpoint=http://localhost:4200/api prefect_workspace_id=11111111-2222-3333-4444-555555555555 tf_rpc=ConfigureProvider timestamp=2024-06-13T14:53:07.585-0500

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # prefect_variable.myvar will be created
  + resource "prefect_variable" "myvar" {
      + created = (known after apply)
      + id      = (known after apply)
      + name    = "myvar"
      + tags    = []
      + updated = (known after apply)
      + value   = "foobar"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

...
```

Note the log lines that mention configuration of the prefect client, and that the API key is masked.