### PR TITLE
feat(deployments): support pull steps

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -59,8 +59,26 @@ resource "prefect_deployment" "deployment" {
       "some-parameter2" : { "type" : "string" }
     }
   })
-  path                = "./foo/bar"
-  paused              = false
+  path   = "./foo/bar"
+  paused = false
+  pull_steps = [
+    {
+      type      = "set_working_directory",
+      directory = "/some/directory",
+    },
+    {
+      type         = "git_clone"
+      repository   = "https://github.com/some/repo"
+      branch       = "main"
+      access_token = "123abc"
+    },
+    {
+      type     = "pull_from_s3",
+      requires = "prefect-aws>=0.3.4"
+      bucket   = "some-bucket",
+      folder   = "some-folder",
+    }
+  ]
   storage_document_id = prefect_block.test_gh_repository.id
   version             = "v1.1.1"
   work_pool_name      = "some-testing-pool"
@@ -88,6 +106,7 @@ resource "prefect_deployment" "deployment" {
 - `parameters` (String) Parameters for flow runs scheduled by the deployment.
 - `path` (String) The path to the working directory for the workflow, relative to remote storage or an absolute path.
 - `paused` (Boolean) Whether or not the deployment is paused.
+- `pull_steps` (Attributes List) Pull steps to prepare flows for a deployment run. (see [below for nested schema](#nestedatt--pull_steps))
 - `storage_document_id` (String) ID of the associated storage document (UUID)
 - `tags` (List of String) Tags associated with the deployment
 - `version` (String) An optional version for the deployment.
@@ -100,6 +119,24 @@ resource "prefect_deployment" "deployment" {
 - `created` (String) Timestamp of when the resource was created (RFC3339)
 - `id` (String) Workspace ID (UUID)
 - `updated` (String) Timestamp of when the resource was updated (RFC3339)
+
+<a id="nestedatt--pull_steps"></a>
+### Nested Schema for `pull_steps`
+
+Required:
+
+- `type` (String) The type of pull step
+
+Optional:
+
+- `access_token` (String) Access token for the repository.
+- `branch` (String) The branch to clone. If not provided, the default branch is used.
+- `bucket` (String) The name of the bucket where files are stored.
+- `credentials` (String) Credentials to use for the pull step.
+- `directory` (String) The directory to set as the working directory.
+- `folder` (String) The folder in the bucket where files are stored.
+- `repository` (String) The URL of the repository to clone.
+- `requires` (String) A list of Python package dependencies.
 
 ## Import
 

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -129,13 +129,13 @@ Required:
 
 Optional:
 
-- `access_token` (String) Access token for the repository. Refer to a credentials block for security purposes. Used in leiu of 'credentials'.
-- `branch` (String) The branch to clone. If not provided, the default branch is used.
-- `bucket` (String) The name of the bucket where files are stored.
+- `access_token` (String) (For type 'git_clone') Access token for the repository. Refer to a credentials block for security purposes. Used in leiu of 'credentials'.
+- `branch` (String) (For type 'git_clone') The branch to clone. If not provided, the default branch is used.
+- `bucket` (String) (For type 'pull_from_*') The name of the bucket where files are stored.
 - `credentials` (String) Credentials to use for the pull step. Refer to a {GitHub,GitLab,BitBucket} credentials block.
-- `directory` (String) The directory to set as the working directory.
-- `folder` (String) The folder in the bucket where files are stored.
-- `repository` (String) The URL of the repository to clone.
+- `directory` (String) (For type 'set_working_directory') The directory to set as the working directory.
+- `folder` (String) (For type 'pull_from_*') The folder in the bucket where files are stored.
+- `repository` (String) (For type 'git_clone') The URL of the repository to clone.
 - `requires` (String) A list of Python package dependencies.
 
 ## Import

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -129,10 +129,10 @@ Required:
 
 Optional:
 
-- `access_token` (String) Access token for the repository.
+- `access_token` (String) Access token for the repository. Refer to a credentials block for security purposes. Used in leiu of 'credentials'.
 - `branch` (String) The branch to clone. If not provided, the default branch is used.
 - `bucket` (String) The name of the bucket where files are stored.
-- `credentials` (String) Credentials to use for the pull step.
+- `credentials` (String) Credentials to use for the pull step. Refer to a {GitHub,GitLab,BitBucket} credentials block.
 - `directory` (String) The directory to set as the working directory.
 - `folder` (String) The folder in the bucket where files are stored.
 - `repository` (String) The URL of the repository to clone.

--- a/examples/resources/prefect_deployment/resource.tf
+++ b/examples/resources/prefect_deployment/resource.tf
@@ -44,8 +44,26 @@ resource "prefect_deployment" "deployment" {
       "some-parameter2" : { "type" : "string" }
     }
   })
-  path                = "./foo/bar"
-  paused              = false
+  path   = "./foo/bar"
+  paused = false
+  pull_steps = [
+    {
+      type      = "set_working_directory",
+      directory = "/some/directory",
+    },
+    {
+      type         = "git_clone"
+      repository   = "https://github.com/some/repo"
+      branch       = "main"
+      access_token = "123abc"
+    },
+    {
+      type     = "pull_from_s3",
+      requires = "prefect-aws>=0.3.4"
+      bucket   = "some-bucket",
+      folder   = "some-folder",
+    }
+  ]
   storage_document_id = prefect_block.test_gh_repository.id
   version             = "v1.1.1"
   work_pool_name      = "some-testing-pool"

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -32,6 +32,7 @@ type Deployment struct {
 	Parameters             map[string]interface{} `json:"parameters,omitempty"`
 	Path                   string                 `json:"path"`
 	Paused                 bool                   `json:"paused"`
+	PullSteps              []PullStep             `json:"pull_steps,omitempty"`
 	StorageDocumentID      uuid.UUID              `json:"storage_document_id,omitempty"`
 	Tags                   []string               `json:"tags"`
 	Version                string                 `json:"version,omitempty"`
@@ -52,6 +53,7 @@ type DeploymentCreate struct {
 	Parameters             map[string]interface{} `json:"parameters,omitempty"`
 	Path                   string                 `json:"path,omitempty"`
 	Paused                 bool                   `json:"paused,omitempty"`
+	PullSteps              []PullStep             `json:"pull_steps,omitempty"`
 	StorageDocumentID      *uuid.UUID             `json:"storage_document_id,omitempty"`
 	Tags                   []string               `json:"tags,omitempty"`
 	Version                string                 `json:"version,omitempty"`
@@ -69,9 +71,59 @@ type DeploymentUpdate struct {
 	Parameters             map[string]interface{} `json:"parameters,omitempty"`
 	Path                   string                 `json:"path,omitempty"`
 	Paused                 bool                   `json:"paused,omitempty"`
+	PullSteps              []PullStep             `json:"pull_steps,omitempty"`
 	StorageDocumentID      *uuid.UUID             `json:"storage_document_id,omitempty"`
 	Tags                   []string               `json:"tags,omitempty"`
 	Version                string                 `json:"version,omitempty"`
 	WorkPoolName           string                 `json:"work_pool_name,omitempty"`
 	WorkQueueName          string                 `json:"work_queue_name,omitempty"`
+}
+
+// PullStep contains instructions for preparing your flows for a deployment run.
+type PullStep struct {
+	// Type is the type of pull step.
+	// One of:
+	// - set_working_directory
+	// - git_clone
+	// - pull_from_azure_blob_storage
+	// - pull_from_gcs
+	// - pull_from_s3
+	Type string `json:"type"`
+
+	// Credentials is the credentials to use for the pull step.
+	// Used on all PullStep types.
+	Credentials *string `json:"credentials,omitempty"`
+
+	// Requires is a list of Python package dependencies.
+	Requires *string `json:"requires,omitempty"`
+
+	//
+	// Fields for set_working_directory
+	//
+
+	// The directory to set as the working directory.
+	Directory *string `json:"directory,omitempty"`
+
+	//
+	// Fields for git_clone
+	//
+
+	// The URL of the repository to clone.
+	Repository *string `json:"repository,omitempty"`
+
+	// The branch to clone. If not provided, the default branch is used.
+	Branch *string `json:"branch,omitempty"`
+
+	// Access token for the repository.
+	AccessToken *string `json:"access_token,omitempty"`
+
+	//
+	// Fields for pull_from_{cloud}
+	//
+
+	// The name of the bucket where files are stored.
+	Bucket *string `json:"bucket,omitempty"`
+
+	// The folder in the bucket where files are stored.
+	Folder *string `json:"folder,omitempty"`
 }

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -355,27 +355,27 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 							Optional:    true,
 						},
 						"directory": schema.StringAttribute{
-							Description: "The directory to set as the working directory.",
+							Description: "(For type 'set_working_directory') The directory to set as the working directory.",
 							Optional:    true,
 						},
 						"repository": schema.StringAttribute{
-							Description: "The URL of the repository to clone.",
+							Description: "(For type 'git_clone') The URL of the repository to clone.",
 							Optional:    true,
 						},
 						"branch": schema.StringAttribute{
-							Description: "The branch to clone. If not provided, the default branch is used.",
+							Description: "(For type 'git_clone') The branch to clone. If not provided, the default branch is used.",
 							Optional:    true,
 						},
 						"access_token": schema.StringAttribute{
-							Description: "Access token for the repository. Refer to a credentials block for security purposes. Used in leiu of 'credentials'.",
+							Description: "(For type 'git_clone') Access token for the repository. Refer to a credentials block for security purposes. Used in leiu of 'credentials'.",
 							Optional:    true,
 						},
 						"bucket": schema.StringAttribute{
-							Description: "The name of the bucket where files are stored.",
+							Description: "(For type 'pull_from_*') The name of the bucket where files are stored.",
 							Optional:    true,
 						},
 						"folder": schema.StringAttribute{
-							Description: "The folder in the bucket where files are stored.",
+							Description: "(For type 'pull_from_*') The folder in the bucket where files are stored.",
 							Optional:    true,
 						},
 					},

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -312,7 +312,7 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Computed:    true,
 				PlanModifiers: []planmodifier.List{
 					// Pull steps are only set on create, so any change in their value will require a resource
-					// of the resource.
+					// of the resource. See https://github.com/PrefectHQ/prefect/issues/11052 for more context.
 					listplanmodifier.RequiresReplace(),
 				},
 				Default: listdefault.StaticValue(basetypes.NewListValueMust(
@@ -347,7 +347,7 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 							},
 						},
 						"credentials": schema.StringAttribute{
-							Description: "Credentials to use for the pull step.",
+							Description: "Credentials to use for the pull step. Refer to a {GitHub,GitLab,BitBucket} credentials block.",
 							Optional:    true,
 						},
 						"requires": schema.StringAttribute{
@@ -367,7 +367,7 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 							Optional:    true,
 						},
 						"access_token": schema.StringAttribute{
-							Description: "Access token for the repository.",
+							Description: "Access token for the repository. Refer to a credentials block for security purposes. Used in leiu of 'credentials'.",
 							Optional:    true,
 						},
 						"bucket": schema.StringAttribute{

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -309,6 +310,11 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Description: "Pull steps to prepare flows for a deployment run.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.List{
+					// Pull steps are only set on create, so any change in their value will require a resource
+					// of the resource.
+					listplanmodifier.RequiresReplace(),
+				},
 				Default: listdefault.StaticValue(basetypes.NewListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -629,13 +629,6 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 	model.ParameterOpenAPISchema = jsontypes.NewNormalizedValue(string(parameterOpenAPISchemaByteSlice))
 
-	pullSteps, diags := mapPullStepsAPIToTerraform(deployment.PullSteps)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	model.PullSteps = pullSteps
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
Adds support for pull steps on the deployments resource.

Closes https://linear.app/prefect/issue/PLA-441/deployments-support-pull-steps

## References
- https://docs.prefect.io/v3/deploy/infrastructure-concepts/prefect-yaml#the-pull-action
- https://developer.hashicorp.com/terraform/plugin/framework/resources/validate-configuration
- https://developer.hashicorp.com/terraform/plugin/framework/providers/validate-configuration
- https://developer.hashicorp.com/terraform/plugin/framework/handling-data/paths
- https://developer.hashicorp.com/terraform/plugin/framework/handling-data/path-expressions