### PR TITLE
fix(deployments): refactor pull step payload structure

### DIFF
--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -91,6 +91,7 @@ Read-Only:
 - `credentials` (String) Credentials to use for the pull step. Refer to a {GitHub,GitLab,BitBucket} credentials block.
 - `directory` (String) (For type 'set_working_directory') The directory to set as the working directory.
 - `folder` (String) (For type 'pull_from_*') The folder in the bucket where files are stored.
+- `include_submodules` (Boolean) (For type 'git_clone') Whether to include submodules when cloning the repository.
 - `repository` (String) (For type 'git_clone') The URL of the repository to clone.
 - `requires` (String) A list of Python package dependencies.
 - `type` (String) The type of pull step

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -71,6 +71,7 @@ resource "prefect_deployment" "deployment" {
       repository   = "https://github.com/some/repo"
       branch       = "main"
       access_token = "123abc"
+      include_submodules = true
     },
     {
       type     = "pull_from_s3",
@@ -145,6 +146,7 @@ Optional:
 - `credentials` (String) Credentials to use for the pull step. Refer to a {GitHub,GitLab,BitBucket} credentials block.
 - `directory` (String) (For type 'set_working_directory') The directory to set as the working directory.
 - `folder` (String) (For type 'pull_from_*') The folder in the bucket where files are stored.
+- `include_submodules` (Boolean) (For type 'git_clone') Whether to include submodules when cloning the repository.
 - `repository` (String) (For type 'git_clone') The URL of the repository to clone.
 - `requires` (String) A list of Python package dependencies.
 

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -67,10 +67,10 @@ resource "prefect_deployment" "deployment" {
       directory = "/some/directory",
     },
     {
-      type         = "git_clone"
-      repository   = "https://github.com/some/repo"
-      branch       = "main"
-      access_token = "123abc"
+      type               = "git_clone"
+      repository         = "https://github.com/some/repo"
+      branch             = "main"
+      access_token       = "123abc"
       include_submodules = true
     },
     {

--- a/examples/resources/prefect_deployment/resource.tf
+++ b/examples/resources/prefect_deployment/resource.tf
@@ -52,10 +52,11 @@ resource "prefect_deployment" "deployment" {
       directory = "/some/directory",
     },
     {
-      type         = "git_clone"
-      repository   = "https://github.com/some/repo"
-      branch       = "main"
-      access_token = "123abc"
+      type               = "git_clone"
+      repository         = "https://github.com/some/repo"
+      branch             = "main"
+      access_token       = "123abc"
+      include_submodules = true
     },
     {
       type     = "pull_from_s3",

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -105,34 +105,19 @@ type GlobalConcurrencyLimit struct {
 	// SlotDecayPerSecond int    `json:"slot_decay_per_second"`
 }
 
-// PullStep contains instructions for preparing your flows for a deployment run.
-type PullStep struct {
-	// Type is the type of pull step.
-	// One of:
-	// - set_working_directory
-	// - git_clone
-	// - pull_from_azure_blob_storage
-	// - pull_from_gcs
-	// - pull_from_s3
-	Type string `json:"type"`
-
+// PullStepCommon is a representation of the common fields for certain pull steps.
+type PullStepCommon struct {
 	// Credentials is the credentials to use for the pull step.
 	// Used on all PullStep types.
 	Credentials *string `json:"credentials,omitempty"`
 
 	// Requires is a list of Python package dependencies.
 	Requires *string `json:"requires,omitempty"`
+}
 
-	//
-	// Fields for set_working_directory
-	//
-
-	// The directory to set as the working directory.
-	Directory *string `json:"directory,omitempty"`
-
-	//
-	// Fields for git_clone
-	//
+// PullStepGitClone is a representation of a pull step that clones a git repository.
+type PullStepGitClone struct {
+	PullStepCommon
 
 	// The URL of the repository to clone.
 	Repository *string `json:"repository,omitempty"`
@@ -142,14 +127,30 @@ type PullStep struct {
 
 	// Access token for the repository.
 	AccessToken *string `json:"access_token,omitempty"`
+}
 
-	//
-	// Fields for pull_from_{cloud}
-	//
+// PullStepSetWorkingDirectory is a representation of a pull step that sets the working directory.
+type PullStepSetWorkingDirectory struct {
+	// The directory to set as the working directory.
+	Directory *string `json:"directory,omitempty"`
+}
+
+// PullStepPullFrom is a representation of a pull step that pulls from a remote storage bucket.
+type PullStepPullFrom struct {
+	PullStepCommon
 
 	// The name of the bucket where files are stored.
 	Bucket *string `json:"bucket,omitempty"`
 
 	// The folder in the bucket where files are stored.
 	Folder *string `json:"folder,omitempty"`
+}
+
+// PullStep contains instructions for preparing your flows for a deployment run.
+type PullStep struct {
+	PullStepGitClone                 *PullStepGitClone            `json:"prefect.deployments.steps.git_clone,omitempty"`
+	PullStepSetWorkingDirectory      *PullStepSetWorkingDirectory `json:"prefect.deployments.steps.set_working_directory,omitempty"`
+	PullStepPullFromAzureBlobStorage *PullStepPullFrom            `json:"prefect_azure.deployments.steps.pull_from_azure_blob_storage,omitempty"`
+	PullStepPullFromGCS              *PullStepPullFrom            `json:"prefect_gcp.deployments.steps.pull_from_gcs,omitempty"`
+	PullStepPullFromS3               *PullStepPullFrom            `json:"prefect_aws.deployments.steps.pull_from_s3,omitempty"`
 }

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -127,6 +127,9 @@ type PullStepGitClone struct {
 
 	// Access token for the repository.
 	AccessToken *string `json:"access_token,omitempty"`
+
+	// IncludeSubmodules determines whether to include submodules when cloning the repository.
+	IncludeSubmodules *bool `json:"include_submodules,omitempty"`
 }
 
 // PullStepSetWorkingDirectory is a representation of a pull step that sets the working directory.

--- a/internal/provider/datasources/deployment.go
+++ b/internal/provider/datasources/deployment.go
@@ -205,6 +205,10 @@ The Deployment ID takes precedence over deployment name.
 							Computed:    true,
 							Description: "(For type 'git_clone') Access token for the repository. Refer to a credentials block for security purposes. Used in leiu of 'credentials'.",
 						},
+						"include_submodules": schema.BoolAttribute{
+							Computed:    true,
+							Description: "(For type 'git_clone') Whether to include submodules when cloning the repository.",
+						},
 						"bucket": schema.StringAttribute{
 							Computed:    true,
 							Description: "(For type 'pull_from_*') The name of the bucket where files are stored.",

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -117,6 +117,9 @@ resource "prefect_deployment" "{{.DeploymentName}}" {
 			{{-   if .AccessToken }}
 			access_token = "{{.AccessToken}}"
 			{{-   end }}
+			{{-   if .IncludeSubmodules }}
+			include_submodules = {{.IncludeSubmodules}}
+			{{-   end }}
 			{{-   if .Credentials }}
 			credentials = "{{.Credentials}}"
 			{{-   end }}
@@ -277,9 +280,10 @@ func TestAccResource_deployment(t *testing.T) {
 			},
 			{
 				PullStepGitClone: &api.PullStepGitClone{
-					Repository:  ptr.To("https://github.com/prefecthq/prefect"),
-					Branch:      ptr.To("main"),
-					AccessToken: ptr.To("123abc"),
+					Repository:        ptr.To("https://github.com/prefecthq/prefect"),
+					Branch:            ptr.To("main"),
+					AccessToken:       ptr.To("123abc"),
+					IncludeSubmodules: ptr.To(true),
 				},
 			},
 			{
@@ -432,7 +436,7 @@ func testAccCheckDeploymentValues(fetchedDeployment *api.Deployment, expectedVal
 		}
 
 		if !reflect.DeepEqual(fetchedDeployment.PullSteps, expectedValues.pullSteps) {
-			return fmt.Errorf("Expected pull steps to be %v, got %v", expectedValues.pullSteps, fetchedDeployment.PullSteps)
+			return fmt.Errorf("Expected pull steps to be: \n%v\n got \n%v", expectedValues.pullSteps, fetchedDeployment.PullSteps)
 		}
 
 		return nil

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -117,6 +117,12 @@ resource "prefect_deployment" "{{.DeploymentName}}" {
 			{{-   if .AccessToken }}
 			access_token = "{{.AccessToken}}"
 			{{-   end }}
+			{{-   if .Credentials }}
+			credentials = "{{.Credentials}}"
+			{{-   end }}
+			{{-   if .Requires }}
+			requires = "{{.Requires}}"
+			{{-   end }}
 			{{- end }}
 
 			{{- with .PullStepPullFromAzureBlobStorage }}
@@ -127,6 +133,12 @@ resource "prefect_deployment" "{{.DeploymentName}}" {
 			{{-   if .Folder }}
 			folder = "{{.Folder}}"
 			{{-   end}}
+			{{-   if .Credentials }}
+			credentials = "{{.Credentials}}"
+			{{-   end }}
+			{{-   if .Requires }}
+			requires = "{{.Requires}}"
+			{{-   end }}
 			{{- end }}
 
 			{{- with .PullStepPullFromGCS }}
@@ -137,6 +149,12 @@ resource "prefect_deployment" "{{.DeploymentName}}" {
 			{{-   if .Folder }}
 			folder = "{{.Folder}}"
 			{{-   end}}
+			{{-   if .Credentials }}
+			credentials = "{{.Credentials}}"
+			{{-   end }}
+			{{-   if .Requires }}
+			requires = "{{.Requires}}"
+			{{-   end }}
 			{{- end }}
 
 			{{- with .PullStepPullFromS3 }}
@@ -147,6 +165,12 @@ resource "prefect_deployment" "{{.DeploymentName}}" {
 			{{-   if .Folder }}
 			folder = "{{.Folder}}"
 			{{-   end}}
+			{{-   if .Credentials }}
+			credentials = "{{.Credentials}}"
+			{{-   end }}
+			{{-   if .Requires }}
+			requires = "{{.Requires}}"
+			{{-   end }}
 			{{- end }}
 		},
 		{{end}}
@@ -262,6 +286,10 @@ func TestAccResource_deployment(t *testing.T) {
 				PullStepPullFromS3: &api.PullStepPullFrom{
 					Bucket: ptr.To("some-bucket"),
 					Folder: ptr.To("some-folder"),
+					PullStepCommon: api.PullStepCommon{
+						Credentials: ptr.To("some-credentials"),
+						Requires:    ptr.To("prefect-aws>=0.3.4"),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Pull steps have a specific format in the API payload
that isn't very clearly defined by the API docs, since
the payload value is an empty list.

Looking more at the source code and documentation,
I adjusted the payload sent to the API to match the
expected format.

The format of the Terraform resource stays the same.

For reference, the incorrect format we had was:

```json
[
  {
    "type": "git_clone",
    "branch": "main",
    "repository": "https://my-git-repo.git",
    "access_token": "fake-token"
  }
]
```

The correct format is:

```json
[
  {
    "prefect.deployments.steps.git_clone": {
      "branch": "main",
      "repository": "https://my-git-repo.git",
      "access_token": "fake-token"
    }
  }
]
```

Overall changes:
* Introduced PullStepCommon to encapsulate shared fields across pull step types.
* Created specific types for PullStepGitClone, PullStepSetWorkingDirectory, and PullStepPullFrom to improve clarity and maintainability. This is where we can define the correct JSON field name for the payload.
* Updated the mapping functions to accommodate the new structure, ensuring proper handling of pull steps in both API and Terraform contexts.
* Also added `IncludeSubmodules` field, which I missed on the first pass

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/321

## Testing

### Acceptance tests

Check out the acceptance tests added in the PR.

### Manual tests

Also manually tested this to validate #321 is addressed:

1. Deployed the configuration from #321.
2. Confirmed the Deployment shows the correct Pull Step configuration:

    <img width="528" alt="image" src="https://github.com/user-attachments/assets/84a0a0b7-57a8-4f65-9fd3-639860805cd2" />

3. Clicked "Quick run" and confirmed that the flow ran successfully after cloning the repository per the pull steps:

    <img width="1068" alt="image" src="https://github.com/user-attachments/assets/0b3d4c3f-7cf0-4f32-88bf-9da8284c9b7e" />
