### PR TITLE
chore/Add infrastructure document id support

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -82,6 +82,7 @@ resource "prefect_deployment" "deployment" {
 - `description` (String) A description for the deployment.
 - `enforce_parameter_schema` (Boolean) Whether or not the deployment should enforce the parameter schema.
 - `entrypoint` (String) The path to the entrypoint for the workflow, relative to the path.
+- `infrastructure_document_id` (String) ID of the associated infrastructure document (UUID)
 - `job_variables` (String) Overrides for the flow's infrastructure configuration.
 - `manifest_path` (String) The path to the flow's manifest file, relative to the chosen storage.
 - `parameter_openapi_schema` (String) The parameter schema of the flow, including defaults.

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -21,59 +21,62 @@ type Deployment struct {
 	AccountID   uuid.UUID `json:"account_id"`
 	WorkspaceID uuid.UUID `json:"workspace_id"`
 
-	Description            string                 `json:"description,omitempty"`
-	EnforceParameterSchema bool                   `json:"enforce_parameter_schema"`
-	Entrypoint             string                 `json:"entrypoint"`
-	FlowID                 uuid.UUID              `json:"flow_id"`
-	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
-	ManifestPath           string                 `json:"manifest_path,omitempty"`
-	Name                   string                 `json:"name"`
-	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
-	Parameters             map[string]interface{} `json:"parameters,omitempty"`
-	Path                   string                 `json:"path"`
-	Paused                 bool                   `json:"paused"`
-	StorageDocumentID      uuid.UUID              `json:"storage_document_id,omitempty"`
-	Tags                   []string               `json:"tags"`
-	Version                string                 `json:"version,omitempty"`
-	WorkPoolName           string                 `json:"work_pool_name,omitempty"`
-	WorkQueueName          string                 `json:"work_queue_name,omitempty"`
+	Description              string                 `json:"description,omitempty"`
+	EnforceParameterSchema   bool                   `json:"enforce_parameter_schema"`
+	Entrypoint               string                 `json:"entrypoint"`
+	FlowID                   uuid.UUID              `json:"flow_id"`
+	InfrastructureDocumentID uuid.UUID              `json:"infrastructure_document_id,omitempty"`
+	JobVariables             map[string]interface{} `json:"job_variables,omitempty"`
+	ManifestPath             string                 `json:"manifest_path,omitempty"`
+	Name                     string                 `json:"name"`
+	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
+	Parameters               map[string]interface{} `json:"parameters,omitempty"`
+	Path                     string                 `json:"path"`
+	Paused                   bool                   `json:"paused"`
+	StorageDocumentID        uuid.UUID              `json:"storage_document_id,omitempty"`
+	Tags                     []string               `json:"tags"`
+	Version                  string                 `json:"version,omitempty"`
+	WorkPoolName             string                 `json:"work_pool_name,omitempty"`
+	WorkQueueName            string                 `json:"work_queue_name,omitempty"`
 }
 
 // DeploymentCreate is a subset of Deployment used when creating deployments.
 type DeploymentCreate struct {
-	Description            string                 `json:"description,omitempty"`
-	EnforceParameterSchema bool                   `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint             string                 `json:"entrypoint,omitempty"`
-	FlowID                 uuid.UUID              `json:"flow_id"`
-	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
-	ManifestPath           string                 `json:"manifest_path,omitempty"`
-	Name                   string                 `json:"name"`
-	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
-	Parameters             map[string]interface{} `json:"parameters,omitempty"`
-	Path                   string                 `json:"path,omitempty"`
-	Paused                 bool                   `json:"paused,omitempty"`
-	StorageDocumentID      *uuid.UUID             `json:"storage_document_id,omitempty"`
-	Tags                   []string               `json:"tags,omitempty"`
-	Version                string                 `json:"version,omitempty"`
-	WorkPoolName           string                 `json:"work_pool_name,omitempty"`
-	WorkQueueName          string                 `json:"work_queue_name,omitempty"`
+	Description              string                 `json:"description,omitempty"`
+	EnforceParameterSchema   bool                   `json:"enforce_parameter_schema,omitempty"`
+	Entrypoint               string                 `json:"entrypoint,omitempty"`
+	FlowID                   uuid.UUID              `json:"flow_id"`
+	InfrastructureDocumentID *uuid.UUID             `json:"infrastructure_document_id,omitempty"`
+	JobVariables             map[string]interface{} `json:"job_variables,omitempty"`
+	ManifestPath             string                 `json:"manifest_path,omitempty"`
+	Name                     string                 `json:"name"`
+	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
+	Parameters               map[string]interface{} `json:"parameters,omitempty"`
+	Path                     string                 `json:"path,omitempty"`
+	Paused                   bool                   `json:"paused,omitempty"`
+	StorageDocumentID        *uuid.UUID             `json:"storage_document_id,omitempty"`
+	Tags                     []string               `json:"tags,omitempty"`
+	Version                  string                 `json:"version,omitempty"`
+	WorkPoolName             string                 `json:"work_pool_name,omitempty"`
+	WorkQueueName            string                 `json:"work_queue_name,omitempty"`
 }
 
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
 type DeploymentUpdate struct {
-	Description            string                 `json:"description,omitempty"`
-	EnforceParameterSchema bool                   `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint             string                 `json:"entrypoint,omitempty"`
-	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
-	ManifestPath           string                 `json:"manifest_path"`
-	Parameters             map[string]interface{} `json:"parameters,omitempty"`
-	Path                   string                 `json:"path,omitempty"`
-	Paused                 bool                   `json:"paused,omitempty"`
-	StorageDocumentID      *uuid.UUID             `json:"storage_document_id,omitempty"`
-	Tags                   []string               `json:"tags,omitempty"`
-	Version                string                 `json:"version,omitempty"`
-	WorkPoolName           string                 `json:"work_pool_name,omitempty"`
-	WorkQueueName          string                 `json:"work_queue_name,omitempty"`
+	Description              string                 `json:"description,omitempty"`
+	EnforceParameterSchema   bool                   `json:"enforce_parameter_schema,omitempty"`
+	Entrypoint               string                 `json:"entrypoint,omitempty"`
+	InfrastructureDocumentID *uuid.UUID             `json:"infrastructure_document_id,omitempty"`
+	JobVariables             map[string]interface{} `json:"job_variables,omitempty"`
+	ManifestPath             string                 `json:"manifest_path"`
+	Parameters               map[string]interface{} `json:"parameters,omitempty"`
+	Path                     string                 `json:"path,omitempty"`
+	Paused                   bool                   `json:"paused,omitempty"`
+	StorageDocumentID        *uuid.UUID             `json:"storage_document_id,omitempty"`
+	Tags                     []string               `json:"tags,omitempty"`
+	Version                  string                 `json:"version,omitempty"`
+	WorkPoolName             string                 `json:"work_pool_name,omitempty"`
+	WorkQueueName            string                 `json:"work_queue_name,omitempty"`
 }
 
 // DeploymentFilter defines the search filter payload

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -44,22 +44,23 @@ type DeploymentResourceModel struct {
 	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
 	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
-	Description            types.String          `tfsdk:"description"`
-	EnforceParameterSchema types.Bool            `tfsdk:"enforce_parameter_schema"`
-	Entrypoint             types.String          `tfsdk:"entrypoint"`
-	FlowID                 customtypes.UUIDValue `tfsdk:"flow_id"`
-	JobVariables           jsontypes.Normalized  `tfsdk:"job_variables"`
-	ManifestPath           types.String          `tfsdk:"manifest_path"`
-	Name                   types.String          `tfsdk:"name"`
-	ParameterOpenAPISchema jsontypes.Normalized  `tfsdk:"parameter_openapi_schema"`
-	Parameters             jsontypes.Normalized  `tfsdk:"parameters"`
-	Path                   types.String          `tfsdk:"path"`
-	Paused                 types.Bool            `tfsdk:"paused"`
-	StorageDocumentID      customtypes.UUIDValue `tfsdk:"storage_document_id"`
-	Tags                   types.List            `tfsdk:"tags"`
-	Version                types.String          `tfsdk:"version"`
-	WorkPoolName           types.String          `tfsdk:"work_pool_name"`
-	WorkQueueName          types.String          `tfsdk:"work_queue_name"`
+	Description              types.String          `tfsdk:"description"`
+	EnforceParameterSchema   types.Bool            `tfsdk:"enforce_parameter_schema"`
+	Entrypoint               types.String          `tfsdk:"entrypoint"`
+	FlowID                   customtypes.UUIDValue `tfsdk:"flow_id"`
+	InfrastructureDocumentID customtypes.UUIDValue `tfsdk:"infrastructure_document_id"`
+	JobVariables             jsontypes.Normalized  `tfsdk:"job_variables"`
+	ManifestPath             types.String          `tfsdk:"manifest_path"`
+	Name                     types.String          `tfsdk:"name"`
+	ParameterOpenAPISchema   jsontypes.Normalized  `tfsdk:"parameter_openapi_schema"`
+	Parameters               jsontypes.Normalized  `tfsdk:"parameters"`
+	Path                     types.String          `tfsdk:"path"`
+	Paused                   types.Bool            `tfsdk:"paused"`
+	StorageDocumentID        customtypes.UUIDValue `tfsdk:"storage_document_id"`
+	Tags                     types.List            `tfsdk:"tags"`
+	Version                  types.String          `tfsdk:"version"`
+	WorkPoolName             types.String          `tfsdk:"work_pool_name"`
+	WorkQueueName            types.String          `tfsdk:"work_queue_name"`
 }
 
 // NewDeploymentResource returns a new DeploymentResource.
@@ -145,6 +146,12 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				CustomType:  customtypes.UUIDType{},
 				Description: "Flow ID (UUID) to associate deployment to",
 				Required:    true,
+			},
+			"infrastructure_document_id": schema.StringAttribute{
+				Optional:    true,
+				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "Infrastructure document ID (UUID) to associate deployment to",
 			},
 			"paused": schema.BoolAttribute{
 				Description: "Whether or not the deployment is paused.",
@@ -265,6 +272,7 @@ func copyDeploymentToModel(ctx context.Context, deployment *api.Deployment, mode
 	model.EnforceParameterSchema = types.BoolValue(deployment.EnforceParameterSchema)
 	model.Entrypoint = types.StringValue(deployment.Entrypoint)
 	model.FlowID = customtypes.NewUUIDValue(deployment.FlowID)
+	model.InfrastructureDocumentID = customtypes.NewUUIDValue(deployment.InfrastructureDocumentID)
 	model.ManifestPath = types.StringValue(deployment.ManifestPath)
 	model.Name = types.StringValue(deployment.Name)
 	model.Path = types.StringValue(deployment.Path)
@@ -326,22 +334,23 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	deployment, err := client.Create(ctx, api.DeploymentCreate{
-		Description:            plan.Description.ValueString(),
-		EnforceParameterSchema: plan.EnforceParameterSchema.ValueBool(),
-		Entrypoint:             plan.Entrypoint.ValueString(),
-		FlowID:                 plan.FlowID.ValueUUID(),
-		JobVariables:           jobVariables,
-		ManifestPath:           plan.ManifestPath.ValueString(),
-		Name:                   plan.Name.ValueString(),
-		Parameters:             parameters,
-		Path:                   plan.Path.ValueString(),
-		Paused:                 plan.Paused.ValueBool(),
-		StorageDocumentID:      plan.StorageDocumentID.ValueUUIDPointer(),
-		Tags:                   tags,
-		Version:                plan.Version.ValueString(),
-		WorkPoolName:           plan.WorkPoolName.ValueString(),
-		WorkQueueName:          plan.WorkQueueName.ValueString(),
-		ParameterOpenAPISchema: parameterOpenAPISchema,
+		Description:              plan.Description.ValueString(),
+		EnforceParameterSchema:   plan.EnforceParameterSchema.ValueBool(),
+		Entrypoint:               plan.Entrypoint.ValueString(),
+		FlowID:                   plan.FlowID.ValueUUID(),
+		InfrastructureDocumentID: plan.InfrastructureDocumentID.ValueUUIDPointer(),
+		JobVariables:             jobVariables,
+		ManifestPath:             plan.ManifestPath.ValueString(),
+		Name:                     plan.Name.ValueString(),
+		Parameters:               parameters,
+		Path:                     plan.Path.ValueString(),
+		Paused:                   plan.Paused.ValueBool(),
+		StorageDocumentID:        plan.StorageDocumentID.ValueUUIDPointer(),
+		Tags:                     tags,
+		Version:                  plan.Version.ValueString(),
+		WorkPoolName:             plan.WorkPoolName.ValueString(),
+		WorkQueueName:            plan.WorkQueueName.ValueString(),
+		ParameterOpenAPISchema:   parameterOpenAPISchema,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -489,19 +498,20 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	payload := api.DeploymentUpdate{
-		Description:            model.Description.ValueString(),
-		EnforceParameterSchema: model.EnforceParameterSchema.ValueBool(),
-		Entrypoint:             model.Entrypoint.ValueString(),
-		JobVariables:           jobVariables,
-		ManifestPath:           model.ManifestPath.ValueString(),
-		Parameters:             parameters,
-		Path:                   model.Path.ValueString(),
-		Paused:                 model.Paused.ValueBool(),
-		StorageDocumentID:      model.StorageDocumentID.ValueUUIDPointer(),
-		Tags:                   tags,
-		Version:                model.Version.ValueString(),
-		WorkPoolName:           model.WorkPoolName.ValueString(),
-		WorkQueueName:          model.WorkQueueName.ValueString(),
+		Description:              model.Description.ValueString(),
+		EnforceParameterSchema:   model.EnforceParameterSchema.ValueBool(),
+		Entrypoint:               model.Entrypoint.ValueString(),
+		InfrastructureDocumentID: model.InfrastructureDocumentID.ValueUUIDPointer(),
+		JobVariables:             jobVariables,
+		ManifestPath:             model.ManifestPath.ValueString(),
+		Parameters:               parameters,
+		Path:                     model.Path.ValueString(),
+		Paused:                   model.Paused.ValueBool(),
+		StorageDocumentID:        model.StorageDocumentID.ValueUUIDPointer(),
+		Tags:                     tags,
+		Version:                  model.Version.ValueString(),
+		WorkPoolName:             model.WorkPoolName.ValueString(),
+		WorkQueueName:            model.WorkQueueName.ValueString(),
 	}
 	err = client.Update(ctx, deploymentID, payload)
 


### PR DESCRIPTION
- Resolves: https://linear.app/prefect/issue/PLA-442/deployments-support-infrastructure-document-id
- Adds support and tests for `infrastructure_document_ids` in deployment specs
- I believe that the k8s job block is about as simple as I can make an infra block to pull the id from but happy for suggestions 