### PR TITLE
fix(automations): use req.Plan in Create() for default value

### DIFF
--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -69,7 +69,7 @@ type DeploymentCreate struct {
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
 type DeploymentUpdate struct {
 	ConcurrencyLimit       *int64                 `json:"concurrency_limit,omitempty"`
-	ConcurrencyOptions     *ConcurrencyOptions    `json:"concurrency_options,omitempty"`
+	ConcurrencyOptions     *ConcurrencyOptions    `json:"concurrency_options"`
 	Description            string                 `json:"description,omitempty"`
 	EnforceParameterSchema bool                   `json:"enforce_parameter_schema,omitempty"`
 	Entrypoint             string                 `json:"entrypoint,omitempty"`

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -133,7 +133,9 @@ func request(ctx context.Context, client *http.Client, cfg requestConfig) (*http
 	}
 
 	if !success {
-		return nil, fmt.Errorf("status code %s", resp.Status)
+		body, _ := io.ReadAll(resp.Body)
+
+		return nil, fmt.Errorf("status code=%s, error=%s", resp.Status, body)
 	}
 
 	return resp, nil

--- a/internal/provider/resources/automation_resource.go
+++ b/internal/provider/resources/automation_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
@@ -179,8 +178,6 @@ func (r *AutomationResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	tflog.Info(ctx, fmt.Sprintf("planID: %+v", plan.ID.ValueString()))
 
 	automationID, err := uuid.Parse(plan.ID.ValueString())
 	if err != nil {
@@ -494,9 +491,6 @@ func mapAutomationTerraformToAPI(ctx context.Context, apiAutomation *api.Automat
 	apiAutomation.Name = tfModel.Name.ValueString()
 	apiAutomation.Description = tfModel.Description.ValueString()
 	apiAutomation.Enabled = tfModel.Enabled.ValueBool()
-
-	tflog.Info(ctx, fmt.Sprintf("apiAutomation.Enabled: %+v", apiAutomation.Enabled))
-	tflog.Info(ctx, fmt.Sprintf("tfModel.Enabled: %+v", tfModel.Enabled.ValueBool()))
 
 	// Map actions
 	actions, diagnostics := mapActionsTerraformToAPI(tfModel.Actions)

--- a/internal/provider/resources/automation_resource.go
+++ b/internal/provider/resources/automation_resource.go
@@ -79,7 +79,7 @@ func (r *AutomationResource) Create(ctx context.Context, req resource.CreateRequ
 	var plan AutomationResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -494,6 +494,9 @@ func mapAutomationTerraformToAPI(ctx context.Context, apiAutomation *api.Automat
 	apiAutomation.Name = tfModel.Name.ValueString()
 	apiAutomation.Description = tfModel.Description.ValueString()
 	apiAutomation.Enabled = tfModel.Enabled.ValueBool()
+
+	tflog.Info(ctx, fmt.Sprintf("apiAutomation.Enabled: %+v", apiAutomation.Enabled))
+	tflog.Info(ctx, fmt.Sprintf("tfModel.Enabled: %+v", tfModel.Enabled.ValueBool()))
 
 	// Map actions
 	actions, diagnostics := mapActionsTerraformToAPI(tfModel.Actions)

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -527,7 +527,7 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	var plan DeploymentResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -238,6 +239,7 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Optional:    true,
 				Computed:    true,
 				CustomType:  jsontypes.NormalizedType{},
+				Default:     stringdefault.StaticString("{}"),
 			},
 			"work_queue_name": schema.StringAttribute{
 				Description: "The work queue for the deployment. If no work queue is set, work will not be scheduled.",
@@ -299,12 +301,14 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Optional:    true,
 				Computed:    true,
 				CustomType:  jsontypes.NormalizedType{},
+				Default:     stringdefault.StaticString("{}"),
 			},
 			"parameter_openapi_schema": schema.StringAttribute{
 				Description: "The parameter schema of the flow, including defaults.",
 				Optional:    true,
 				Computed:    true,
 				CustomType:  jsontypes.NormalizedType{},
+				Default:     stringdefault.StaticString("{}"),
 				// OpenAPI schema is also only set on create, and
 				// we do not support modifying this value. Therefore, any changes
 				// to this attribute will force a replacement.
@@ -315,7 +319,6 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			"concurrency_limit": schema.Int64Attribute{
 				Description: "The deployment's concurrency limit.",
 				Optional:    true,
-				Computed:    true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),
 				},
@@ -323,7 +326,6 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			"concurrency_options": schema.SingleNestedAttribute{
 				Description: "Concurrency options for the deployment.",
 				Optional:    true,
-				Computed:    true,
 				Attributes: map[string]schema.Attribute{
 					"collision_strategy": schema.StringAttribute{
 						Description: "Enumeration of concurrency collision strategies.",
@@ -762,7 +764,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		WorkQueueName:          model.WorkQueueName.ValueString(),
 	}
 
-	if !model.ConcurrencyOptions.CollisionStrategy.IsNull() {
+	if model.ConcurrencyOptions != nil {
 		payload.ConcurrencyOptions = &api.ConcurrencyOptions{
 			CollisionStrategy: model.ConcurrencyOptions.CollisionStrategy.ValueString(),
 		}

--- a/internal/provider/resources/flow.go
+++ b/internal/provider/resources/flow.go
@@ -156,7 +156,7 @@ func (r *FlowResource) Create(ctx context.Context, req resource.CreateRequest, r
 	var plan FlowResourceModel
 
 	// Populate the model from resource configuration and emit diagnostics on error
-	resp.Diagnostics.Append(req.Config.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/resources/service_account.go
+++ b/internal/provider/resources/service_account.go
@@ -427,7 +427,7 @@ func (r *ServiceAccountResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	// Practitioners can rotate their Service Account API Key my modifying the
+	// Practitioners can rotate their Service Account API Key by modifying the
 	// `api_key_expiration` attribute. If the provided value is different than the current
 	// value, we'll call the RotateKey method on the client, which returns the
 	// ServiceAccount object with the new API Key value included in the response.


### PR DESCRIPTION
resolves https://linear.app/prefect/issue/PLA-803/errors-when-trying-to-deploy-an-automation

while investigating https://github.com/PrefectHQ/terraform-provider-prefect/issues/317, I noticed that the default value we set in the `prefect_automation.enabled` resource schema attribute wasn't being respected.  We set it to be `true` if no user configuration is provided, but the user submitting #317 ran into an issue where omitting the `enabled` flag was causing a state value conflict - the API was returning `false`, because we were sending a `false`

It looks like we mistakenly used `req.Config` in the `Create()` method to pull the HCL configuration, when we should be using `req.Plan`
- `req.Config` - raw, user-inputted configuration (so the `enabled` flag wouldn't be set).  Will be missing any computed/interpolated values as well
- `req.Plan` - the full computed plan, which incorporates any schema defaults

We also do this in `deployment` and `flow` resource schemas - when we look at the TF plugin framework docs, it looks like:
- [Create()](https://developer.hashicorp.com/terraform/plugin/framework/resources/create#define-create-method) uses `req.Plan`
- [Update()](https://developer.hashicorp.com/terraform/plugin/framework/resources/update#define-update-method) uses `req.Plan`
- [Read()](https://developer.hashicorp.com/terraform/plugin/framework/resources/read#define-read-method) uses `req.State`
- [Delete()](https://developer.hashicorp.com/terraform/plugin/framework/resources/delete) uses `req.State`

[Additionally, this section in the framework docs calls out](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values) using either `req.Plan` or `req.State` to access values for different situations. `req.Config` is not mentioned  

Net net, we should only use `req.Config` for certain situations when we need access to the raw user input.  Otherwise, we should be using `req.Plan` and `req.State` to reference the fully computed plan (or serialized state)