### PR TITLE
feat(Deployments): support Parameters

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -25,7 +25,7 @@ resource "prefect_flow" "flow" {
 }
 
 resource "prefect_deployment" "deployment" {
-  name                     = "%s"
+  name                     = "my-deployment"
   description              = "string"
   workspace_id             = prefect_workspace.workspace.id
   flow_id                  = prefect_flow.flow.id
@@ -33,11 +33,15 @@ resource "prefect_deployment" "deployment" {
   tags                     = ["test"]
   enforce_parameter_schema = false
   manifest_path            = "./bar/foo"
-  path                     = "./foo/bar"
-  paused                   = false
-  version                  = "v1.1.1"
-  work_pool_name           = "mitch-testing-pool"
-  work_queue_name          = "default"
+  parameters = jsonencode({
+    "some-parameter" : "some-value",
+    "some-parameter2" : "some-value2"
+  })
+  path            = "./foo/bar"
+  paused          = false
+  version         = "v1.1.1"
+  work_pool_name  = "mitch-testing-pool"
+  work_queue_name = "default"
 }
 ```
 
@@ -56,6 +60,7 @@ resource "prefect_deployment" "deployment" {
 - `enforce_parameter_schema` (Boolean) Whether or not the deployment should enforce the parameter schema.
 - `entrypoint` (String) The path to the entrypoint for the workflow, relative to the path.
 - `manifest_path` (String) The path to the flow's manifest file, relative to the chosen storage.
+- `parameters` (String) Parameters for flow runs scheduled by the deployment.
 - `path` (String) The path to the working directory for the workflow, relative to remote storage or an absolute path.
 - `paused` (Boolean) Whether or not the deployment is paused.
 - `tags` (List of String) Tags associated with the deployment

--- a/examples/resources/prefect_deployment/resource.tf
+++ b/examples/resources/prefect_deployment/resource.tf
@@ -18,10 +18,14 @@ resource "prefect_deployment" "deployment" {
   tags                     = ["test"]
   enforce_parameter_schema = false
   manifest_path            = "./bar/foo"
-  path                     = "./foo/bar"
-  paused                   = false
-  version                  = "v1.1.1"
-  work_pool_name           = "mitch-testing-pool"
-  work_queue_name          = "default"
+  parameters = jsonencode({
+    "some-parameter" : "some-value",
+    "some-parameter2" : "some-value2"
+  })
+  path            = "./foo/bar"
+  paused          = false
+  version         = "v1.1.1"
+  work_pool_name  = "mitch-testing-pool"
+  work_queue_name = "default"
 }
 

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -21,48 +21,51 @@ type Deployment struct {
 	AccountID   uuid.UUID `json:"account_id"`
 	WorkspaceID uuid.UUID `json:"workspace_id"`
 
-	Description            string    `json:"description,omitempty"`
-	EnforceParameterSchema bool      `json:"enforce_parameter_schema"`
-	Entrypoint             string    `json:"entrypoint"`
-	FlowID                 uuid.UUID `json:"flow_id"`
-	ManifestPath           string    `json:"manifest_path,omitempty"`
-	Name                   string    `json:"name"`
-	Path                   string    `json:"path"`
-	Paused                 bool      `json:"paused"`
-	Tags                   []string  `json:"tags"`
-	Version                string    `json:"version,omitempty"`
-	WorkPoolName           string    `json:"work_pool_name,omitempty"`
-	WorkQueueName          string    `json:"work_queue_name,omitempty"`
+	Description            string                 `json:"description,omitempty"`
+	EnforceParameterSchema bool                   `json:"enforce_parameter_schema"`
+	Entrypoint             string                 `json:"entrypoint"`
+	FlowID                 uuid.UUID              `json:"flow_id"`
+	ManifestPath           string                 `json:"manifest_path,omitempty"`
+	Name                   string                 `json:"name"`
+	Parameters             map[string]interface{} `json:"parameters,omitempty"`
+	Path                   string                 `json:"path"`
+	Paused                 bool                   `json:"paused"`
+	Tags                   []string               `json:"tags"`
+	Version                string                 `json:"version,omitempty"`
+	WorkPoolName           string                 `json:"work_pool_name,omitempty"`
+	WorkQueueName          string                 `json:"work_queue_name,omitempty"`
 }
 
 // DeploymentCreate is a subset of Deployment used when creating deployments.
 type DeploymentCreate struct {
-	Description            string    `json:"description,omitempty"`
-	EnforceParameterSchema bool      `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint             string    `json:"entrypoint,omitempty"`
-	FlowID                 uuid.UUID `json:"flow_id"`
-	ManifestPath           string    `json:"manifest_path,omitempty"`
-	Name                   string    `json:"name"`
-	Path                   string    `json:"path,omitempty"`
-	Paused                 bool      `json:"paused,omitempty"`
-	Tags                   []string  `json:"tags,omitempty"`
-	Version                string    `json:"version,omitempty"`
-	WorkPoolName           string    `json:"work_pool_name,omitempty"`
-	WorkQueueName          string    `json:"work_queue_name,omitempty"`
+	Description            string                 `json:"description,omitempty"`
+	EnforceParameterSchema bool                   `json:"enforce_parameter_schema,omitempty"`
+	Entrypoint             string                 `json:"entrypoint,omitempty"`
+	FlowID                 uuid.UUID              `json:"flow_id"`
+	ManifestPath           string                 `json:"manifest_path,omitempty"`
+	Name                   string                 `json:"name"`
+	Parameters             map[string]interface{} `json:"parameters,omitempty"`
+	Path                   string                 `json:"path,omitempty"`
+	Paused                 bool                   `json:"paused,omitempty"`
+	Tags                   []string               `json:"tags,omitempty"`
+	Version                string                 `json:"version,omitempty"`
+	WorkPoolName           string                 `json:"work_pool_name,omitempty"`
+	WorkQueueName          string                 `json:"work_queue_name,omitempty"`
 }
 
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
 type DeploymentUpdate struct {
-	Description            string   `json:"description,omitempty"`
-	EnforceParameterSchema bool     `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint             string   `json:"entrypoint,omitempty"`
-	ManifestPath           string   `json:"manifest_path"`
-	Path                   string   `json:"path,omitempty"`
-	Paused                 bool     `json:"paused,omitempty"`
-	Tags                   []string `json:"tags,omitempty"`
-	Version                string   `json:"version,omitempty"`
-	WorkPoolName           string   `json:"work_pool_name,omitempty"`
-	WorkQueueName          string   `json:"work_queue_name,omitempty"`
+	Description            string                 `json:"description,omitempty"`
+	EnforceParameterSchema bool                   `json:"enforce_parameter_schema,omitempty"`
+	Entrypoint             string                 `json:"entrypoint,omitempty"`
+	ManifestPath           string                 `json:"manifest_path"`
+	Parameters             map[string]interface{} `json:"parameters,omitempty"`
+	Path                   string                 `json:"path,omitempty"`
+	Paused                 bool                   `json:"paused,omitempty"`
+	Tags                   []string               `json:"tags,omitempty"`
+	Version                string                 `json:"version,omitempty"`
+	WorkPoolName           string                 `json:"work_pool_name,omitempty"`
+	WorkQueueName          string                 `json:"work_queue_name,omitempty"`
 }
 
 // DeploymentFilter defines the search filter payload

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -24,6 +24,7 @@ type deploymentConfig struct {
 	EnforceParameterSchema bool
 	Entrypoint             string
 	ManifestPath           string
+	Parameters             string
 	Path                   string
 	Paused                 bool
 	Tags                   []string
@@ -54,6 +55,9 @@ resource "prefect_deployment" "{{.DeploymentName}}" {
 	entrypoint = "{{.Entrypoint}}"
 	flow_id = prefect_flow.{{.FlowName}}.id
 	manifest_path = "{{.ManifestPath}}"
+	parameters = jsonencode({
+		"some-parameter": "{{.Parameters}}"
+	})
 	path = "{{.Path}}"
 	paused = {{.Paused}}
 	tags = [{{range .Tags}}"{{.}}", {{end}}]
@@ -84,6 +88,7 @@ func TestAccResource_deployment(t *testing.T) {
 		EnforceParameterSchema: false,
 		Entrypoint:             "hello_world.py:hello_world",
 		ManifestPath:           "some-manifest-path",
+		Parameters:             "some-value1",
 		Path:                   "some-path",
 		Paused:                 false,
 		Tags:                   []string{"test1", "test2"},
@@ -106,6 +111,7 @@ func TestAccResource_deployment(t *testing.T) {
 		Description:   "My deployment description v2",
 		Entrypoint:    "hello_world.py:hello_world2",
 		ManifestPath:  "some-manifest-path2",
+		Parameters:    "some-value2",
 		Path:          "some-path2",
 		Paused:        true,
 		Version:       "v1.1.2",
@@ -145,6 +151,7 @@ func TestAccResource_deployment(t *testing.T) {
 					resource.TestCheckResourceAttr(cfgCreate.DeploymentResourceName, "enforce_parameter_schema", strconv.FormatBool(cfgCreate.EnforceParameterSchema)),
 					resource.TestCheckResourceAttr(cfgCreate.DeploymentResourceName, "entrypoint", cfgCreate.Entrypoint),
 					resource.TestCheckResourceAttr(cfgCreate.DeploymentResourceName, "manifest_path", cfgCreate.ManifestPath),
+					resource.TestCheckResourceAttr(cfgCreate.DeploymentResourceName, "parameters", `{"some-parameter":"some-value1"}`),
 					resource.TestCheckResourceAttr(cfgCreate.DeploymentResourceName, "path", cfgCreate.Path),
 					resource.TestCheckResourceAttr(cfgCreate.DeploymentResourceName, "paused", strconv.FormatBool(cfgCreate.Paused)),
 					resource.TestCheckResourceAttr(cfgCreate.DeploymentResourceName, "tags.#", "2"),
@@ -169,6 +176,7 @@ func TestAccResource_deployment(t *testing.T) {
 					resource.TestCheckResourceAttr(cfgUpdate.DeploymentResourceName, "enforce_parameter_schema", strconv.FormatBool(cfgUpdate.EnforceParameterSchema)),
 					resource.TestCheckResourceAttr(cfgUpdate.DeploymentResourceName, "entrypoint", cfgUpdate.Entrypoint),
 					resource.TestCheckResourceAttr(cfgUpdate.DeploymentResourceName, "manifest_path", cfgUpdate.ManifestPath),
+					resource.TestCheckResourceAttr(cfgCreate.DeploymentResourceName, "parameters", `{"some-parameter":"some-value2"}`),
 					resource.TestCheckResourceAttr(cfgUpdate.DeploymentResourceName, "path", cfgUpdate.Path),
 					resource.TestCheckResourceAttr(cfgUpdate.DeploymentResourceName, "paused", strconv.FormatBool(cfgUpdate.Paused)),
 					resource.TestCheckResourceAttr(cfgUpdate.DeploymentResourceName, "tags.#", "2"),


### PR DESCRIPTION
## Summary

Supports setting Parameters on Deployment resouces.

Related to https://github.com/PrefectHQ/terraform-provider-prefect/issues/238

## Testing

First, see that the acceptance tests passed ✅ 

Also tested manually:

```terraform
terraform {
  required_providers {
    prefect = {
      source = "registry.terraform.io/prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint = "https://api.stg.prefect.dev"

  account_id   = "my-account-id"
  workspace_id = "<my-workspace-id>"

  api_key = "<my-api-key>"
}

resource "prefect_workspace" "workspace" {
  handle = "mitch-testing"
  name   = "mitch-testing"
}

resource "prefect_flow" "flow" {
  name         = "my-flow"
  workspace_id = prefect_workspace.workspace.id
  tags         = ["tf-test"]
}

resource "prefect_deployment" "deployment" {
  name                     = "my-deployment"
  description              = "string"
  workspace_id             = prefect_workspace.workspace.id
  flow_id                  = prefect_flow.flow.id
  entrypoint               = "hello_world.py:hello_world"
  tags                     = ["test"]
  enforce_parameter_schema = false
  manifest_path            = "./bar/foo"
  parameters               = jsonencode({ "some-parameter" : "some-value" })
  path                     = "./foo/bar"
  paused                   = false
  version                  = "v1.1.1"
  work_pool_name           = "mitch-testing-pool"
  work_queue_name          = "default"
}
```

```
$ go install
...

$ tf apply
...
```

<img width="690" alt="image" src="https://github.com/user-attachments/assets/01ab9918-c994-4059-bb14-0e1fde551a9a">

Then I updated my config to add another field with an `int` and applied it, and ran a job:

<img width="691" alt="image" src="https://github.com/user-attachments/assets/c2027af7-4f71-42b6-a645-7ba0cb1db12d">
