### PR TITLE
fix(automations): use SetAttribute for expect, after, and for_each

### DIFF
--- a/docs/resources/automation.md
+++ b/docs/resources/automation.md
@@ -304,9 +304,9 @@ Required:
 
 Optional:
 
-- `after` (List of String) The event(s) which must first been seen to fire this trigger. If empty, then fire this trigger immediately
-- `expect` (List of String) The event(s) this trigger is expecting to see. If empty, this trigger will match any event
-- `for_each` (List of String) Evaluate the trigger separately for each distinct value of these labels on the resource
+- `after` (Set of String) The event(s) which must first been seen to fire this trigger. If empty, then fire this trigger immediately
+- `expect` (Set of String) The event(s) this trigger is expecting to see. If empty, this trigger will match any event
+- `for_each` (Set of String) Evaluate the trigger separately for each distinct value of these labels on the resource
 - `match` (String) (JSON) Resource specification labels which this trigger will match. Use `jsonencode()`.
 - `match_related` (String) (JSON) Resource specification labels for related resources which this trigger will match. Use `jsonencode()`.
 - `threshold` (Number) The number of events required for this trigger to fire (Reactive) or expected (Proactive)
@@ -349,9 +349,9 @@ Required:
 
 Optional:
 
-- `after` (List of String) The event(s) which must first been seen to fire this trigger. If empty, then fire this trigger immediately
-- `expect` (List of String) The event(s) this trigger is expecting to see. If empty, this trigger will match any event
-- `for_each` (List of String) Evaluate the trigger separately for each distinct value of these labels on the resource
+- `after` (Set of String) The event(s) which must first been seen to fire this trigger. If empty, then fire this trigger immediately
+- `expect` (Set of String) The event(s) this trigger is expecting to see. If empty, this trigger will match any event
+- `for_each` (Set of String) Evaluate the trigger separately for each distinct value of these labels on the resource
 - `match` (String) (JSON) Resource specification labels which this trigger will match. Use `jsonencode()`.
 - `match_related` (String) (JSON) Resource specification labels for related resources which this trigger will match. Use `jsonencode()`.
 - `threshold` (Number) The number of events required for this trigger to fire (Reactive) or expected (Proactive)
@@ -411,9 +411,9 @@ Required:
 
 Optional:
 
-- `after` (List of String) The event(s) which must first been seen to fire this trigger. If empty, then fire this trigger immediately
-- `expect` (List of String) The event(s) this trigger is expecting to see. If empty, this trigger will match any event
-- `for_each` (List of String) Evaluate the trigger separately for each distinct value of these labels on the resource
+- `after` (Set of String) The event(s) which must first been seen to fire this trigger. If empty, then fire this trigger immediately
+- `expect` (Set of String) The event(s) this trigger is expecting to see. If empty, this trigger will match any event
+- `for_each` (Set of String) Evaluate the trigger separately for each distinct value of these labels on the resource
 - `match` (String) (JSON) Resource specification labels which this trigger will match. Use `jsonencode()`.
 - `match_related` (String) (JSON) Resource specification labels for related resources which this trigger will match. Use `jsonencode()`.
 - `threshold` (Number) The number of events required for this trigger to fire (Reactive) or expected (Proactive)

--- a/internal/provider/resources/automation_model.go
+++ b/internal/provider/resources/automation_model.go
@@ -41,9 +41,9 @@ type EventTriggerModel struct {
 	Posture      types.String         `tfsdk:"posture"`
 	Match        jsontypes.Normalized `tfsdk:"match"`
 	MatchRelated jsontypes.Normalized `tfsdk:"match_related"`
-	After        types.List           `tfsdk:"after"`
-	Expect       types.List           `tfsdk:"expect"`
-	ForEach      types.List           `tfsdk:"for_each"`
+	After        types.Set            `tfsdk:"after"`
+	Expect       types.Set            `tfsdk:"expect"`
+	ForEach      types.Set            `tfsdk:"for_each"`
 	Threshold    types.Int64          `tfsdk:"threshold"`
 	Within       types.Float64        `tfsdk:"within"`
 }

