### PR TITLE
chore(tests): run acceptance tests on main w/o approval

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     name: Acceptance Tests
-    environment: Acceptance Tests
+    environment: ${{ github.event_name == 'push' && 'Acceptance Tests (main)' || 'Acceptance Tests' }}
     runs-on: ubuntu-latest
     steps:
       - if: |


### PR DESCRIPTION
normally, our Acceptance Tests are run with approval because the GH environment contains secrets that theoretically _**could**_ be exfiltrated

However, this made it so that merges to main would have pending Acceptance Tests.  While it's unlikely that a commit is merged without running these tests first, it's probably good to cover our bases and have them run automatically on main merge

To facilitate that, I've created a separate GH environment called `Acceptance Tests (main)`, which can only be used on a protected branch (eg. `main`)

This environment has the same secrets, but will run without any approval needed

![image](https://github.com/user-attachments/assets/0cacc3dd-ec39-4f3f-a36a-fdbe1759850d)
