### PR TITLE
chore: consistently validate workspace_id

### DIFF
--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -167,3 +167,18 @@ The `tfplugindocs` CLI will:
 3. Crawl and extract all named examples in `examples/**` + add those HCL configurations into the examples section of each `.md`
 
 **NOTE:** If any documentation input files inside `examples/**` are modified, Github Actions will automatically run `make docs` and push any udpates to the working branch
+
+## Development considerations
+
+Here are some considerations to keep in mind when developing for the provider.
+
+### Prefect Cloud endpoints
+
+The provider can be configured to target a Prefect Cloud instance, or a self-hosted Prefect instance
+using the `endpoint` field.
+
+Prefect Cloud API endpoints often require a `workspace_id` to be configured, either on the provider or on the resource itself.
+A helper function named `validateCloudEndpoint` in the `internal/client` package can be used in each client creation method
+to validate that a `workspace_id` is configured, and provide an informative error if not.
+
+If the API endpoint does not require a `workspace_id`, such as `accounts`, you can omit this helper function.

--- a/internal/client/automations.go
+++ b/internal/client/automations.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 var _ = api.AutomationsClient(&AutomationsClient{})
@@ -30,8 +29,8 @@ func (c *Client) Automations(accountID uuid.UUID, workspaceID uuid.UUID) (api.Au
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if helpers.IsCloudEndpoint(c.endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
-		return nil, fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set")
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &AutomationsClient{

--- a/internal/client/block_documents.go
+++ b/internal/client/block_documents.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 var _ = api.BlockDocumentClient(&BlockDocumentClient{})
@@ -31,8 +30,8 @@ func (c *Client) BlockDocuments(accountID uuid.UUID, workspaceID uuid.UUID) (api
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if helpers.IsCloudEndpoint(c.endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
-		return nil, fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set on either the provider or the resource")
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &BlockDocumentClient{

--- a/internal/client/block_schemas.go
+++ b/internal/client/block_schemas.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 // BlockSchemaClient is a client for working with block schemas.
@@ -28,8 +27,8 @@ func (c *Client) BlockSchemas(accountID uuid.UUID, workspaceID uuid.UUID) (api.B
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if helpers.IsCloudEndpoint(c.endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
-		return nil, fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set on either the provider or the resource")
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &BlockSchemaClient{

--- a/internal/client/block_types.go
+++ b/internal/client/block_types.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 var _ = api.BlockTypeClient(&BlockTypeClient{})
@@ -30,8 +29,8 @@ func (c *Client) BlockTypes(accountID uuid.UUID, workspaceID uuid.UUID) (api.Blo
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if helpers.IsCloudEndpoint(c.endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
-		return nil, fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set on either the provider or the resource")
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &BlockTypeClient{

--- a/internal/client/collections.go
+++ b/internal/client/collections.go
@@ -30,8 +30,8 @@ func (c *Client) Collections(accountID, workspaceID uuid.UUID) (api.CollectionsC
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if helpers.IsCloudEndpoint(c.endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
-		return nil, fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set on either the provider or the resource")
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &CollectionsClient{

--- a/internal/client/deployment_access.go
+++ b/internal/client/deployment_access.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 var _ = api.DeploymentAccessClient(&DeploymentAccessClient{})
@@ -30,8 +29,8 @@ func (c *Client) DeploymentAccess(accountID uuid.UUID, workspaceID uuid.UUID) (a
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if helpers.IsCloudEndpoint(c.endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
-		return nil, fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set on either the provider or the resource")
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &DeploymentAccessClient{

--- a/internal/client/deployment_schedule.go
+++ b/internal/client/deployment_schedule.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 var _ = api.DeploymentScheduleClient(&DeploymentScheduleClient{})
@@ -30,8 +29,8 @@ func (c *Client) DeploymentSchedule(accountID, workspaceID uuid.UUID) (api.Deplo
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if helpers.IsCloudEndpoint(c.endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
-		return nil, fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set on either the provider or the resource")
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &DeploymentScheduleClient{

--- a/internal/client/deployments.go
+++ b/internal/client/deployments.go
@@ -31,6 +31,10 @@ func (c *Client) Deployments(accountID uuid.UUID, workspaceID uuid.UUID) (api.De
 		workspaceID = c.defaultWorkspaceID
 	}
 
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
+	}
+
 	return &DeploymentsClient{
 		hc:          c.hc,
 		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "deployments"),

--- a/internal/client/flows.go
+++ b/internal/client/flows.go
@@ -31,6 +31,10 @@ func (c *Client) Flows(accountID uuid.UUID, workspaceID uuid.UUID) (api.FlowsCli
 		workspaceID = c.defaultWorkspaceID
 	}
 
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
+	}
+
 	return &FlowsClient{
 		hc:          c.hc,
 		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "flows"),

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 // getAccountScopedURL constructs a URL for an account-scoped route.
@@ -62,6 +63,16 @@ func setDefaultHeaders(request *http.Request, apiKey string) {
 
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "application/json")
+}
+
+// validateCloudEndpoint validates that proper configuration is provided
+// when the endpoint points to Prefect Cloud.
+func validateCloudEndpoint(endpoint string, accountID, workspaceID uuid.UUID) error {
+	if helpers.IsCloudEndpoint(endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
+		return fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set on either the provider or the resource")
+	}
+
+	return nil
 }
 
 // requestConfig is a configuration object for an HTTP request.

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -26,8 +26,13 @@ func (c *Client) Variables(accountID uuid.UUID, workspaceID uuid.UUID) (api.Vari
 	if accountID == uuid.Nil {
 		accountID = c.defaultAccountID
 	}
+
 	if workspaceID == uuid.Nil {
 		workspaceID = c.defaultWorkspaceID
+	}
+
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &VariablesClient{

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 var _ = api.WorkPoolsClient(&WorkPoolsClient{})
@@ -31,8 +30,8 @@ func (c *Client) WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (api.Work
 		workspaceID = c.defaultWorkspaceID
 	}
 
-	if helpers.IsCloudEndpoint(c.endpoint) && (accountID == uuid.Nil || workspaceID == uuid.Nil) {
-		return nil, fmt.Errorf("prefect Cloud endpoints require an account_id and workspace_id to be set on either the provider or the resource")
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &WorkPoolsClient{

--- a/internal/client/workspace_access.go
+++ b/internal/client/workspace_access.go
@@ -26,11 +26,13 @@ func (c *Client) WorkspaceAccess(accountID uuid.UUID, workspaceID uuid.UUID) (ap
 	if accountID == uuid.Nil {
 		accountID = c.defaultAccountID
 	}
+
 	if workspaceID == uuid.Nil {
 		workspaceID = c.defaultWorkspaceID
 	}
-	if accountID == uuid.Nil || workspaceID == uuid.Nil {
-		return nil, fmt.Errorf("both accountID and workspaceID must be defined")
+
+	if err := validateCloudEndpoint(c.endpoint, accountID, workspaceID); err != nil {
+		return nil, err
 	}
 
 	return &WorkspaceAccessClient{


### PR DESCRIPTION
Consistently checks if `workspace_id` is configured for endpoints that
use that field.

Adds a helper function to consistently provide this check.

Closes https://linear.app/prefect/issue/PLA-405/consistently-handle-resources-that-require-a-workspace-id