### PR TITLE
Require workspace ID for work pools in Cloud

### DIFF
--- a/docs/resources/work_pool.md
+++ b/docs/resources/work_pool.md
@@ -60,7 +60,7 @@ resource "prefect_work_pool" "example" {
 - `description` (String) Description of the work pool
 - `paused` (Boolean) Whether this work pool is paused
 - `type` (String) Type of the work pool, eg. kubernetes, ecs, process, etc.
-- `workspace_id` (String) Workspace ID (UUID), defaults to the workspace set in the provider
+- `workspace_id` (String) Workspace ID (UUID), defaults to the workspace set in the provider. In Prefect Cloud, either the `work_pool` resource or the provider's `workspace_id` must be set.
 
 ### Read-Only
 

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 var _ = api.WorkPoolsClient(&WorkPoolsClient{})
@@ -28,8 +29,13 @@ func (c *Client) WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (api.Work
 	if accountID == uuid.Nil {
 		accountID = c.defaultAccountID
 	}
+
 	if workspaceID == uuid.Nil {
 		workspaceID = c.defaultWorkspaceID
+	}
+
+	if helpers.IsCloudEndpoint(c.endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
+		return nil, fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set on either the provider or the resource")
 	}
 
 	return &WorkPoolsClient{

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -115,7 +115,7 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"workspace_id": schema.StringAttribute{
 				CustomType:  customtypes.UUIDType{},
-				Description: "Workspace ID (UUID), defaults to the workspace set in the provider",
+				Description: "Workspace ID (UUID), defaults to the workspace set in the provider. In Prefect Cloud, either the `work_pool` resource or the provider's `workspace_id` must be set.",
 				Optional:    true,
 			},
 			"name": schema.StringAttribute{


### PR DESCRIPTION
## Summary

In Cloud, workspace_id is required. It's marked as optional to support OSS.

Related to https://github.com/PrefectHQ/terraform-provider-prefect/issues/281

Related to https://linear.app/prefect/issue/PLA-399/prefect-terraform-provider-errors-with-404-when-trying-to-create-a-new

## Testing

First, test without workspace ID set on our currently released provider:

```terraform
provider "prefect" {
  api_key    = var.prefect_api_key
  account_id = var.prefect_account_id

  # note that no workspace_id is configured
}

resource "prefect_work_pool" "test_work_pool" {
  name = "test-work-pool"
  type = "kubernetes"
}
```

You'll see:

> Could not create Work Pool, unexpected error: status code 404 Not Found, error=

Try the same configuration from this branch and you'll see:

> Could not create Work Pool client, due to error: workspace_id is required for Work Pool resources. Please report this issue to the provider developers