### PR TITLE
chore: move common fields into BaseModel types

### DIFF
--- a/internal/provider/datasources/account.go
+++ b/internal/provider/datasources/account.go
@@ -22,9 +22,7 @@ type AccountDataSource struct {
 
 // AccountDataSourceModel defines the Terraform data source model.
 type AccountDataSourceModel struct {
-	ID      customtypes.UUIDValue      `tfsdk:"id"`
-	Created customtypes.TimestampValue `tfsdk:"created"`
-	Updated customtypes.TimestampValue `tfsdk:"updated"`
+	helpers.BaseModel
 
 	Name         types.String `tfsdk:"name"`
 	Handle       types.String `tfsdk:"handle"`

--- a/internal/provider/datasources/account.go
+++ b/internal/provider/datasources/account.go
@@ -22,7 +22,7 @@ type AccountDataSource struct {
 
 // AccountDataSourceModel defines the Terraform data source model.
 type AccountDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	Name         types.String `tfsdk:"name"`
 	Handle       types.String `tfsdk:"handle"`

--- a/internal/provider/datasources/account_role.go
+++ b/internal/provider/datasources/account_role.go
@@ -25,7 +25,7 @@ type AccountRoleDataSource struct {
 // AccountRoleDataSource defines the Terraform data source model
 // the TF data source configuration will be unmarshalled into this struct.
 type AccountRoleDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	Name         types.String          `tfsdk:"name"`
 	Permissions  types.List            `tfsdk:"permissions"`

--- a/internal/provider/datasources/account_role.go
+++ b/internal/provider/datasources/account_role.go
@@ -25,9 +25,7 @@ type AccountRoleDataSource struct {
 // AccountRoleDataSource defines the Terraform data source model
 // the TF data source configuration will be unmarshalled into this struct.
 type AccountRoleDataSourceModel struct {
-	ID      customtypes.UUIDValue      `tfsdk:"id"`
-	Created customtypes.TimestampValue `tfsdk:"created"`
-	Updated customtypes.TimestampValue `tfsdk:"updated"`
+	helpers.BaseModel
 
 	Name         types.String          `tfsdk:"name"`
 	Permissions  types.List            `tfsdk:"permissions"`

--- a/internal/provider/datasources/automation_model.go
+++ b/internal/provider/datasources/automation_model.go
@@ -4,12 +4,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 // AutomationResourceModel defines the Terraform resource model.
 type AutomationDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
 	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`

--- a/internal/provider/datasources/automation_model.go
+++ b/internal/provider/datasources/automation_model.go
@@ -4,15 +4,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 // AutomationResourceModel defines the Terraform resource model.
 type AutomationDataSourceModel struct {
-	ID          customtypes.UUIDValue      `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	helpers.BaseModel
+
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
 	Name        types.String  `tfsdk:"name"`
 	Description types.String  `tfsdk:"description"`

--- a/internal/provider/datasources/base_model.go
+++ b/internal/provider/datasources/base_model.go
@@ -1,4 +1,4 @@
-package helpers
+package datasources
 
 import "github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
 

--- a/internal/provider/datasources/block.go
+++ b/internal/provider/datasources/block.go
@@ -26,7 +26,7 @@ type blockDataSource struct {
 
 // BlockDataSourceModel defines the Terraform data source model.
 type BlockDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
 	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`

--- a/internal/provider/datasources/block.go
+++ b/internal/provider/datasources/block.go
@@ -26,11 +26,10 @@ type blockDataSource struct {
 
 // BlockDataSourceModel defines the Terraform data source model.
 type BlockDataSourceModel struct {
-	ID          customtypes.UUIDValue      `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	helpers.BaseModel
+
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
 	Name     types.String         `tfsdk:"name"`
 	Data     jsontypes.Normalized `tfsdk:"data"`

--- a/internal/provider/datasources/deployment.go
+++ b/internal/provider/datasources/deployment.go
@@ -331,9 +331,11 @@ func copyDeploymentToModel(ctx context.Context, deployment *api.Deployment, mode
 	// type because struct embedding does not automatically make the embedding
 	// struct convertible to the embedded type.
 	compatibleModel := &resources.DeploymentResourceModel{
-		ID:      model.ID,
-		Created: model.Created,
-		Updated: model.Updated,
+		BaseModel: resources.BaseModel{
+			ID:      model.ID,
+			Created: model.Created,
+			Updated: model.Updated,
+		},
 
 		AccountID:              model.AccountID,
 		ConcurrencyLimit:       model.ConcurrencyLimit,

--- a/internal/provider/datasources/service_account.go
+++ b/internal/provider/datasources/service_account.go
@@ -22,9 +22,7 @@ type ServiceAccountDataSource struct {
 
 // ServiceAccountDataSourceModel defines the Terraform data source model.
 type ServiceAccountDataSourceModel struct {
-	ID      customtypes.UUIDValue      `tfsdk:"id"`
-	Created customtypes.TimestampValue `tfsdk:"created"`
-	Updated customtypes.TimestampValue `tfsdk:"updated"`
+	helpers.BaseModel
 
 	Name            types.String          `tfsdk:"name"`
 	ActorID         customtypes.UUIDValue `tfsdk:"actor_id"`

--- a/internal/provider/datasources/service_account.go
+++ b/internal/provider/datasources/service_account.go
@@ -22,7 +22,7 @@ type ServiceAccountDataSource struct {
 
 // ServiceAccountDataSourceModel defines the Terraform data source model.
 type ServiceAccountDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	Name            types.String          `tfsdk:"name"`
 	ActorID         customtypes.UUIDValue `tfsdk:"actor_id"`

--- a/internal/provider/datasources/team.go
+++ b/internal/provider/datasources/team.go
@@ -21,7 +21,7 @@ type TeamDataSource struct {
 }
 
 type TeamDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`

--- a/internal/provider/datasources/team.go
+++ b/internal/provider/datasources/team.go
@@ -21,11 +21,10 @@ type TeamDataSource struct {
 }
 
 type TeamDataSourceModel struct {
-	ID          customtypes.UUIDValue      `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	Name        types.String               `tfsdk:"name"`
-	Description types.String               `tfsdk:"description"`
+	helpers.BaseModel
+
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
 
 	AccountID customtypes.UUIDValue `tfsdk:"account_id"`
 }

--- a/internal/provider/datasources/variable.go
+++ b/internal/provider/datasources/variable.go
@@ -27,7 +27,7 @@ type VariableDataSource struct {
 
 // VariableDataSourceModel defines the Terraform data source model.
 type VariableDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
 	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`

--- a/internal/provider/datasources/variable.go
+++ b/internal/provider/datasources/variable.go
@@ -27,11 +27,10 @@ type VariableDataSource struct {
 
 // VariableDataSourceModel defines the Terraform data source model.
 type VariableDataSourceModel struct {
-	ID          customtypes.UUIDValue      `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	helpers.BaseModel
+
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
 	Name  types.String  `tfsdk:"name"`
 	Value types.Dynamic `tfsdk:"value"`

--- a/internal/provider/datasources/work_pool.go
+++ b/internal/provider/datasources/work_pool.go
@@ -25,7 +25,7 @@ type WorkPoolDataSource struct {
 
 // WorkPoolDataSourceModel defines the Terraform data source model.
 type WorkPoolDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
 	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`

--- a/internal/provider/datasources/work_pool.go
+++ b/internal/provider/datasources/work_pool.go
@@ -25,11 +25,10 @@ type WorkPoolDataSource struct {
 
 // WorkPoolDataSourceModel defines the Terraform data source model.
 type WorkPoolDataSourceModel struct {
-	ID          customtypes.UUIDValue      `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	helpers.BaseModel
+
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
 	Name             types.String          `tfsdk:"name"`
 	Description      types.String          `tfsdk:"description"`

--- a/internal/provider/datasources/workspace.go
+++ b/internal/provider/datasources/workspace.go
@@ -23,7 +23,7 @@ type WorkspaceDataSource struct {
 
 // WorkspaceDataSourceModel defines the Terraform data source model.
 type WorkspaceDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	AccountID customtypes.UUIDValue `tfsdk:"account_id"`
 

--- a/internal/provider/datasources/workspace.go
+++ b/internal/provider/datasources/workspace.go
@@ -23,10 +23,9 @@ type WorkspaceDataSource struct {
 
 // WorkspaceDataSourceModel defines the Terraform data source model.
 type WorkspaceDataSourceModel struct {
-	ID        customtypes.UUIDValue      `tfsdk:"id"`
-	Created   customtypes.TimestampValue `tfsdk:"created"`
-	Updated   customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID customtypes.UUIDValue      `tfsdk:"account_id"`
+	helpers.BaseModel
+
+	AccountID customtypes.UUIDValue `tfsdk:"account_id"`
 
 	Name        types.String `tfsdk:"name"`
 	Handle      types.String `tfsdk:"handle"`

--- a/internal/provider/datasources/workspace_role.go
+++ b/internal/provider/datasources/workspace_role.go
@@ -23,9 +23,7 @@ type WorkspaceRoleDataSource struct {
 // WorkspaceRoleDataSourceModel defines the Terraform data source model
 // the TF data source configuration will be unmarshalled into this struct.
 type WorkspaceRoleDataSourceModel struct {
-	ID      customtypes.UUIDValue      `tfsdk:"id"`
-	Created customtypes.TimestampValue `tfsdk:"created"`
-	Updated customtypes.TimestampValue `tfsdk:"updated"`
+	helpers.BaseModel
 
 	Name            types.String          `tfsdk:"name"`
 	Description     types.String          `tfsdk:"description"`

--- a/internal/provider/datasources/workspace_role.go
+++ b/internal/provider/datasources/workspace_role.go
@@ -23,7 +23,7 @@ type WorkspaceRoleDataSource struct {
 // WorkspaceRoleDataSourceModel defines the Terraform data source model
 // the TF data source configuration will be unmarshalled into this struct.
 type WorkspaceRoleDataSourceModel struct {
-	helpers.BaseModel
+	BaseModel
 
 	Name            types.String          `tfsdk:"name"`
 	Description     types.String          `tfsdk:"description"`

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -32,9 +32,7 @@ type AccountResource struct {
 
 // AccountResourceModel defines the Terraform resource model.
 type AccountResourceModel struct {
-	ID      types.String               `tfsdk:"id"`
-	Created customtypes.TimestampValue `tfsdk:"created"`
-	Updated customtypes.TimestampValue `tfsdk:"updated"`
+	BaseModel
 
 	Name         types.String `tfsdk:"name"`
 	Handle       types.String `tfsdk:"handle"`

--- a/internal/provider/resources/automation_model.go
+++ b/internal/provider/resources/automation_model.go
@@ -8,11 +8,10 @@ import (
 
 // AutomationResourceModel defines the Terraform resource model.
 type AutomationResourceModel struct {
-	ID          types.String               `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	BaseModel
+
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`

--- a/internal/provider/resources/base_model.go
+++ b/internal/provider/resources/base_model.go
@@ -1,0 +1,14 @@
+package resources
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
+)
+
+// BaseModel is embedded in all other types and defines fields
+// common to all Prefect data models.
+type BaseModel struct {
+	ID      types.String               `tfsdk:"id"`
+	Created customtypes.TimestampValue `tfsdk:"created"`
+	Updated customtypes.TimestampValue `tfsdk:"updated"`
+}

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -26,11 +26,10 @@ type BlockResource struct {
 }
 
 type BlockResourceModel struct {
-	ID          types.String               `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	BaseModel
+
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
 	Name     types.String         `tfsdk:"name"`
 	TypeSlug types.String         `tfsdk:"type_slug"`

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -42,9 +42,7 @@ type DeploymentResource struct {
 
 // DeploymentResourceModel defines the Terraform resource model.
 type DeploymentResourceModel struct {
-	ID      types.String               `tfsdk:"id"`
-	Created customtypes.TimestampValue `tfsdk:"created"`
-	Updated customtypes.TimestampValue `tfsdk:"updated"`
+	BaseModel
 
 	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
 	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -22,7 +22,11 @@ type DeploymentScheduleResource struct {
 }
 
 type DeploymentScheduleResourceModel struct {
-	helpers.BaseModel
+	// This model uses UUIDValue for the ID type, while most other
+	// resources use types.String. This may eventually be made consistent.
+	ID      customtypes.UUIDValue      `tfsdk:"id"`
+	Created customtypes.TimestampValue `tfsdk:"created"`
+	Updated customtypes.TimestampValue `tfsdk:"updated"`
 
 	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
 	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`

--- a/internal/provider/resources/flow.go
+++ b/internal/provider/resources/flow.go
@@ -34,11 +34,10 @@ type FlowResource struct {
 
 // FlowResourceModel defines the Terraform resource model.
 type FlowResourceModel struct {
-	ID          types.String               `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
+	BaseModel
+
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
 
 	Name types.String `tfsdk:"name"`
 	Tags types.List   `tfsdk:"tags"`

--- a/internal/provider/resources/service_account.go
+++ b/internal/provider/resources/service_account.go
@@ -38,9 +38,7 @@ type ServiceAccountResource struct {
 }
 
 type ServiceAccountResourceModel struct {
-	ID      types.String               `tfsdk:"id"`
-	Created customtypes.TimestampValue `tfsdk:"created"`
-	Updated customtypes.TimestampValue `tfsdk:"updated"`
+	BaseModel
 
 	Name            types.String          `tfsdk:"name"`
 	ActorID         customtypes.UUIDValue `tfsdk:"actor_id"`

--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -43,11 +43,10 @@ type VariableResource struct {
 //
 // V0: Value is types.String.
 type VariableResourceModelV0 struct {
-	ID          types.String               `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	BaseModel
+
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
 	Name  types.String `tfsdk:"name"`
 	Value types.String `tfsdk:"value"`
@@ -56,11 +55,10 @@ type VariableResourceModelV0 struct {
 
 // V1: Value is types.Dynamic.
 type VariableResourceModelV1 struct {
-	ID          types.String               `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	BaseModel
+
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
 	Name  types.String  `tfsdk:"name"`
 	Value types.Dynamic `tfsdk:"value"`
@@ -197,9 +195,11 @@ func (r *VariableResource) UpgradeState(_ context.Context) map[int64]resource.St
 				// that is tied to the old schema version, we need to copy
 				// the existing state into the new schema version.
 				upgradedStateData := VariableResourceModelV1{
-					ID:          priorStateData.ID,
-					Created:     priorStateData.Created,
-					Updated:     priorStateData.Updated,
+					BaseModel: BaseModel{
+						ID:      priorStateData.ID,
+						Created: priorStateData.Created,
+						Updated: priorStateData.Updated,
+					},
 					AccountID:   priorStateData.AccountID,
 					WorkspaceID: priorStateData.WorkspaceID,
 					Name:        priorStateData.Name,

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -32,11 +32,10 @@ type WorkPoolResource struct {
 
 // WorkPoolResourceModel defines the Terraform resource model.
 type WorkPoolResourceModel struct {
-	ID          types.String               `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	BaseModel
+
+	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
 
 	Name             types.String          `tfsdk:"name"`
 	Description      types.String          `tfsdk:"description"`

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -31,10 +31,9 @@ type WorkspaceResource struct {
 
 // WorkspaceResourceModel defines the Terraform resource model.
 type WorkspaceResourceModel struct {
-	ID        types.String               `tfsdk:"id"`
-	Created   customtypes.TimestampValue `tfsdk:"created"`
-	Updated   customtypes.TimestampValue `tfsdk:"updated"`
-	AccountID customtypes.UUIDValue      `tfsdk:"account_id"`
+	BaseModel
+
+	AccountID customtypes.UUIDValue `tfsdk:"account_id"`
 
 	Name        types.String `tfsdk:"name"`
 	Handle      types.String `tfsdk:"handle"`

--- a/internal/provider/resources/workspace_role.go
+++ b/internal/provider/resources/workspace_role.go
@@ -29,9 +29,7 @@ type WorkspaceRoleResource struct {
 
 // WorkspaceRoleResourceModel defines the Terraform resource model.
 type WorkspaceRoleResourceModel struct {
-	ID      types.String               `tfsdk:"id"`
-	Created customtypes.TimestampValue `tfsdk:"created"`
-	Updated customtypes.TimestampValue `tfsdk:"updated"`
+	BaseModel
 
 	Name            types.String          `tfsdk:"name"`
 	Description     types.String          `tfsdk:"description"`


### PR DESCRIPTION
## Summary

Moves common fields (ID, Created, and Updated) into BaseModel types for resources and datasources.

This was sparked when we noticed that the type for ID was not consistent between resources (types.String) and datasources (customTypes.UUIDValue).

As a first step, this change at least reduces the repetition in each package. In a future change, we can look into using a consistent type for ID, but I believe this would require writing conversion logic similar to what we had to do in https://github.com/PrefectHQ/terraform-provider-prefect/pull/297. Tracking this in https://linear.app/prefect/issue/PLA-825/terraform-provider-make-the-id-type-consistent.