### PR TITLE
Add helper to run acceptance tests with secrets

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,7 @@
 golang = '1.21.10'
 golangci-lint = '1.61.0'
 goreleaser = '1.26.2'
+gotestsum = '1.12.0'
 pre-commit = '3.7.1'
 terraform = '1.9.8'
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,5 @@
 [tools]
+1password = '2.30.3'
 golang = '1.21.10'
 golangci-lint = '1.61.0'
 goreleaser = '1.26.2'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 NAME=prefect
 BINARY=terraform-provider-${NAME}
 
+TESTS?=""
+LOG_LEVEL?="INFO"
+
 default: build
 .PHONY: default
 
@@ -9,14 +12,15 @@ help:
 	@echo ""
 	@echo "This project defines the following build targets:"
 	@echo ""
-	@echo "  build      - compiles source code to build/"
-	@echo "  clean      - removes built artifacts"
-	@echo "  lint       - run static code analysis"
-	@echo "  test       - run automated unit tests"
-	@echo "  testacc    - run automated acceptance tests"
-	@echo "  docs       - builds Terraform documentation"
-	@echo "  dev-new    - creates a new dev testfile (args: resource=<resource> name=<name>)"
-	@echo "  dev-clean  - cleans up dev directory"
+	@echo "  build       - compiles source code to build/"
+	@echo "  clean       - removes built artifacts"
+	@echo "  lint        - run static code analysis"
+	@echo "  test        - run automated unit tests"
+	@echo "  testacc     - run automated acceptance tests"
+	@echo "  testacc-dev - run automated acceptance tests from a local machine (args TESTS=<tests> LOG_LEVEL=<level>)"
+	@echo "  docs        - builds Terraform documentation"
+	@echo "  dev-new     - creates a new dev testfile (args: resource=<resource> name=<name>)"
+	@echo "  dev-clean   - cleans up dev directory"
 .PHONY: help
 
 build: $(BINARY)
@@ -44,6 +48,10 @@ test:
 testacc:
 	TF_ACC=1 make test
 .PHONY: testacc
+
+testacc-dev:
+	./scripts/testacc-dev $(TESTS) $(LOG_LEVEL)
+.PHONY: testacc-dev
 
 docs:
 	mkdir -p docs

--- a/scripts/testacc-dev
+++ b/scripts/testacc-dev
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+
+# This script runs the acceptance tests from a local machine.
+#
+# It collects the required environment variables from 1Password
+# using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
+#
+# To run specific tests, add the test name as the first argument:
+#   ./scripts/testacc-dev TestAccResource_deployment
+#
+# To adjust the log level, specify it as the second argument:
+#   ./scripts/testacc-dev TestAccResource_deployment DEBUG
+#
+# Log levels are listed here:
+#   https://developer.hashicorp.com/terraform/internals/debugging
+
+vault_entry='op://Platform/Terraform provider acceptance test secrets'
+
+tests=${1:-""}
+log_level=${2:-"INFO"}
+
+run_arg=""
+if [ "${tests}" == "" ]; then
+  echo "no specific test configured, running all"
+else
+  echo "specific test(s) configured: ${tests}"
+  run_arg="-run ${tests}"
+fi
+
+TF_ACC=1 \
+  TF_LOG=${log_level} \
+  PREFECT_API_URL=$(op read "${vault_entry}/PREFECT_API_URL") \
+  PREFECT_API_KEY=$(op read "${vault_entry}/PREFECT_API_KEY") \
+  PREFECT_CLOUD_ACCOUNT_ID=$(op read "${vault_entry}/PREFECT_CLOUD_ACCOUNT_ID") \
+  gotestsum --max-fails=50 ./... -count=1 -v ${run_arg}


### PR DESCRIPTION
Adds a helper to run the acceptance tests by grabbing the required environment variables from a 1Password vault entry.

I've found it helpful when running the tests locally before committing to the project and running the tests from CI, or running them locally and manually configuring each environment variable from a local copy of those secrets.

Related to https://linear.app/prefect/issue/PLA-690/cycle-6-catch-all