### PR TITLE
chore: ordering of release notes blocks

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,18 +8,18 @@ changelog:
     - title: Breaking Changes
       labels:
         - breaking
-    - title: Dependency Updates
-      labels:
-        - dependencies
-    - title: Documentation
-      labels:
-        - docs
     - title: Exciting New Features 🎉
       labels:
         - enhancement
     - title: Fixes
       labels:
         - bugfix
+    - title: Dependency Updates
+      labels:
+        - dependencies
+    - title: Documentation
+      labels:
+        - docs
     - title: And more...
       labels:
         - "*"


### PR DESCRIPTION
shuffles the ordering of the release notes sections so that new features are up at the top, and `docs` issues are lower down