### PR TITLE
fix(blocks): add trailing slash on Create() to avoid 307

### DIFF
--- a/internal/client/block_documents.go
+++ b/internal/client/block_documents.go
@@ -115,7 +115,7 @@ func (c *BlockDocumentClient) Create(ctx context.Context, payload api.BlockDocum
 		return nil, fmt.Errorf("failed to encode create payload data: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.routePrefix, &buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.routePrefix+"/", &buf)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}


### PR DESCRIPTION
resolves https://linear.app/prefect/issue/PLA-412/prefect-blocks-405-response

the specific matched endpoint is `POST /block_documents/` (with a trailing slash).  currently, our client didn't add that trailing slash.  the API will return a 307 for the client to redirect.  

```hcl
provider "prefect" {
  endpoint = "http://localhost:4200/api"
}

resource "prefect_block" "secret" {
  name      = "food"
  type_slug = "secret"

  data = jsonencode({
    "name"   = "mine"
    "target" = "prefect-dbt-profile"
  })
}
```

```sh
➜ terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # prefect_block.secret will be created
  + resource "prefect_block" "secret" {
      + created   = (known after apply)
      + data      = (sensitive value)
      + id        = (known after apply)
      + name      = "food"
      + type_slug = "secret"
      + updated   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
prefect_block.secret: Creating...
prefect_block.secret: Creation complete after 0s [id=7938fefb-ba93-4369-b78b-af27c020d16b]
```

```
# on the prefect server
INFO:     127.0.0.1:55451 - "POST /api/block_schemas/filter HTTP/1.1" 200 OK
INFO:     127.0.0.1:54928 - "POST /api/block_documents HTTP/1.1" 307 Temporary Redirect
INFO:     127.0.0.1:54928 - "POST /api/block_documents/ HTTP/1.1" 201 Created
```

for some cases such as with the reporter of https://github.com/PrefectHQ/terraform-provider-prefect/issues/284, a redirect may not be feasible and can cause a mis-routed request

here, we'll add the trailing slash to the block_documents client call for `Create()`, as this is the convention we've applied to all our other resources

after making this change, here are the server logs (notice no 307)

```sh
# same TF code
➜ terraform apply --auto-approve

# on the prefect server
INFO:     127.0.0.1:55451 - "POST /api/block_schemas/filter HTTP/1.1" 200 OK
INFO:     127.0.0.1:55451 - "POST /api/block_documents/ HTTP/1.1" 201 Created
```

