### PR TITLE
fix(deployments datasource): get by name

### DIFF
--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -31,11 +31,17 @@ data "prefect_deployment" "existing_by_id_string" {
 # Get deployment by name using Terraform name reference.
 data "prefect_deployment" "existing_by_id_string" {
   name = prefect_deployment.my_existing_deployment.name
+  # the flow_name field is not available on the Deployment resource
+  # because it isn't a part of the object in the API. However, it's
+  # required by the API to get a Deployment by name, so here we
+  # provide the string value.
+  flow_name = "example_flow"
 }
 
 # Get deployment by name string.
 data "prefect_deployment" "existing_by_id_string" {
-  name = "my_existing_deployment"
+  name      = "my_existing_deployment"
+  flow_name = "example_flow"
 }
 ```
 
@@ -45,6 +51,7 @@ data "prefect_deployment" "existing_by_id_string" {
 ### Optional
 
 - `account_id` (String) Account ID (UUID), defaults to the account set in the provider
+- `flow_name` (String) Flow name associated with the deployment
 - `id` (String) Deployment ID (UUID)
 - `name` (String) Name of the deployment
 - `workspace_id` (String) Workspace ID (UUID) to associate deployment to

--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -30,12 +30,8 @@ data "prefect_deployment" "existing_by_id_string" {
 
 # Get deployment by name using Terraform name reference.
 data "prefect_deployment" "existing_by_id_string" {
-  name = prefect_deployment.my_existing_deployment.name
-  # the flow_name field is not available on the Deployment resource
-  # because it isn't a part of the object in the API. However, it's
-  # required by the API to get a Deployment by name, so here we
-  # provide the string value.
-  flow_name = "example_flow"
+  flow_name = prefect_flow.my_existing_flow.name
+  name      = prefect_deployment.my_existing_deployment.name
 }
 
 # Get deployment by name string.

--- a/examples/data-sources/prefect_deployment/data-source.tf
+++ b/examples/data-sources/prefect_deployment/data-source.tf
@@ -10,10 +10,12 @@ data "prefect_deployment" "existing_by_id_string" {
 
 # Get deployment by name using Terraform name reference.
 data "prefect_deployment" "existing_by_id_string" {
-  name = prefect_deployment.my_existing_deployment.name
+  flow_name = prefect_flow.my_existing_flow.name
+  name      = prefect_deployment.my_existing_deployment.name
 }
 
 # Get deployment by name string.
 data "prefect_deployment" "existing_by_id_string" {
-  name = "my_existing_deployment"
+  name      = "my_existing_deployment"
+  flow_name = "example_flow"
 }

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -10,7 +10,7 @@ import (
 type DeploymentsClient interface {
 	Create(ctx context.Context, data DeploymentCreate) (*Deployment, error)
 	Get(ctx context.Context, deploymentID uuid.UUID) (*Deployment, error)
-	List(ctx context.Context, handleNames []string) ([]*Deployment, error)
+	GetByName(ctx context.Context, flowName, deploymentName string) (*Deployment, error)
 	Update(ctx context.Context, deploymentID uuid.UUID, data DeploymentUpdate) error
 	Delete(ctx context.Context, deploymentID uuid.UUID) error
 }

--- a/internal/client/deployments.go
+++ b/internal/client/deployments.go
@@ -60,29 +60,30 @@ func (c *DeploymentsClient) Create(ctx context.Context, data api.DeploymentCreat
 	return &deployment, nil
 }
 
-// List returns a list of Deployments based on the provided list of names.
-func (c *DeploymentsClient) List(ctx context.Context, _ []string) ([]*api.Deployment, error) {
-	cfg := requestConfig{
-		method:       http.MethodPost,
-		url:          fmt.Sprintf("%s/filter", c.routePrefix),
-		body:         http.NoBody,
-		apiKey:       c.apiKey,
-		successCodes: successCodesStatusOK,
-	}
-
-	var deployments []*api.Deployment
-	if err := requestWithDecodeResponse(ctx, c.hc, cfg, &deployments); err != nil {
-		return nil, fmt.Errorf("failed to list deployments: %w", err)
-	}
-
-	return deployments, nil
-}
-
 // Get returns details for a Deployment by ID.
 func (c *DeploymentsClient) Get(ctx context.Context, deploymentID uuid.UUID) (*api.Deployment, error) {
 	cfg := requestConfig{
 		method:       http.MethodGet,
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, deploymentID.String()),
+		body:         http.NoBody,
+		apiKey:       c.apiKey,
+		successCodes: successCodesStatusOK,
+	}
+
+	var deployment api.Deployment
+	if err := requestWithDecodeResponse(ctx, c.hc, cfg, &deployment); err != nil {
+		return nil, fmt.Errorf("failed to get deployment: %w", err)
+	}
+
+	return &deployment, nil
+}
+
+// GetByName returns details for a Deployment by name.
+func (c *DeploymentsClient) GetByName(ctx context.Context, flowName, deploymentName string) (*api.Deployment, error) {
+	url := fmt.Sprintf("%s/name/%s/%s", c.routePrefix, flowName, deploymentName)
+	cfg := requestConfig{
+		method:       http.MethodGet,
+		url:          url,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
 		successCodes: successCodesStatusOK,

--- a/internal/provider/datasources/deployment.go
+++ b/internal/provider/datasources/deployment.go
@@ -33,6 +33,9 @@ type deploymentDataSource struct {
 type DeploymentDataSourceModel struct {
 	// The model requires the same fields, so reuse the fields defined in the resource model.
 	resources.DeploymentResourceModel
+
+	// The following fields are specific to the Deployment datasource.
+	FlowName types.String `tfsdk:"flow_name"`
 }
 
 // NewDeploymentDataSource is a helper function to simplify the provider implementation.
@@ -93,6 +96,13 @@ The Deployment ID takes precedence over deployment name.
 				Computed:    true,
 				CustomType:  customtypes.UUIDType{},
 				Description: "Flow ID (UUID) to associate deployment to",
+			},
+			// flow_name is specific to the datasource because it's used in the API endpoint
+			// to find a deployment by name.
+			"flow_name": schema.StringAttribute{
+				Computed:    true,
+				Optional:    true,
+				Description: "Flow name associated with the deployment",
 			},
 			"paused": schema.BoolAttribute{
 				Computed:    true,
@@ -243,6 +253,7 @@ func (d *deploymentDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	// If both are set, we prefer the ID
 	var deployment *api.Deployment
 	var operation string
+	var getErr error
 	if !model.ID.IsNull() {
 		var deploymentID uuid.UUID
 		deploymentID, err = uuid.Parse(model.ID.ValueString())
@@ -257,25 +268,13 @@ func (d *deploymentDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		}
 
 		operation = "get"
-		deployment, err = client.Get(ctx, deploymentID)
+		deployment, getErr = client.Get(ctx, deploymentID)
 	} else if !model.Name.IsNull() {
-		var deployments []*api.Deployment
-		operation = "list"
-		deployments, err = client.List(ctx, []string{model.Name.ValueString()})
-
-		if len(deployments) != 1 {
-			resp.Diagnostics.AddError(
-				"Could not find Deployment",
-				fmt.Sprintf("Could not find Deployment with name %s", model.Name.ValueString()),
-			)
-
-			return
-		}
-
-		deployment = deployments[0]
+		operation = "get by name"
+		deployment, getErr = client.GetByName(ctx, model.FlowName.ValueString(), model.Name.ValueString())
 	}
 
-	if err != nil {
+	if getErr != nil {
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Deployment", operation, err))
 
 		return

--- a/internal/provider/datasources/deployment_test.go
+++ b/internal/provider/datasources/deployment_test.go
@@ -44,6 +44,7 @@ data "prefect_deployment" "test_by_id" {
 
 data "prefect_deployment" "test_by_name" {
   name = prefect_deployment.test.name
+  flow_name = prefect_flow.test.name
 
   account_id = "%s"
   workspace_id = prefect_workspace.test.id


### PR DESCRIPTION
## Summary

For the Deployment datasource, we were getting it by name by using the
/filter endpoint. But we weren't passing any filter body in the request,
so it was always getting all Deployments back.

This change uses the API endpoint to get a deployment by name, which now
requires a flow name as well.

Related to https://github.com/PrefectHQ/terraform-provider-prefect/issues/330