--- a/internal/provider/resources/automation_resource.go
+++ b/internal/provider/resources/automation_resource.go
@@ -391,11 +391,11 @@ func mapTriggerAPIToTerraform(ctx context.Context, apiTrigger *api.Trigger, tfTr
 		tfTriggerModel.Event.MatchRelated = jsontypes.NewNormalizedValue(string(matchRelatedByteSlice))
 
 		// Parse and set After, Expect, and ForEach (lists)
-		after, diagnostics := types.ListValueFrom(ctx, types.StringType, apiTrigger.After)
+		after, diagnostics := types.SetValueFrom(ctx, types.StringType, apiTrigger.After)
 		diags.Append(diagnostics...)
-		expect, diagnostics := types.ListValueFrom(ctx, types.StringType, apiTrigger.Expect)
+		expect, diagnostics := types.SetValueFrom(ctx, types.StringType, apiTrigger.Expect)
 		diags.Append(diagnostics...)
-		forEach, diagnostics := types.ListValueFrom(ctx, types.StringType, apiTrigger.ForEach)
+		forEach, diagnostics := types.SetValueFrom(ctx, types.StringType, apiTrigger.ForEach)
 		diags.Append(diagnostics...)
 
 		if diags.HasError() {

--- a/internal/provider/resources/automation_schema.go
+++ b/internal/provider/resources/automation_schema.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -143,26 +144,26 @@ func ResourceTriggerSchemaAttributes() map[string]schema.Attribute {
 					CustomType:  jsontypes.NormalizedType{},
 					Default:     stringdefault.StaticString("{}"),
 				},
-				"after": schema.ListAttribute{
+				"after": schema.SetAttribute{
 					Optional:    true,
 					Computed:    true,
 					Description: "The event(s) which must first been seen to fire this trigger. If empty, then fire this trigger immediately",
 					ElementType: types.StringType,
-					Default:     listdefault.StaticValue(basetypes.NewListValueMust(types.StringType, []attr.Value{})),
+					Default:     setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),
 				},
-				"expect": schema.ListAttribute{
+				"expect": schema.SetAttribute{
 					Optional:    true,
 					Computed:    true,
 					Description: "The event(s) this trigger is expecting to see. If empty, this trigger will match any event",
 					ElementType: types.StringType,
-					Default:     listdefault.StaticValue(basetypes.NewListValueMust(types.StringType, []attr.Value{})),
+					Default:     setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),
 				},
-				"for_each": schema.ListAttribute{
+				"for_each": schema.SetAttribute{
 					Optional:    true,
 					Computed:    true,
 					Description: "Evaluate the trigger separately for each distinct value of these labels on the resource",
 					ElementType: types.StringType,
-					Default:     listdefault.StaticValue(basetypes.NewListValueMust(types.StringType, []attr.Value{})),
+					Default:     setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),
 				},
 				"threshold": schema.Int64Attribute{
 					Optional:    true,

--- a/internal/provider/resources/automation_test.go
+++ b/internal/provider/resources/automation_test.go
@@ -40,9 +40,19 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
         "prefect.resource.id" : ["prefect.flow.ce6ec0c9-4b51-483b-a776-43c085b6c4f8"]
         "prefect.resource.role" : "flow"
       })
-      after     = ["prefect.flow-run.completed"]
-      expect    = ["prefect.flow-run.failed"]
-      for_each  = ["prefect.resource.id"]
+      after     = [
+				"prefect.flow-run.Completed",
+				"prefect.flow-run.Succeeded",
+			]
+      expect    = [
+				"prefect.flow-run.Failed",
+				"prefect.flow-run.Cancelled",
+				"prefect.flow-run.Crashed",
+			]
+      for_each  = [
+				"prefect.resource.id",
+				"prefect.resource.role",
+			]
       threshold = 1
       within    = 60
     }
@@ -141,6 +151,19 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
               "prefect.resource.role" = "flow"
             })
             posture = "Reactive"
+            after = [
+              "prefect.flow-run.Completed",
+              "prefect.flow-run.Succeeded",
+            ]
+            expect = [
+              "prefect.flow-run.Failed",
+              "prefect.flow-run.Cancelled",
+              "prefect.flow-run.Crashed",
+            ]
+            for_each = [
+              "prefect.resource.id",
+              "prefect.resource.role",
+            ]
             threshold = 1
             within = 0
           }
@@ -288,12 +311,16 @@ func TestAccResource_automation(t *testing.T) {
 					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.posture", "Reactive"),
 					testutils.TestCheckJSONAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.match", `{"prefect.resource.id":"prefect.flow-run.*"}`),
 					testutils.TestCheckJSONAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.match_related", `{"prefect.resource.id":["prefect.flow.ce6ec0c9-4b51-483b-a776-43c085b6c4f8"],"prefect.resource.role":"flow"}`),
-					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.after.#", "1"),
-					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.after.0", "prefect.flow-run.completed"),
-					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.expect.#", "1"),
-					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.expect.0", "prefect.flow-run.failed"),
-					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.for_each.#", "1"),
+					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.after.#", "2"),
+					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.after.0", "prefect.flow-run.Completed"),
+					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.after.1", "prefect.flow-run.Succeeded"),
+					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.expect.#", "3"),
+					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.expect.0", "prefect.flow-run.Cancelled"),
+					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.expect.1", "prefect.flow-run.Crashed"),
+					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.expect.2", "prefect.flow-run.Failed"),
+					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.for_each.#", "2"),
 					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.for_each.0", "prefect.resource.id"),
+					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.for_each.1", "prefect.resource.role"),
 					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.threshold", "1"),
 					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "trigger.event.within", "60"),
 					resource.TestCheckResourceAttr(eventTriggerAutomationResourceNameAndPath, "actions.#", "1"),
