### PR TITLE
fix(blocks): always replace Block data on update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ local.tfvars
 build/*
 
 .envrc
+
+dev/*

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,14 @@ help:
 	@echo ""
 	@echo "This project defines the following build targets:"
 	@echo ""
-	@echo "  build - compiles source code to build/"
-	@echo "  clean - removes built artifacts"
-	@echo "  lint - run static code analysis"
-	@echo "  test - run automated unit tests"
-	@echo "  testacc - run automated acceptance tests"
-	@echo "  docs - builds Terraform documentation"
+	@echo "  build      - compiles source code to build/"
+	@echo "  clean      - removes built artifacts"
+	@echo "  lint       - run static code analysis"
+	@echo "  test       - run automated unit tests"
+	@echo "  testacc    - run automated acceptance tests"
+	@echo "  docs       - builds Terraform documentation"
+	@echo "  dev-new    - creates a new dev testfile (args: resource=<resource> name=<name>)"
+	@echo "  dev-clean  - cleans up dev directory"
 .PHONY: help
 
 build: $(BINARY)
@@ -48,3 +50,11 @@ docs:
 	rm -rf ./docs/images
 	go generate ./...
 .PHONY: docs
+
+dev-new:
+	sh ./create-dev-testfile.sh $(resource) $(name)
+.PHONY: dev-new
+
+dev-clean:
+	rm -rf ./dev
+.PHONY: dev-clean

--- a/create-dev-testfile.sh
+++ b/create-dev-testfile.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eo pipefail
+
+main() {
+  resource=$1
+  name=$2
+
+  if [[ -z $resource ]]; then
+    echo "No resource provided. Pass one in through \`make dev-new resource=<resource>\`"
+    exit 1
+  fi
+
+  if [[ -z $name ]]; then
+    echo ""
+    echo "No resource name provided, using \`${resource}\` as name"
+    name=${resource}
+  fi
+
+  resource="prefect_${resource}"
+
+  dev_file_target="./dev/${name}"
+
+  mkdir -p $dev_file_target
+
+  cat <<EOF > $dev_file_target/${resource}.tf
+terraform {
+  required_providers {
+    prefect = {
+      source = "prefecthq/prefect"
+    }
+  }
+}
+
+provider "prefect" {}
+
+resource "${resource}" "${name}" {}
+EOF
+
+  echo ""
+  echo "run:"
+  echo "cd ${dev_file_target} && terraform plan"
+}
+
+main $@

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -114,8 +114,8 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				},
 			},
 			"data": schema.StringAttribute{
-				Required:    true,
-				Sensitive:   true,
+				Required: true,
+				// Sensitive:   true,
 				CustomType:  jsontypes.NormalizedType{},
 				Description: "The user-inputted Block payload, as a JSON string. The value's schema will depend on the selected `type` slug. Use `prefect block types inspect <slug>` to view the data schema for a given Block type.",
 			},
@@ -410,7 +410,7 @@ func (r *BlockResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	err = blockDocumentClient.Update(ctx, blockID, api.BlockDocumentUpdate{
 		BlockSchemaID:     latestBlockSchema.ID,
 		Data:              data,
-		MergeExistingData: true,
+		MergeExistingData: false,
 	})
 
 	if err != nil {

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -114,8 +114,8 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				},
 			},
 			"data": schema.StringAttribute{
-				Required: true,
-				// Sensitive:   true,
+				Required:    true,
+				Sensitive:   true,
 				CustomType:  jsontypes.NormalizedType{},
 				Description: "The user-inputted Block payload, as a JSON string. The value's schema will depend on the selected `type` slug. Use `prefect block types inspect <slug>` to view the data schema for a given Block type.",
 			},
@@ -408,8 +408,13 @@ func (r *BlockResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	err = blockDocumentClient.Update(ctx, blockID, api.BlockDocumentUpdate{
-		BlockSchemaID:     latestBlockSchema.ID,
-		Data:              data,
+		BlockSchemaID: latestBlockSchema.ID,
+		Data:          data,
+
+		// NOTE: setting this to `false` will replace the contents of `.data`
+		// We want to do this on Update() - if we don't, removing top-level keys
+		// will cause the API to ignore those removals, which causes a provider-level
+		// state conflict + failure.
 		MergeExistingData: false,
 	})
 


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/215

Also, I'm adding a questionably-useful `make dev-new` command, which creates a test file in a new gitignored directly, which scaffolds some of the commonly copy-pasta'ed TF configuration blocks.  

```sh
➜ make help
Usage: /Library/Developer/CommandLineTools/usr/bin/make [target]

This project defines the following build targets:
...
  dev-new    - creates a new dev testfile (args: resource=<resource> name=<name>)
  dev-clean  - cleans up dev directory
```

# Testing

```sh
docker-compose up -d
```

Before:

```hcl
terraform {
  required_providers {
    prefect = {
      source = "prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint = "http://localhost:4200"
}

resource "prefect_block" "json" {
  name = "json"
  type_slug = "json"
  data = jsonencode({
    "value" = "foo"
    "value2" = "bar"
  })
}
```

```sh
➜ terraform apply --auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/edwardpark/CODE/prefect/terraform-provider-prefect/build
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state
│ to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  + create

Terraform will perform the following actions:

  # prefect_block.json will be created
  + resource "prefect_block" "json" {
      + created   = (known after apply)
      + data      = (sensitive value)
      + id        = (known after apply)
      + name      = "json"
      + type_slug = "json"
      + updated   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
prefect_block.json: Creating...
prefect_block.json: Creation complete after 0s [id=75c59269-f1e5-46b5-aebb-3f089163283f]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

You should see the resource being created.  Now remove `value2` and apply again and see the error

```hcl
resource "prefect_block" "json" {
  name = "json"
  type_slug = "json"
  data = jsonencode({
    "value" = "foo"
  })
}
```

```sh
➜ terraform apply --auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/edwardpark/CODE/prefect/terraform-provider-prefect/build
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state
│ to become incompatible with published releases.
╵
prefect_block.json: Refreshing state... [id=75c59269-f1e5-46b5-aebb-3f089163283f]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # prefect_block.json will be updated in-place
  ~ resource "prefect_block" "json" {
      ~ data      = (sensitive value)
        id        = "75c59269-f1e5-46b5-aebb-3f089163283f"
        name      = "json"
      ~ updated   = "2024-06-14T19:31:09Z" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
prefect_block.json: Modifying... [id=75c59269-f1e5-46b5-aebb-3f089163283f]
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to prefect_block.json, provider "provider[\"registry.terraform.io/prefecthq/prefect\"]"
│ produced an unexpected new value: .data: inconsistent values for sensitive attribute.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

After (same steps):

```sh
➜ terraform apply --auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/edwardpark/CODE/prefect/terraform-provider-prefect/build
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state
│ to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  + create

Terraform will perform the following actions:

  # prefect_block.json will be created
  + resource "prefect_block" "json" {
      + created   = (known after apply)
      + data      = (sensitive value)
      + id        = (known after apply)
      + name      = "json"
      + type_slug = "json"
      + updated   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
prefect_block.json: Creating...
prefect_block.json: Creation complete after 0s [id=8cb569cf-a8c3-4bbd-ba47-d419e045f79c]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Remove the `value2` key
```sh
➜ terraform apply --auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/edwardpark/CODE/prefect/terraform-provider-prefect/build
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state
│ to become incompatible with published releases.
╵
prefect_block.json: Refreshing state... [id=8cb569cf-a8c3-4bbd-ba47-d419e045f79c]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # prefect_block.json will be updated in-place
  ~ resource "prefect_block" "json" {
      ~ data      = (sensitive value)
        id        = "8cb569cf-a8c3-4bbd-ba47-d419e045f79c"
        name      = "json"
      ~ updated   = "2024-06-14T19:32:23Z" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
prefect_block.json: Modifying... [id=8cb569cf-a8c3-4bbd-ba47-d419e045f79c]
prefect_block.json: Modifications complete after 1s [id=8cb569cf-a8c3-4bbd-ba47-d419e045f79c]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```