### PR TITLE
Finish ephemeral workspace implementation, address race conditions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
+	github.com/avast/retry-go/v4 v4.6.0
 	github.com/go-test/deep v1.1.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
@@ -66,7 +67,6 @@ require (
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
+github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=

--- a/internal/provider/datasources/block_test.go
+++ b/internal/provider/datasources/block_test.go
@@ -9,13 +9,11 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccBlockByName(name string) string {
+func fixtureAccBlockByName(workspace, name string) string {
 	aID := os.Getenv("PREFECT_CLOUD_ACCOUNT_ID")
 
 	return fmt.Sprintf(`
-data "prefect_workspace" "evergreen" {
-	handle = "github-ci-tests"
-}
+%s
 
 resource "prefect_block" "%s" {
   name      = "%s"
@@ -26,14 +24,14 @@ resource "prefect_block" "%s" {
   })
 
   account_id = "%s"
-  workspace_id = data.prefect_workspace.evergreen.id
+  workspace_id = prefect_workspace.test.id
 }
 
 data "prefect_block" "my_existing_secret_by_id" {
   id = prefect_block.%s.id
 
   account_id = "%s"
-  workspace_id = data.prefect_workspace.evergreen.id
+  workspace_id = prefect_workspace.test.id
 
   depends_on = [prefect_block.%s]
 }
@@ -43,15 +41,17 @@ data "prefect_block" "my_existing_secret_by_name" {
   type_slug = "secret"
 
   account_id = "%s"
-  workspace_id = data.prefect_workspace.evergreen.id
+  workspace_id = prefect_workspace.test.id
 
   depends_on = [prefect_block.%s]
 }
-`, name, name, aID, name, aID, name, name, aID, name)
+`, workspace, name, name, aID, name, aID, name, name, aID, name)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccDatasource_block(t *testing.T) {
+	workspace := testutils.NewEphemeralWorkspace()
+
 	datasourceNameByID := "data.prefect_block.my_existing_secret_by_id"
 	datasourceNameByName := "data.prefect_block.my_existing_secret_by_name"
 
@@ -64,7 +64,7 @@ func TestAccDatasource_block(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test block datasource by ID.
-				Config: fixtureAccBlockByName(blockName),
+				Config: fixtureAccBlockByName(workspace.Resource, blockName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceNameByID, "id"),
 					resource.TestCheckResourceAttr(datasourceNameByID, "name", blockName),
@@ -73,7 +73,7 @@ func TestAccDatasource_block(t *testing.T) {
 			},
 			{
 				// Test block datasource by name.
-				Config: fixtureAccBlockByName(blockName),
+				Config: fixtureAccBlockByName(workspace.Resource, blockName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceNameByName, "id"),
 					resource.TestCheckResourceAttr(datasourceNameByName, "name", blockName),

--- a/internal/provider/resources/deployment_access_test.go
+++ b/internal/provider/resources/deployment_access_test.go
@@ -98,7 +98,7 @@ func TestAccResource_deployment_access(t *testing.T) {
 			{
 				Config: fixtureAccDeploymentAccess(cfgSet),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDeploymentExists("prefect_deployment.test", cfgSet.WorkspaceResourceName, &deployment),
+					testAccCheckDeploymentExists("prefect_deployment.test", &deployment),
 					testAccCheckDeploymentAccessExists("prefect_deployment_access.test", &deploymentAccess),
 					testAccCheckDeploymentAccessValues(&deploymentAccess, expectedDeploymentAccessValues{
 						manageActors: []api.ObjectActorAccess{

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -90,8 +90,9 @@ func NewRandomPrefixedString() string {
 
 // Workspace is a struct that represents a workspace for acceptance tests.
 type Workspace struct {
-	Resource string
-	Name     string
+	Resource    string
+	Name        string
+	Description string
 }
 
 // NewEphemeralWorkspace returns a new ephemeral workspace for acceptance tests.
@@ -100,12 +101,14 @@ func NewEphemeralWorkspace() Workspace {
 
 	randomName := NewRandomPrefixedString()
 	workspace.Name = randomName
+	workspace.Description = randomName
 
 	workspace.Resource = fmt.Sprintf(`
 resource "prefect_workspace" "test" {
 	name = "%s"
 	handle = "%s"
-}`, randomName, randomName)
+	description = "%s"
+}`, randomName, randomName, randomName)
 
 	return workspace
 }


### PR DESCRIPTION
Closes https://linear.app/prefect/issue/PLA-641/use-ephemeral-workspaces-in-resources-with-race-conditions

- Adds retry functionality on block schema retrieval, addressing the race conditions that can occur when creating ephemeral workspaces for block and deployment acceptance tests
- Implements ephemeral workspaces for the remaining resources and datasources

This means we no longer use the evergreen workspace, but we'll address removal and cleanup in https://linear.app/prefect/issue/PLA-642/ensure-ephemeral-workspaces-are-cleaned-up-consistently.