### PR TITLE
feat(deployments): support multiple schedules

### DIFF
--- a/docs/resources/deployment_schedule.md
+++ b/docs/resources/deployment_schedule.md
@@ -3,12 +3,12 @@
 page_title: "prefect_deployment_schedule Resource - prefect"
 subcategory: ""
 description: |-
-  The resource deployment_schedule represents a schedule for a deployment. Note that only one schedule is supported per deployment. Support for multiple schedules is planned.
+  The resource deployment_schedule represents a schedule for a deployment.
 ---
 
 # prefect_deployment_schedule (Resource)
 
-The resource `deployment_schedule` represents a schedule for a deployment. Note that only one schedule is supported per deployment. Support for multiple schedules is planned.
+The resource `deployment_schedule` represents a schedule for a deployment.
 
 ## Example Usage
 
@@ -31,7 +31,7 @@ resource "prefect_deployment" "test" {
   flow_id      = prefect_flow.test.id
 }
 
-resource "prefect_deployment_schedule" "test" {
+resource "prefect_deployment_schedule" "test_interval" {
   workspace_id  = data.prefect_workspace.test.id
   deployment_id = prefect_deployment.test.id
 
@@ -40,15 +40,35 @@ resource "prefect_deployment_schedule" "test" {
   max_active_runs = 10
   timezone        = "America/New_York"
 
-  # Option: Interval schedule
+  # Interval-specific fields
   interval    = 30
   anchor_date = "2024-01-01T00:00:00Z"
+}
 
-  # Option: Cron schedule
+resource "prefect_deployment_schedule" "test_cron" {
+  workspace_id  = data.prefect_workspace.test.id
+  deployment_id = prefect_deployment.test.id
+
+  active          = true
+  catchup         = false
+  max_active_runs = 10
+  timezone        = "America/New_York"
+
+  # Cron-specific fields
   cron   = "0 0 * * *"
   day_or = true
+}
 
-  # Option: RRule schedule
+resource "prefect_deployment_schedule" "test_rrule" {
+  workspace_id  = data.prefect_workspace.test.id
+  deployment_id = prefect_deployment.test.id
+
+  active          = true
+  catchup         = false
+  max_active_runs = 10
+  timezone        = "America/New_York"
+
+  # RRule-specific fields
   rrule = "FREQ=DAILY;INTERVAL=1"
 }
 ```

--- a/examples/resources/prefect_deployment_schedule/resource.tf
+++ b/examples/resources/prefect_deployment_schedule/resource.tf
@@ -16,7 +16,7 @@ resource "prefect_deployment" "test" {
   flow_id      = prefect_flow.test.id
 }
 
-resource "prefect_deployment_schedule" "test" {
+resource "prefect_deployment_schedule" "test_interval" {
   workspace_id  = data.prefect_workspace.test.id
   deployment_id = prefect_deployment.test.id
 
@@ -25,15 +25,35 @@ resource "prefect_deployment_schedule" "test" {
   max_active_runs = 10
   timezone        = "America/New_York"
 
-  # Option: Interval schedule
+  # Interval-specific fields
   interval    = 30
   anchor_date = "2024-01-01T00:00:00Z"
+}
 
-  # Option: Cron schedule
+resource "prefect_deployment_schedule" "test_cron" {
+  workspace_id  = data.prefect_workspace.test.id
+  deployment_id = prefect_deployment.test.id
+
+  active          = true
+  catchup         = false
+  max_active_runs = 10
+  timezone        = "America/New_York"
+
+  # Cron-specific fields
   cron   = "0 0 * * *"
   day_or = true
+}
 
-  # Option: RRule schedule
+resource "prefect_deployment_schedule" "test_rrule" {
+  workspace_id  = data.prefect_workspace.test.id
+  deployment_id = prefect_deployment.test.id
+
+  active          = true
+  catchup         = false
+  max_active_runs = 10
+  timezone        = "America/New_York"
+
+  # RRule-specific fields
   rrule = "FREQ=DAILY;INTERVAL=1"
 }
 

--- a/internal/provider/helpers/base_model.go
+++ b/internal/provider/helpers/base_model.go
@@ -1,0 +1,11 @@
+package helpers
+
+import "github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
+
+// BaseModel is embedded in all other types and defines fields
+// common to all Prefect data models.
+type BaseModel struct {
+	ID      customtypes.UUIDValue      `tfsdk:"id"`
+	Created customtypes.TimestampValue `tfsdk:"created"`
+	Updated customtypes.TimestampValue `tfsdk:"updated"`
+}

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -22,9 +22,7 @@ type DeploymentScheduleResource struct {
 }
 
 type DeploymentScheduleResourceModel struct {
-	ID      customtypes.UUIDValue      `tfsdk:"id"`
-	Created customtypes.TimestampValue `tfsdk:"created"`
-	Updated customtypes.TimestampValue `tfsdk:"updated"`
+	helpers.BaseModel
 
 	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
 	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -81,9 +81,8 @@ func (r *DeploymentScheduleResource) Configure(_ context.Context, req resource.C
 
 func (r *DeploymentScheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "The resource `deployment_schedule` represents a schedule for a deployment. " +
-			"Note that only one schedule is supported per deployment. Support for multiple schedules is planned.",
-		Version: 0,
+		Description: "The resource `deployment_schedule` represents a schedule for a deployment.",
+		Version:     0,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,


### PR DESCRIPTION
## Summary

Supports multiple schedules per deployment.

The list schedules returned by Create should only include the schedule
associated with that resource, rather than all schedules on the
deployment, so we can use that to create the schedule and then persist
the correct one to the state.

Then for Read calls, we can get the correct schedule by ID.

Related to https://linear.app/prefect/issue/PLA-772/deployments-support-multiple-schedules

## Testing

You can deploy the example configuration and check the Deployment in the UI:

<img width="260" alt="image" src="https://github.com/user-attachments/assets/9b530de4-9dbb-441d-86c5-0133771a4f53">

I also tested changing one of the schedule values, `active`, and confirmed it updated the correct schedule:

<img width="267" alt="image" src="https://github.com/user-attachments/assets/13d34b77-90ba-4b40-a097-1187ee222509">
