### PR TITLE
chore(blocks): fix doc example for GCP service account block

### DIFF
--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -64,8 +64,8 @@ resource "prefect_block" "gcp_credentials_key" {
 
   # prefect block type inspect gcp-credentials
   data = jsonencode({
-    "project" : "my-gcp-project",
-    "service_account_info" : base64decode(google_service_account_key.test_bot.private_key)
+    "project" = "my-gcp-project",
+    "service_account_info" = base64decode(google_service_account_key.test_bot.private_key)
   })
 }
 ```

--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -26,7 +26,7 @@ resource "prefect_block" "secret" {
   type_slug = "secret"
 
   data = jsonencode({
-    "value" : "bar"
+    "value" = "bar"
   })
 
   # set the workpace_id attribute on the provider OR the resource
@@ -64,8 +64,8 @@ resource "prefect_block" "gcp_credentials_key" {
 
   # prefect block type inspect gcp-credentials
   data = jsonencode({
-    "project" = "my-gcp-project",
-    "service_account_info" = base64decode(google_service_account_key.test_bot.private_key)
+    "project"              = "my-gcp-project",
+    "service_account_info" = jsondecode(base64decode(google_service_account_key.test_bot.private_key))
   })
 }
 ```

--- a/docs/resources/block_access.md
+++ b/docs/resources/block_access.md
@@ -29,7 +29,7 @@ resource "prefect_block" "my_secret" {
   name      = "my-secret"
   type_slug = "secret"
   data = jsonencode({
-    "value" : "foobar"
+    "value" = "foobar"
   })
   workspace_id = data.prefect_workspace.my_workspace.id
 }

--- a/examples/resources/prefect_block/resource.tf
+++ b/examples/resources/prefect_block/resource.tf
@@ -5,7 +5,7 @@ resource "prefect_block" "secret" {
   type_slug = "secret"
 
   data = jsonencode({
-    "value" : "bar"
+    "value" = "bar"
   })
 
   # set the workpace_id attribute on the provider OR the resource
@@ -43,7 +43,7 @@ resource "prefect_block" "gcp_credentials_key" {
 
   # prefect block type inspect gcp-credentials
   data = jsonencode({
-    "project" : "my-gcp-project",
-    "service_account_info" : base64decode(google_service_account_key.test_bot.private_key)
+    "project"              = "my-gcp-project",
+    "service_account_info" = jsondecode(base64decode(google_service_account_key.test_bot.private_key))
   })
 }

--- a/examples/resources/prefect_block_access/resource.tf
+++ b/examples/resources/prefect_block_access/resource.tf
@@ -8,7 +8,7 @@ resource "prefect_block" "my_secret" {
   name      = "my-secret"
   type_slug = "secret"
   data = jsonencode({
-    "value" : "foobar"
+    "value" = "foobar"
   })
   workspace_id = data.prefect_workspace.my_workspace.id
 }

--- a/internal/provider/datasources/block_test.go
+++ b/internal/provider/datasources/block_test.go
@@ -22,7 +22,7 @@ resource "prefect_block" "%s" {
   type_slug = "secret"
 
   data = jsonencode({
-    "someKey" : "someValue"
+    "someKey" = "someValue"
   })
 
   account_id = "%s"

--- a/internal/provider/resources/block_test.go
+++ b/internal/provider/resources/block_test.go
@@ -25,7 +25,7 @@ resource "prefect_block" "block" {
 	type_slug = "secret"
 	workspace_id = prefect_workspace.workspace.id
 	data = jsonencode({
-		"value": "%s"
+		"value" = "%s"
 	})
 	depends_on = [prefect_workspace.workspace]
 }


### PR DESCRIPTION
through testing, we found that you need to jsondecode() a gcp service account key before passing it into the block