### PR TITLE
feat(service_accounts): support old key expiration

### DIFF
--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -50,6 +50,7 @@ resource "prefect_service_account" "example" {
 - `account_id` (String) Account ID (UUID), defaults to the account set in the provider
 - `account_role_name` (String) Account Role name of the service account
 - `api_key_expiration` (String) Timestamp of the API Key expiration (RFC3339). If left as null, the API Key will not expire. Modify this attribute to force a key rotation.
+- `old_key_expires_in_seconds` (Number) Provide this field to set an expiration for the currently active api key. If not provided or provided Null, the current key will be deleted. If provided, it cannot be more than 48 hours (172800 seconds) in the future.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.10.0
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0
-	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/hashicorp/terraform-plugin-framework v1.10.0 h1:xXhICE2Fns1RYZxEQebwk
 github.com/hashicorp/terraform-plugin-framework v1.10.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
 github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0 h1:b8vZYB/SkXJT4YPbT3trzE6oJ7dPyMy68+9dEDKsJjE=
 github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0/go.mod h1:tP9BC3icoXBz72evMS5UTFvi98CiKhPdXF6yLs1wS8A=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
+github.com/hashicorp/terraform-plugin-framework-validators v0.13.0 h1:bxZfGo9DIUoLLtHMElsu+zwqI4IsMZQBRRy4iLzZJ8E=
+github.com/hashicorp/terraform-plugin-framework-validators v0.13.0/go.mod h1:wGeI02gEhj9nPANU62F2jCaHjXulejm/X+af4PdZaNo=
 github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=
 github.com/hashicorp/terraform-plugin-go v0.23.0/go.mod h1:1E3Cr9h2vMlahWMbsSEcNrOCxovCZhOOIXjFHbjc/lQ=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/api/service_accounts.go
+++ b/internal/api/service_accounts.go
@@ -30,7 +30,8 @@ type ServiceAccountUpdateRequest struct {
 }
 
 type ServiceAccountRotateKeyRequest struct {
-	APIKeyExpiration *time.Time `json:"api_key_expiration"`
+	APIKeyExpiration       *time.Time `json:"api_key_expiration"`
+	OldKeyExpiresInSeconds int32      `json:"old_key_expires_in_seconds"`
 }
 
 // ServiceAccountFilter defines the search filter payload

--- a/internal/provider/resources/service_account_test.go
+++ b/internal/provider/resources/service_account_test.go
@@ -136,14 +136,14 @@ func TestAccResource_service_account(t *testing.T) {
 				ResourceName:                         botResourceName,
 				ImportStateVerify:                    true,
 				ImportStateVerifyIdentifierAttribute: "name",
-				ImportStateVerifyIgnore:              []string{"api_key"},
+				ImportStateVerifyIgnore:              []string{"api_key", "old_key_expires_in_seconds"},
 			},
 			// Import State checks - import by ID (default)
 			{
 				ImportState:             true,
 				ResourceName:            botResourceName,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"api_key"},
+				ImportStateVerifyIgnore: []string{"api_key", "old_key_expires_in_seconds"},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Supports setting the old key expiration seconds for service accounts.

API docs:
https://app.prefect.cloud/api/docs#tag/Bots/operation/rotate_api_key_api_accounts__account_id__bots__id__rotate_api_key_post

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/233

## Notes

- This may be difficult to test, since the API doesn't return any fields related to the old key expiration specifically. It just returns the newly-rotated key.

## Testing

```terraform
terraform {
  required_providers {
    prefect = {
      source = "registry.terraform.io/prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint = "https://api.stg.prefect.dev"
  account_id   = "myacocuntid"
  workspace_id = "myworkspaceid"

  api_key = "myapikey"
}

provider "time" {}
resource "time_rotating" "one_minute" {
  rotation_minutes = 1
}
resource "time_rotating" "two_minutes" {
  rotation_minutes = 2
}
```

For the first test, just create a new Service Account and set the expiration:

```terraform
resource "prefect_service_account" "mitch" {
  name                       = "mitch"
  api_key_expiration         = time_rotating.one_minute.rotation_rfc3339
}
```

Next, rotate the API token by setting a _new_ expiration (this is required to trigger a key rotation). Also, set the number of seconds for the old key to expire in (this is what this PR adds).

```terraform
resource "prefect_service_account" "mitch" {
  name                       = "mitch"
  api_key_expiration         = time_rotating.two_minutes.rotation_rfc3339
  old_key_expires_in_seconds = 90
}
```

In the UI, you'll now see that:
- There is a new active token
- The previous token is now listed under `Rotating API keys` and is set to expire at `time you applied the change` + `number of seconds you specified`

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/b7fe5448-6a3f-4137-91e3-4a13a63031f4">

I was also able to import an existing object:

```
$ tf import prefect_service_account.mitch name/mitch
prefect_service_account.mitch: Importing from ID "name/mitch"...
prefect_service_account.mitch: Import prepared!
  Prepared prefect_service_account for import
prefect_service_account.mitch: Refreshing state...

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

... and destroy one:

```
prefect_service_account.mitch: Refreshing state... [id=13b18d19-c6b9-42ef-b88b-7aa63abd34a6]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  # prefect_service_account.mitch will be destroyed
  - resource "prefect_service_account" "mitch" {
      - account_id                 = "9a67b081-4f14-4035-b000-1f715f46231b" -> null
      - account_role_name          = "Member" -> null
      - actor_id                   = "959f061e-0038-4737-9828-d229080f9c1d" -> null
      - api_key                    = (sensitive value) -> null
      - api_key_created            = "2024-07-17T17:08:47Z" -> null
      - api_key_expiration         = "2024-07-17T17:10:30Z" -> null
      - api_key_id                 = "1fdc14d0-577e-407a-8310-3bedf062b788" -> null
      - api_key_name               = "mitch_ae4cdcfb3a054de3b02ec134322fcadb" -> null
      - created                    = "2024-07-17T16:57:55Z" -> null
      - id                         = "13b18d19-c6b9-42ef-b88b-7aa63abd34a6" -> null
      - name                       = "mitch" -> null
      - old_key_expires_in_seconds = 181 -> null
      - updated                    = "2024-07-17T17:08:47Z" -> null
    }

  # time_rotating.two_minutes will be destroyed
  - resource "time_rotating" "two_minutes" {
      - day              = 17 -> null
      - hour             = 17 -> null
      - id               = "2024-07-17T17:08:30Z" -> null
      - minute           = 10 -> null
      - month            = 7 -> null
      - rfc3339          = "2024-07-17T17:08:30Z" -> null
      - rotation_minutes = 2 -> null
      - rotation_rfc3339 = "2024-07-17T17:10:30Z" -> null
      - second           = 30 -> null
      - unix             = 1721236230 -> null
      - year             = 2024 -> null
    }

Plan: 0 to add, 0 to change, 2 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

prefect_service_account.mitch: Destroying... [id=13b18d19-c6b9-42ef-b88b-7aa63abd34a6]
prefect_service_account.mitch: Destruction complete after 0s
time_rotating.two_minutes: Destroying... [id=2024-07-17T17:08:30Z]
time_rotating.two_minutes: Destruction complete after 0s
```