### PR TITLE
fix(variables): add UpgradeState method to migrate existing resources

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,7 +19,7 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - forbidigo
     - forcetypeassert
     - gocheckcompilerdirectives

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,7 +3,7 @@ golang = '1.21.10'
 golangci-lint = '1.61.0'
 goreleaser = '1.26.2'
 pre-commit = '3.7.1'
-terraform = '1.8.4'
+terraform = '1.9.8'
 
 # tomlv does not currently have an entry in the registry.
 # For now, install with `go`:

--- a/create-dev-testfile.sh
+++ b/create-dev-testfile.sh
@@ -36,9 +36,12 @@ provider "prefect" {}
 resource "${resource}" "${name}" {}
 EOF
 
+  cmd="cd ${dev_file_target} && terraform plan"
   echo ""
   echo "run:"
-  echo "cd ${dev_file_target} && terraform plan"
+  echo "${cmd}"
+  echo "(copied to clipboard)"
+  printf "${cmd}" | pbcopy
 }
 
 main $@


### PR DESCRIPTION
resolves https://linear.app/prefect/issue/PLA-557/prefect-variable-error-when-upgrading-from-240-to-250-prior-state

In #277, we made a schema update to the `prefect_variable` resource to accommodate changes to our variables API, where a flexible, dynamic type is now accepted for the `value` attribute.  In the Terraform resource schema, we changed the `value` attribute from `schema.StringAttribute` => `schema.DynamicAttribute`

However, without versioning the resource's schema, we opened ourself to a breaking schema change, where users who were on the _**previous**_ schema + serialized a `prefect_variable` to their state would be unable to run a `terraform plan` when upgrading the provider to the _**new**_ schema.  This is because Terraform has an underlying type system, and every plan will attempt to deserialize the state data to the current resource schema in the provider.  Being on the older schema, these state resources would become inaccessible without being destroyed and re-created

In this PR, we add an `UpgradeState` method to the variables resource to help these users migrate their resources gracefully - see this documentation for more detail
https://developer.hashicorp.com/terraform/plugin/framework/resources/state-upgrade

At a high level - moving forward, anytime we make a schema change to a resource, we'll need to do the following:
1. Version the golang `*ResourceModel` struct with the new type
2. Increment the `Schema.Version` value (most of ours are 0 at the moment, since we've not needed to perform a breaking schema change yet)
3. Define a `UpgradeState` method (which implements the `ResourceWithUpgradeState` interface), which will provide the proper schema migration operation

# Testing
Start on the last provider version before this schema change was introduced, eg. `2.4.0`.  Create a `prefect_variable` resource and serialize it to your state
```hcl
terraform {
  required_providers {
    prefect = {
      source = "prefecthq/prefect"
      version = "2.4.0"
    }
  }
}

provider "prefect" {}

resource "prefect_variable" "strange_value" {
  name = "environment"
  value = "new-value"
}
```


```sh
➜ terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # prefect_variable.strange_value will be created
  + resource "prefect_variable" "strange_value" {
      + created = (known after apply)
      + id      = (known after apply)
      + name    = "environment"
      + tags    = []
      + updated = (known after apply)
      + value   = "new-value"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
prefect_variable.strange_value: Creating...
prefect_variable.strange_value: Creation complete after 0s [id=13e3ad85-73f9-4c00-8165-90228bff4dc2]
```

Reproduce the issue by bumping the provider to `2.5.0`
```hcl
terraform {
  required_providers {
    prefect = {
      source = "prefecthq/prefect"
      version = "2.5.0"
    }
  }
}
```

```sh
➜ terraform init --upgrade
➜ terraform plan

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Unable to Read Previously Saved State for UpgradeResourceState
│
│   with prefect_variable.strange_value,
│   on prefect_variable.tf line 18, in resource "prefect_variable" "strange_value":
│   18: resource "prefect_variable" "strange_value" {
│
│ There was an error reading the saved resource state using the current resource schema.
│
│ If this resource state was last refreshed with Terraform CLI 0.11 and earlier, it must be refreshed or applied with an older provider version first. If you manually modified the resource state, you will need to manually modify it to match the current resource schema.
│ Otherwise, please report this to the provider developer:
│
│ AttributeName("value"): invalid JSON, expected "{", got "new-value"
```

Then, build the provider locally at this commit to test the fix
```sh
$ pwd
terraform-provider-prefect

$ make build
```

Point your `.terraformrc` `dev_override` to your local provider build
```sh
➜ vi ~/.terraformrc

provider_installation {
  dev_overrides {
      "prefecthq/prefect" = "/Users/your-directory/terraform-provider-prefect/build"
  }
}

➜ terraform plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/your-directory/terraform-provider-prefect/build
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
prefect_variable.strange_value: Refreshing state... [id=13e3ad85-73f9-4c00-8165-90228bff4dc2]

No changes. Your infrastructure matches the configuration.
```

Verify that a change can be made as well:

```hcl
resource "prefect_variable" "strange_value" {
  name = "environment"
  value = "new-value-2"
}
```
```sh
➜ terraform apply --auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in /Users/your-directory/terraform-provider-prefect/build
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
prefect_variable.strange_value: Refreshing state... [id=13e3ad85-73f9-4c00-8165-90228bff4dc2]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # prefect_variable.strange_value will be updated in-place
  ~ resource "prefect_variable" "strange_value" {
        id      = "13e3ad85-73f9-4c00-8165-90228bff4dc2"
        name    = "environment"
        tags    = []
      ~ updated = "2024-11-01T21:10:29Z" -> (known after apply)
      ~ value   = "new-value" -> "new-value-2"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
prefect_variable.strange_value: Modifying... [id=13e3ad85-73f9-4c00-8165-90228bff4dc2]
prefect_variable.strange_value: Modifications complete after 1s [id=13e3ad85-73f9-4c00-8165-90228bff4dc2]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```