@@ -357,13 +384,18 @@ func TestAccResource_automation(t *testing.T) {
 					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.require", "any"),
 					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.within", "302"),
 					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.#", "2"),
-					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.expect.#", "1"),
-					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.expect.0", "prefect.flow-run.Failed"),
+					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.expect.#", "3"),
+					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.expect.0", "prefect.flow-run.Cancelled"),
+					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.expect.1", "prefect.flow-run.Crashed"),
+					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.expect.2", "prefect.flow-run.Failed"),
 					testutils.TestCheckJSONAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.match", `{"prefect.resource.id":"prefect.flow-run.*"}`),
 					testutils.TestCheckJSONAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.match_related", `{"prefect.resource.id":"prefect.flow-run.*","prefect.resource.role":"flow"}`),
 					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.posture", "Reactive"),
 					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.threshold", "1"),
 					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.within", "0"),
+					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.after.#", "2"),
+					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.after.0", "prefect.flow-run.Completed"),
+					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.0.event.after.1", "prefect.flow-run.Succeeded"),
 					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.1.event.expect.#", "1"),
 					resource.TestCheckResourceAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.1.event.expect.0", "prefect.flow-run.Completed"),
 					testutils.TestCheckJSONAttr(compoundTriggerAutomationResourceNameAndPath, "trigger.compound.triggers.1.event.match", `{"prefect.resource.id":"prefect.flow-run.*"}`),


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/338

it turns out that our API returns random sorting for strings in `expect`, `after`, and `for_each` attributes on the trigger object

this creates an inconsistent value error, as the HCL/state representation of an ordered list would always conflict with whatever the API returns (which is random)

we could fix this on the API to be statically sorted, but this would still create a diff + inconsistent value error because we shouldn't expect that the Terraform user will order their values in the exact way that the API would

The change in this PR uses a [SetAttribute](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/attributes/set) (unordered, unique) instead of a [ListAttribute](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/attributes/list)

## Testing
```hcl
resource "prefect_automation" "import" {
  name = "import"
  trigger = {
    event = {
      posture = "Proactive"
      match = jsonencode({
        "prefect.resource.id" : "prefect.flow-run.*"
      })
      match_related = jsonencode({
        "prefect.resource.id" : ["prefect.tag.Tag1", "prefect.tag.Tag2"]
        "prefect.resource.role" : "tag"
      })
      after     = [
        "prefect.flow-run.Failed",
        "prefect.flow-run.Cancelled",
        "prefect.flow-run.Crashed",
        "prefect.flow-run.Completed"
      ]
      expect    = ["prefect.flow-run.*"]
      for_each  = ["prefect.resource.id"]
      threshold = 1
      within    = 30
    }
  }
}
```

Before:
```
➜ terraform apply --auto-approve
prefect_automation.import: Refreshing state... [id=341d6f73-f088-4438-89c9-9fd444a39bd3]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # prefect_automation.import will be updated in-place
  ~ resource "prefect_automation" "import" {
        id                 = "341d6f73-f088-4438-89c9-9fd444a39bd3"
        name               = "import"
      ~ trigger            = {
          ~ event = {
              ~ after         = [
                  - "prefect.flow-run.Completed",
                  - "prefect.flow-run.Crashed",
                    "prefect.flow-run.Failed",
                    "prefect.flow-run.Cancelled",
                  + "prefect.flow-run.Crashed",
                  + "prefect.flow-run.Completed",
                ]
                # (7 unchanged attributes hidden)
            }
        }
      ~ updated            = "2024-12-18T20:24:08Z" -> (known after apply)
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
prefect_automation.import: Modifying... [id=341d6f73-f088-4438-89c9-9fd444a39bd3]
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to prefect_automation.import, provider "provider[\"registry.terraform.io/prefecthq/prefect\"]" produced an unexpected new value: .trigger.event.after[0]: was
│ cty.StringVal("prefect.flow-run.Failed"), but now cty.StringVal("prefect.flow-run.Cancelled").
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to prefect_automation.import, provider "provider[\"registry.terraform.io/prefecthq/prefect\"]" produced an unexpected new value: .trigger.event.after[1]: was
│ cty.StringVal("prefect.flow-run.Cancelled"), but now cty.StringVal("prefect.flow-run.Failed").
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

After:
```sh
➜ terraform apply --auto-approve
prefect_automation.import: Refreshing state... [id=341d6f73-f088-4438-89c9-9fd444a39bd3]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

```