### PR TITLE
feat(accounts): support configuration under "settings"

### DIFF
--- a/docs/data-sources/account.md
+++ b/docs/data-sources/account.md
@@ -32,10 +32,10 @@ data "prefect_account" "my_organization" {}
 ### Optional
 
 - `id` (String) Account ID (UUID)
+- `settings` (Attributes) Group of settings related to accounts (see [below for nested schema](#nestedatt--settings))
 
 ### Read-Only
 
-- `allow_public_workspaces` (Boolean) Whether or not this account allows public workspaces
 - `billing_email` (String) Billing email to apply to the account's Stripe customer
 - `created` (String) Timestamp of when the resource was created (RFC3339)
 - `handle` (String) Unique handle of the account
@@ -43,3 +43,12 @@ data "prefect_account" "my_organization" {}
 - `location` (String) An optional physical location for the account, e.g. Washington, D.C.
 - `name` (String) Name of the account
 - `updated` (String) Timestamp of when the resource was updated (RFC3339)
+
+<a id="nestedatt--settings"></a>
+### Nested Schema for `settings`
+
+Optional:
+
+- `ai_log_summaries` (Boolean) Whether to use AI to generate log summaries.
+- `allow_public_workspaces` (Boolean) Whether or not this account allows public workspaces
+- `managed_execution` (Boolean) Whether to enable the use of managed work pools

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -17,10 +17,14 @@ Note that this resource can only be imported, as account creation is not current
 
 ```terraform
 resource "prefect_account" "example" {
-  name                    = "My Imported Account"
-  description             = "A cool account"
-  billing_email           = "marvin@prefect.io"
-  allow_public_workspaces = true
+  name          = "My Imported Account"
+  description   = "A cool account"
+  billing_email = "marvin@prefect.io"
+  settings = {
+    allow_public_workspaces = true
+    ai_log_summaries        = false
+    managed_execution       = false
+  }
 }
 ```
 
@@ -34,16 +38,25 @@ resource "prefect_account" "example" {
 
 ### Optional
 
-- `allow_public_workspaces` (Boolean) Whether or not this account allows public workspaces
 - `billing_email` (String) Billing email to apply to the account's Stripe customer
 - `link` (String) An optional for an external url associated with the account, e.g. https://prefect.io/
 - `location` (String) An optional physical location for the account, e.g. Washington, D.C.
+- `settings` (Attributes) Group of settings related to accounts (see [below for nested schema](#nestedatt--settings))
 
 ### Read-Only
 
 - `created` (String) Timestamp of when the resource was created (RFC3339)
 - `id` (String) Account ID (UUID)
 - `updated` (String) Timestamp of when the resource was updated (RFC3339)
+
+<a id="nestedatt--settings"></a>
+### Nested Schema for `settings`
+
+Optional:
+
+- `ai_log_summaries` (Boolean) Whether to use AI to generate log summaries.
+- `allow_public_workspaces` (Boolean) Whether or not this account allows public workspaces
+- `managed_execution` (Boolean) Whether to enable the use of managed work pools
 
 ## Import
 

--- a/examples/resources/prefect_account/resource.tf
+++ b/examples/resources/prefect_account/resource.tf
@@ -1,6 +1,10 @@
 resource "prefect_account" "example" {
-  name                    = "My Imported Account"
-  description             = "A cool account"
-  billing_email           = "marvin@prefect.io"
-  allow_public_workspaces = true
+  name          = "My Imported Account"
+  description   = "A cool account"
+  billing_email = "marvin@prefect.io"
+  settings = {
+    allow_public_workspaces = true
+    ai_log_summaries        = false
+    managed_execution       = false
+  }
 }

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -8,30 +8,31 @@ import (
 type AccountsClient interface {
 	Get(ctx context.Context) (*AccountResponse, error)
 	Update(ctx context.Context, data AccountUpdate) error
+	UpdateSettings(ctx context.Context, data AccountSettingsUpdate) error
 	Delete(ctx context.Context) error
 }
 
 // Settings is a representation of an account's settings.
 type Settings struct {
-	AllowPublicWorkspaces *bool `json:"allow_public_workspaces"`
-	AILogSummaries        *bool `json:"ai_log_summaries"`
-	ManagedExecution      *bool `json:"managed_execution"`
+	AllowPublicWorkspaces bool `json:"allow_public_workspaces"`
+	AILogSummaries        bool `json:"ai_log_summaries"`
+	ManagedExecution      bool `json:"managed_execution"`
 }
 
 // Account is a representation of an account.
 type Account struct {
 	BaseModel
-	Name                  string    `json:"name"`
-	Handle                string    `json:"handle"`
-	Location              *string   `json:"location"`
-	Link                  *string   `json:"link"`
-	ImageLocation         *string   `json:"image_location"`
-	StripeCustomerID      *string   `json:"stripe_customer_id"`
-	WorkOSDirectoryIDs    []string  `json:"workos_directory_ids"`
-	WorkOSOrganizationID  *string   `json:"workos_organization_id"`
-	WorkOSConnectionIDs   []string  `json:"workos_connection_ids"`
-	AuthExpirationSeconds *int64    `json:"auth_expiration_seconds"`
-	Settings              *Settings `json:"settings"`
+	Name                  string   `json:"name"`
+	Handle                string   `json:"handle"`
+	Location              *string  `json:"location"`
+	Link                  *string  `json:"link"`
+	ImageLocation         *string  `json:"image_location"`
+	StripeCustomerID      *string  `json:"stripe_customer_id"`
+	WorkOSDirectoryIDs    []string `json:"workos_directory_ids"`
+	WorkOSOrganizationID  *string  `json:"workos_organization_id"`
+	WorkOSConnectionIDs   []string `json:"workos_connection_ids"`
+	AuthExpirationSeconds *int64   `json:"auth_expiration_seconds"`
+	Settings              Settings `json:"settings"`
 }
 
 // AccountResponse is the data about an account returned by the Accounts API.
@@ -50,11 +51,15 @@ type AccountResponse struct {
 
 // AccountUpdate is the data sent when updating an account.
 type AccountUpdate struct {
-	Name                  *string   `json:"name"`
-	Handle                *string   `json:"handle"`
-	Location              *string   `json:"location"`
-	Link                  *string   `json:"link"`
-	AuthExpirationSeconds *int64    `json:"auth_expiration_seconds"`
-	BillingEmail          *string   `json:"billing_email"`
-	Settings              *Settings `json:"settings"`
+	Name                  *string `json:"name"`
+	Handle                *string `json:"handle"`
+	Location              *string `json:"location"`
+	Link                  *string `json:"link"`
+	AuthExpirationSeconds *int64  `json:"auth_expiration_seconds"`
+	BillingEmail          *string `json:"billing_email"`
+}
+
+// AccountSettingsUpdate is the data sent when updating an account's settings.
+type AccountSettingsUpdate struct {
+	Settings `json:"settings"`
 }

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -11,20 +11,27 @@ type AccountsClient interface {
 	Delete(ctx context.Context) error
 }
 
+// Settings is a representation of an account's settings.
+type Settings struct {
+	AllowPublicWorkspaces *bool `json:"allow_public_workspaces"`
+	AILogSummaries        *bool `json:"ai_log_summaries"`
+	ManagedExecution      *bool `json:"managed_execution"`
+}
+
 // Account is a representation of an account.
 type Account struct {
 	BaseModel
-	Name                  string   `json:"name"`
-	Handle                string   `json:"handle"`
-	Location              *string  `json:"location"`
-	Link                  *string  `json:"link"`
-	ImageLocation         *string  `json:"image_location"`
-	StripeCustomerID      *string  `json:"stripe_customer_id"`
-	WorkOSDirectoryIDs    []string `json:"workos_directory_ids"`
-	WorkOSOrganizationID  *string  `json:"workos_organization_id"`
-	WorkOSConnectionIDs   []string `json:"workos_connection_ids"`
-	AuthExpirationSeconds *int64   `json:"auth_expiration_seconds"`
-	AllowPublicWorkspaces *bool    `json:"allow_public_workspaces"`
+	Name                  string    `json:"name"`
+	Handle                string    `json:"handle"`
+	Location              *string   `json:"location"`
+	Link                  *string   `json:"link"`
+	ImageLocation         *string   `json:"image_location"`
+	StripeCustomerID      *string   `json:"stripe_customer_id"`
+	WorkOSDirectoryIDs    []string  `json:"workos_directory_ids"`
+	WorkOSOrganizationID  *string   `json:"workos_organization_id"`
+	WorkOSConnectionIDs   []string  `json:"workos_connection_ids"`
+	AuthExpirationSeconds *int64    `json:"auth_expiration_seconds"`
+	Settings              *Settings `json:"settings"`
 }
 
 // AccountResponse is the data about an account returned by the Accounts API.
@@ -43,11 +50,11 @@ type AccountResponse struct {
 
 // AccountUpdate is the data sent when updating an account.
 type AccountUpdate struct {
-	Name                  *string `json:"name"`
-	Handle                *string `json:"handle"`
-	Location              *string `json:"location"`
-	Link                  *string `json:"link"`
-	AuthExpirationSeconds *int64  `json:"auth_expiration_seconds"`
-	AllowPublicWorkspaces *bool   `json:"allow_public_workspaces"`
-	BillingEmail          *string `json:"billing_email"`
+	Name                  *string   `json:"name"`
+	Handle                *string   `json:"handle"`
+	Location              *string   `json:"location"`
+	Link                  *string   `json:"link"`
+	AuthExpirationSeconds *int64    `json:"auth_expiration_seconds"`
+	BillingEmail          *string   `json:"billing_email"`
+	Settings              *Settings `json:"settings"`
 }

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -12,8 +12,8 @@ type AccountsClient interface {
 	Delete(ctx context.Context) error
 }
 
-// Settings is a representation of an account's settings.
-type Settings struct {
+// AccountSettings is a representation of an account's settings.
+type AccountSettings struct {
 	AllowPublicWorkspaces bool `json:"allow_public_workspaces"`
 	AILogSummaries        bool `json:"ai_log_summaries"`
 	ManagedExecution      bool `json:"managed_execution"`
@@ -22,17 +22,17 @@ type Settings struct {
 // Account is a representation of an account.
 type Account struct {
 	BaseModel
-	Name                  string   `json:"name"`
-	Handle                string   `json:"handle"`
-	Location              *string  `json:"location"`
-	Link                  *string  `json:"link"`
-	ImageLocation         *string  `json:"image_location"`
-	StripeCustomerID      *string  `json:"stripe_customer_id"`
-	WorkOSDirectoryIDs    []string `json:"workos_directory_ids"`
-	WorkOSOrganizationID  *string  `json:"workos_organization_id"`
-	WorkOSConnectionIDs   []string `json:"workos_connection_ids"`
-	AuthExpirationSeconds *int64   `json:"auth_expiration_seconds"`
-	Settings              Settings `json:"settings"`
+	Name                  string          `json:"name"`
+	Handle                string          `json:"handle"`
+	Location              *string         `json:"location"`
+	Link                  *string         `json:"link"`
+	ImageLocation         *string         `json:"image_location"`
+	StripeCustomerID      *string         `json:"stripe_customer_id"`
+	WorkOSDirectoryIDs    []string        `json:"workos_directory_ids"`
+	WorkOSOrganizationID  *string         `json:"workos_organization_id"`
+	WorkOSConnectionIDs   []string        `json:"workos_connection_ids"`
+	AuthExpirationSeconds *int64          `json:"auth_expiration_seconds"`
+	Settings              AccountSettings `json:"settings"`
 }
 
 // AccountResponse is the data about an account returned by the Accounts API.
@@ -61,5 +61,5 @@ type AccountUpdate struct {
 
 // AccountSettingsUpdate is the data sent when updating an account's settings.
 type AccountSettingsUpdate struct {
-	Settings `json:"settings"`
+	AccountSettings `json:"settings"`
 }

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -98,6 +98,36 @@ func (c *AccountsClient) Update(ctx context.Context, data api.AccountUpdate) err
 	return nil
 }
 
+// UpdateSettings modifies an existing account's settings by ID.
+func (c *AccountsClient) UpdateSettings(ctx context.Context, data api.AccountSettingsUpdate) error {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(&data.Settings); err != nil {
+		return fmt.Errorf("failed to encode data: %w", err)
+	}
+
+	url := c.routePrefix + "settings"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, &buf)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	setDefaultHeaders(req, c.apiKey)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("http error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		errorBody, _ := io.ReadAll(resp.Body)
+
+		return fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)
+	}
+
+	return nil
+}
+
 // Delete removes an account by ID.
 func (c *AccountsClient) Delete(ctx context.Context) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.routePrefix, http.NoBody)

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -101,7 +101,7 @@ func (c *AccountsClient) Update(ctx context.Context, data api.AccountUpdate) err
 // UpdateSettings modifies an existing account's settings by ID.
 func (c *AccountsClient) UpdateSettings(ctx context.Context, data api.AccountSettingsUpdate) error {
 	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(&data.Settings); err != nil {
+	if err := json.NewEncoder(&buf).Encode(&data.AccountSettings); err != nil {
 		return fmt.Errorf("failed to encode data: %w", err)
 	}
 

--- a/internal/provider/datasources/account.go
+++ b/internal/provider/datasources/account.go
@@ -110,14 +110,17 @@ Use this data source to obtain account-level attributes
 					"allow_public_workspaces": schema.BoolAttribute{
 						Description: "Whether or not this account allows public workspaces",
 						Optional:    true,
+						Computed:    true,
 					},
 					"ai_log_summaries": schema.BoolAttribute{
 						Description: "Whether to use AI to generate log summaries.",
 						Optional:    true,
+						Computed:    true,
 					},
 					"managed_execution": schema.BoolAttribute{
 						Description: "Whether to enable the use of managed work pools",
 						Optional:    true,
+						Computed:    true,
 					},
 				},
 			},
@@ -168,9 +171,9 @@ func (d *AccountDataSource) Read(ctx context.Context, req datasource.ReadRequest
 			"managed_execution":       types.BoolType,
 		},
 		map[string]attr.Value{
-			"allow_public_workspaces": types.BoolValue(*account.Settings.AllowPublicWorkspaces),
-			"ai_log_summaries":        types.BoolValue(*account.Settings.AILogSummaries),
-			"managed_execution":       types.BoolValue(*account.Settings.ManagedExecution),
+			"allow_public_workspaces": types.BoolValue(account.Settings.AllowPublicWorkspaces),
+			"ai_log_summaries":        types.BoolValue(account.Settings.AILogSummaries),
+			"managed_execution":       types.BoolValue(account.Settings.ManagedExecution),
 		},
 	)
 	resp.Diagnostics.Append(diag...)

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -274,7 +274,7 @@ func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest
 	// If settings have changed, we need to create a separate request to update them.
 	if !plan.Settings.Equal(state.Settings) {
 		err = client.UpdateSettings(ctx, api.AccountSettingsUpdate{
-			Settings: newSettingsFromObject(plan.Settings),
+			AccountSettings: newAccountSettingsFromObject(plan.Settings),
 		})
 		if err != nil {
 			resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Account settings", "update", err))
@@ -340,10 +340,10 @@ func (r *AccountResource) ImportState(ctx context.Context, req resource.ImportSt
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func newSettingsFromObject(settings basetypes.ObjectValue) api.Settings {
+func newAccountSettingsFromObject(settings basetypes.ObjectValue) api.AccountSettings {
 	attrs := settings.Attributes()
 
-	return api.Settings{
+	return api.AccountSettings{
 		AllowPublicWorkspaces: valToBool(attrs["allow_public_workspaces"]),
 		AILogSummaries:        valToBool(attrs["ai_log_summaries"]),
 		ManagedExecution:      valToBool(attrs["managed_execution"]),

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -126,23 +125,21 @@ func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"settings": schema.SingleNestedAttribute{
 				Description: "Group of settings related to accounts",
 				Optional:    true,
+				Computed:    true,
 				Attributes: map[string]schema.Attribute{
 					"allow_public_workspaces": schema.BoolAttribute{
 						Description: "Whether or not this account allows public workspaces",
 						Optional:    true,
-						Default:     booldefault.StaticBool(false),
 						Computed:    true,
 					},
 					"ai_log_summaries": schema.BoolAttribute{
 						Description: "Whether to use AI to generate log summaries.",
 						Optional:    true,
-						Default:     booldefault.StaticBool(true),
 						Computed:    true,
 					},
 					"managed_execution": schema.BoolAttribute{
 						Description: "Whether to enable the use of managed work pools",
 						Optional:    true,
-						Default:     booldefault.StaticBool(true),
 						Computed:    true,
 					},
 				},


### PR DESCRIPTION
## Summary

The [Account API](https://app.prefect.cloud/api/docs#tag/Accounts/operation/update_account_api_accounts__account_id__patch) now has a `settings` block for a few configuration fields. This PR adds support for that new set of fields.

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/227

## References

- https://github.com/PrefectHQ/nebula/pull/5454
- [API docs: update account settings](https://app.prefect.cloud/api/docs#tag/Accounts/operation/update_account_settings_api_accounts__account_id__settings_patch)
- [Terraform provider docs: single nested attributes](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/attributes/single-nested)

## Testing

I tested in staging with a personal account:

```terraform
terraform {
  required_providers {
    prefect = {
      source = "registry.terraform.io/prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint     = "https://api.stg.prefect.dev"
  account_id   = "<my account ID>"
  workspace_id = "<my workspace ID>"
  api_key      = "<my API key>"
}

resource "prefect_account" "mitchell-nielsen-testing" {
  name          = "Mitchell Nielsen Testing"
  handle        = "mitchell-nielsen-testing"
  billing_email = "mitchell+testing@prefect.io"

  settings = {
    allow_public_workspaces = true
    ai_log_summaries        = true
    managed_execution       = true
  }
}
```

Before continuing, you'll have to import the account:

```
tf import prefect_account.<account name> <account ID>
```

Once it's imported, adjust each of the `settings` and confirm that they are updated in Prefect:

- AI log summaries and managed execution are in account settings: https://app.stg.prefect.dev/organization/<account ID>/settings
- I'm not really sure where "allow public workspaces" appears in the UI, but the API doesn't complain 😄 

```
$ tf apply -auto-approve

Terraform will perform the following actions:

  # prefect_account.<account ID> will be updated in-place
  ~ resource "prefect_account" "<account ID>" {
        id            = "<account ID>"
        name          = "<account name>"
      ~ settings      = {
          ~ managed_execution       = false -> true
            # (2 unchanged attributes hidden)
        }
      ~ updated       = "2024-07-10T23:56:21Z" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
prefect_account.<account name>: Modifying... [id=<account ID>]
prefect_account.<account name>: Modifications complete after 1s [id=<account ID>]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.