### PR TITLE
Retry Workspace creation to mitigate 503s

### DIFF
--- a/internal/client/workspaces.go
+++ b/internal/client/workspaces.go
@@ -57,7 +57,12 @@ func (c *WorkspacesClient) Create(ctx context.Context, data api.WorkspaceCreate)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusCreated {
+	// Create is considered successful if the response is either:
+	// 1. StatusCreated (201) - meaning it was created
+	// 2. StatusConflict (409) - meaning it already exists.
+	//   This is relevant in cases where the Create method is retried.
+	// If the error is not one of these, then Create is considered unsuccessful.
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusConflict {
 		errorBody, _ := io.ReadAll(resp.Body)
 
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)

--- a/internal/client/workspaces.go
+++ b/internal/client/workspaces.go
@@ -57,12 +57,7 @@ func (c *WorkspacesClient) Create(ctx context.Context, data api.WorkspaceCreate)
 	}
 	defer resp.Body.Close()
 
-	// Create is considered successful if the response is either:
-	// 1. StatusCreated (201) - meaning it was created
-	// 2. StatusConflict (409) - meaning it already exists.
-	//   This is relevant in cases where the Create method is retried.
-	// If the error is not one of these, then Create is considered unsuccessful.
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusConflict {
+	if resp.StatusCode != http.StatusCreated {
 		errorBody, _ := io.ReadAll(resp.Body)
 
 		return nil, fmt.Errorf("status code %s, error=%s", resp.Status, errorBody)

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -158,8 +158,7 @@ func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateReque
 
 	// In certain scenarios, such as in tests when multiple Workspaces are created at the same time
 	// for test isolation, Prefect will return a "503 Service Unavailable" error.
-	// To mitigate this, we will retry the Workspace creation. The Create method will stop retrying
-	// if either the Workspace was created or if the Workspace already exists.
+	// To mitigate this, we will retry the Workspace creation.
 	// See https://github.com/PrefectHQ/terraform-provider-prefect/issues/241 for more information.
 	workspace, err := retry.DoWithData(
 		func() (*api.Workspace, error) {

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -17,6 +18,7 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
+	"github.com/prefecthq/terraform-provider-prefect/internal/utils"
 )
 
 var (
@@ -154,11 +156,25 @@ func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	workspace, err := client.Create(ctx, api.WorkspaceCreate{
-		Name:        plan.Name.ValueString(),
-		Handle:      plan.Handle.ValueString(),
-		Description: plan.Description.ValueStringPointer(),
-	})
+	// In certain scenarios, such as in tests when multiple Workspaces are created at the same time
+	// for test isolation, Prefect will return a "503 Service Unavailable" error.
+	// To mitigate this, we will retry the Workspace creation. The Create method will be considered
+	// successful if either the Workspace was created or if the Workspace already exists.
+	// See https://github.com/PrefectHQ/terraform-provider-prefect/issues/241 for more information.
+	workspace, err := retry.DoWithData(
+		func() (*api.Workspace, error) {
+			return client.Create(
+				ctx,
+				api.WorkspaceCreate{
+					Name:        plan.Name.ValueString(),
+					Handle:      plan.Handle.ValueString(),
+					Description: plan.Description.ValueStringPointer(),
+				},
+			)
+		},
+		utils.DefaultRetryOptions...,
+	)
+
 	if err != nil {
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace", "create", err))
 

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -158,8 +158,8 @@ func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateReque
 
 	// In certain scenarios, such as in tests when multiple Workspaces are created at the same time
 	// for test isolation, Prefect will return a "503 Service Unavailable" error.
-	// To mitigate this, we will retry the Workspace creation. The Create method will be considered
-	// successful if either the Workspace was created or if the Workspace already exists.
+	// To mitigate this, we will retry the Workspace creation. The Create method will stop retrying
+	// if either the Workspace was created or if the Workspace already exists.
 	// See https://github.com/PrefectHQ/terraform-provider-prefect/issues/241 for more information.
 	workspace, err := retry.DoWithData(
 		func() (*api.Workspace, error) {


### PR DESCRIPTION
Mitigates the 503 service unavailable errors by retrying Workspace creation. Further information provided in comments in the code for posterity.

Related to https://github.com/PrefectHQ/terraform-provider-prefect/issues/241

## Testing

Run the Acceptance Tests repeatedly:
- Old behavior: resource tests would sometimes fail to create Workspaces with a `503 Service Unavailable error`
- New behavior: resource tests pass every time