### PR TITLE
fix(blocks): add slug name to error messaging for block type/schema fetch failure

### DIFF
--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -367,14 +367,14 @@ func (r *BlockResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	blockType, err := blockTypeClient.GetBySlug(ctx, plan.TypeSlug.ValueString())
 	if err != nil {
-		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Block Type", "get_by_slug", err))
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Block Type", "get_by_slug", fmt.Errorf("failed to get block type for slug=%s: %w", plan.TypeSlug.ValueString(), err)))
 
 		return
 	}
 
 	blockSchemas, err := blockSchemaClient.List(ctx, []uuid.UUID{blockType.ID})
 	if err != nil {
-		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Block Schema", "list", err))
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Block Schema", "list", fmt.Errorf("failed to list block schemas for block type=%s: %w", plan.TypeSlug.ValueString(), err)))
 
 		return
 	}


### PR DESCRIPTION
when an incorrect slug is provided, the error can be hard to track down.  to help, we'll print the slug itself in the error message

this is the current error message
```
Could not get_by_slug Block Type, unexpected error: All attempts fail:
#1: status code 404 Not Found, error={"detail":"Block type not found"}
```
