### PR TITLE
Block "data" argument: Clarify expected data format

### DIFF
--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -45,7 +45,7 @@ resource "prefect_block" "aws_credentials_from_file" {
   type_slug = "aws-credentials"
 
   # prefect block type inspect aws-credentials
-  data = file("./aws-credentials.json")
+  data = jsonencode(file("./aws-credentials.json"))
 }
 
 # example:
@@ -111,7 +111,7 @@ For more information on the `$ref` syntax definition, see the
 
 ### Required
 
-- `data` (String, Sensitive) The user-inputted Block payload, as a JSON string. The value's schema will depend on the selected `type` slug. Use `prefect block type inspect <slug>` to view the data schema for a given Block type.
+- `data` (String, Sensitive) The user-inputted Block payload, as a JSON string. Use `jsonencode` on the provided value to satisfy the underlying JSON type. The value's schema will depend on the selected `type` slug. Use `prefect block type inspect <slug>` to view the data schema for a given Block type.
 - `name` (String) Unique name of the Block
 - `type_slug` (String) Block Type slug, which determines the schema of the `data` JSON attribute. Use `prefect block type ls` to view all available Block type slugs.
 

--- a/examples/resources/prefect_block/resource.tf
+++ b/examples/resources/prefect_block/resource.tf
@@ -22,7 +22,7 @@ resource "prefect_block" "aws_credentials_from_file" {
   type_slug = "aws-credentials"
 
   # prefect block type inspect aws-credentials
-  data = file("./aws-credentials.json")
+  data = jsonencode(file("./aws-credentials.json"))
 }
 
 # example:

--- a/internal/provider/datasources/account_member_test.go
+++ b/internal/provider/datasources/account_member_test.go
@@ -25,9 +25,9 @@ func TestAccDatasource_account_member(t *testing.T) {
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: fixtureAccAccountMember("marvin+tf-acceptance-tester@prefect.io"),
+				Config: fixtureAccAccountMember("marvin@prefect.io"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "email", "marvin+tf-acceptance-tester@prefect.io"),
+					resource.TestCheckResourceAttr(dataSourceName, "email", "marvin@prefect.io"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "account_role_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "account_role_name"),

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -116,7 +116,7 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Required:    true,
 				Sensitive:   true,
 				CustomType:  jsontypes.NormalizedType{},
-				Description: "The user-inputted Block payload, as a JSON string. The value's schema will depend on the selected `type` slug. Use `prefect block type inspect <slug>` to view the data schema for a given Block type.",
+				Description: "The user-inputted Block payload, as a JSON string. Use `jsonencode` on the provided value to satisfy the underlying JSON type. The value's schema will depend on the selected `type` slug. Use `prefect block type inspect <slug>` to view the data schema for a given Block type.",
 			},
 			"account_id": schema.StringAttribute{
 				Optional:    true,


### PR DESCRIPTION
Clarifies the expected data format for the "data" argument in the Block resource.

The specific type is `schema.stringAttribute`, but we also set a CustomType of `jsontypes.NormalizedType`, which is an RFC 7159 JSON string.

The Terraform Documentation tooling does not consider the CustomType field, so in the generated markdown it only say `String, Sensitive`. This can be confusing for users who expect to just pass any string here.

So this change:
- Clarifies the format expectations in the `data` argument description
- Updates the examples to ensure we use `jsonencode` consistently

Related to https://github.com/PrefectHQ/terraform-provider-prefect/issues/255