### PR TITLE
fix(blocks): always use user-provided HCL for .data attr

### DIFF
--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -8,6 +8,7 @@ description: |-
   Note: you should be on version 3.0.0rc1 or later to use the following commands:
   Use prefect block type ls to view all available Block type slugs, which is used in the type_slug attribute.
   Use prefect block type inspect <slug> to view the data schema for a given Block type. Use this to construct the data attribute value (as JSON string).
+  NOTE: if a Block is managed in Terraform, the .data attribute will NOT be re-reconciled if the remote value is changed. This means that a TF-managed Block will only update the API, and not the other way around.
 ---
 
 # prefect_block (Resource)
@@ -17,6 +18,7 @@ The resource `block` allows creating and managing [Prefect Blocks](https://docs.
 *Note:* you should be on version `3.0.0rc1` or later to use the following commands:
 Use `prefect block type ls` to view all available Block type slugs, which is used in the `type_slug` attribute.
 Use `prefect block type inspect <slug>` to view the data schema for a given Block type. Use this to construct the `data` attribute value (as JSON string).
+*NOTE:* if a Block is managed in Terraform, the `.data` attribute will NOT be re-reconciled if the remote value is changed. This means that a TF-managed Block will only update the API, and not the other way around.
 
 ## Example Usage
 

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -75,7 +76,9 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"\n" +
 			"Use `prefect block type ls` to view all available Block type slugs, which is used in the `type_slug` attribute." +
 			"\n" +
-			"Use `prefect block type inspect <slug>` to view the data schema for a given Block type. Use this to construct the `data` attribute value (as JSON string).",
+			"Use `prefect block type inspect <slug>` to view the data schema for a given Block type. Use this to construct the `data` attribute value (as JSON string)." +
+			"\n" +
+			"*NOTE:* if a Block is managed in Terraform, the `.data` attribute will NOT be re-reconciled if the remote value is changed. This means that a TF-managed Block will only update the API, and not the other way around.",
 		Version: 0,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -196,14 +199,17 @@ func (r *BlockResource) getLatestBlockSchema(ctx context.Context, plan BlockReso
 // copyBlockToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
 func copyBlockToModel(block *api.BlockDocument, tfModel *BlockResourceModel) diag.Diagnostics {
+	// NOTE: we will map the `data` key OUTSIDE of this helper function, as we will
+	// need to skip this step for the POST /block_documents endpoint,
+	// which always returns masked data + will create inconsistent state between the
+	// plan <> fetched value - for Create(), we'll fall back to the user-configured JSON payload,
+	// whereas for Read() / Update() we can ask the API for unmasked values to ensure a consistent
+	// state drift check.
 	tfModel.ID = types.StringValue(block.ID.String())
 	tfModel.Created = customtypes.NewTimestampPointerValue(block.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(block.Updated)
 	tfModel.Name = types.StringValue(block.Name)
 	tfModel.TypeSlug = types.StringValue(block.BlockType.Slug)
-
-	// NOTE: we do not persist the fetched .Data value from the API -> State.
-	// See the `Read()` and `Update()` methods for more context.
 
 	return nil
 }
@@ -259,13 +265,6 @@ func (r *BlockResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	// NOTE: we're not persisting the fetched .Data value from the API -> State.
-	// Normally, we would also copy the retrieved Block's Data field into the
-	// plan object before setting the current state.
-	//
-	// However, the API's POST method does not return unmasked data, so we'll
-	// fall back to the user-configured JSON payload. Otherwise, there will always
-	// be a state conflict between the plan <> fetched value.
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -317,14 +316,14 @@ func (r *BlockResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	// NOTE: we're not persisting the fetched .Data value from the API -> State.
-	// Normally, we would also copy the retrieved Block's Data field into the
-	// plan object before setting the current state.
-	//
-	// However, the API's GET method does not return the `$ref` expression if it
-	// was specified in the Data field on the Block resource. This leads to
-	// "inconsistent result after apply" errors. For now, we'll skip copying the
-	// retrieved Block's Data field and use what was specified in the plan.
+
+	byteSlice, err := json.Marshal(block.Data)
+	if err != nil {
+		resp.Diagnostics.Append(helpers.SerializeDataErrorDiagnostic("data", "Block Data", err))
+
+		return
+	}
+	state.Data = jsontypes.NewNormalizedValue(string(byteSlice))
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -396,7 +395,7 @@ func (r *BlockResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	// NOTE: we're not persisting the fetched .Data value from the API -> State.
+
 	// Normally, we would also copy the retrieved Block's Data field into the
 	// plan object before setting the current state.
 	//

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -199,17 +198,14 @@ func (r *BlockResource) getLatestBlockSchema(ctx context.Context, plan BlockReso
 // copyBlockToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
 func copyBlockToModel(block *api.BlockDocument, tfModel *BlockResourceModel) diag.Diagnostics {
-	// NOTE: we will map the `data` key OUTSIDE of this helper function, as we will
-	// need to skip this step for the POST /block_documents endpoint,
-	// which always returns masked data + will create inconsistent state between the
-	// plan <> fetched value - for Create(), we'll fall back to the user-configured JSON payload,
-	// whereas for Read() / Update() we can ask the API for unmasked values to ensure a consistent
-	// state drift check.
 	tfModel.ID = types.StringValue(block.ID.String())
 	tfModel.Created = customtypes.NewTimestampPointerValue(block.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(block.Updated)
 	tfModel.Name = types.StringValue(block.Name)
 	tfModel.TypeSlug = types.StringValue(block.BlockType.Slug)
+
+	// NOTE: we do not persist the fetched .Data value from the API -> State.
+	// See the `Read()` and `Update()` methods for more context.
 
 	return nil
 }
@@ -265,6 +261,13 @@ func (r *BlockResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	// NOTE: we're not persisting the fetched .Data value from the API -> State.
+	// Normally, we would also copy the retrieved Block's Data field into the
+	// plan object before setting the current state.
+	//
+	// However, the API's POST method does not return unmasked data, so we'll
+	// fall back to the user-configured JSON payload. Otherwise, there will always
+	// be a state conflict between the plan <> fetched value.
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -316,14 +319,14 @@ func (r *BlockResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	byteSlice, err := json.Marshal(block.Data)
-	if err != nil {
-		resp.Diagnostics.Append(helpers.SerializeDataErrorDiagnostic("data", "Block Data", err))
-
-		return
-	}
-	state.Data = jsontypes.NewNormalizedValue(string(byteSlice))
+	// NOTE: we're not persisting the fetched .Data value from the API -> State.
+	// Normally, we would also copy the retrieved Block's Data field into the
+	// plan object before setting the current state.
+	//
+	// However, the API's GET method does not return the `$ref` expression if it
+	// was specified in the Data field on the Block resource. This leads to
+	// "inconsistent result after apply" errors. For now, we'll skip copying the
+	// retrieved Block's Data field and use what was specified in the plan.
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -395,7 +398,7 @@ func (r *BlockResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
+	// NOTE: we're not persisting the fetched .Data value from the API -> State.
 	// Normally, we would also copy the retrieved Block's Data field into the
 	// plan object before setting the current state.
 	//

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -197,17 +196,14 @@ func (r *BlockResource) getLatestBlockSchema(ctx context.Context, plan BlockReso
 // copyBlockToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
 func copyBlockToModel(block *api.BlockDocument, tfModel *BlockResourceModel) diag.Diagnostics {
-	// NOTE: we will map the `data` key OUTSIDE of this helper function, as we will
-	// need to skip this step for the POST /block_documents endpoint,
-	// which always returns masked data + will create inconsistent state between the
-	// plan <> fetched value - for Create(), we'll fall back to the user-configured JSON payload,
-	// whereas for Read() / Update() we can ask the API for unmasked values to ensure a consistent
-	// state drift check.
 	tfModel.ID = types.StringValue(block.ID.String())
 	tfModel.Created = customtypes.NewTimestampPointerValue(block.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(block.Updated)
 	tfModel.Name = types.StringValue(block.Name)
 	tfModel.TypeSlug = types.StringValue(block.BlockType.Slug)
+
+	// NOTE: we do not persist the fetched .Data value from the API -> State.
+	// See the `Read()` and `Update()` methods for more context.
 
 	return nil
 }
@@ -263,6 +259,13 @@ func (r *BlockResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
+	// NOTE: we're not persisting the fetched .Data value from the API -> State.
+	// Normally, we would also copy the retrieved Block's Data field into the
+	// plan object before setting the current state.
+	//
+	// However, the API's POST method does not return unmasked data, so we'll
+	// fall back to the user-configured JSON payload. Otherwise, there will always
+	// be a state conflict between the plan <> fetched value.
 	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -314,14 +317,14 @@ func (r *BlockResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	byteSlice, err := json.Marshal(block.Data)
-	if err != nil {
-		resp.Diagnostics.Append(helpers.SerializeDataErrorDiagnostic("data", "Block Data", err))
-
-		return
-	}
-	state.Data = jsontypes.NewNormalizedValue(string(byteSlice))
+	// NOTE: we're not persisting the fetched .Data value from the API -> State.
+	// Normally, we would also copy the retrieved Block's Data field into the
+	// plan object before setting the current state.
+	//
+	// However, the API's GET method does not return the `$ref` expression if it
+	// was specified in the Data field on the Block resource. This leads to
+	// "inconsistent result after apply" errors. For now, we'll skip copying the
+	// retrieved Block's Data field and use what was specified in the plan.
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -393,7 +396,7 @@ func (r *BlockResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
+	// NOTE: we're not persisting the fetched .Data value from the API -> State.
 	// Normally, we would also copy the retrieved Block's Data field into the
 	// plan object before setting the current state.
 	//


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/341
resolves https://linear.app/prefect/issue/PLA-860/blocks-using-credential-blocks-update-on-every-plan

normally, we reconcile the API values for `.data` in a block / block_document - this means that the remote value always be fetched (even on Reads) and be compared to the state values

however, when using a reference object (`$ref`), the HCL will always look like this:

```hcl
resource "prefect_block" "my_prefect_results" {
  name      = "my-prefect-results"
  type_slug = "s3-bucket"

  data = jsonencode({
    bucket_name = "my-prefect-results"
    credentials = { "$ref" : { "block_document_id" : prefect_block.prefect_aws.id } }
  })
}
```

but the API response will always come back hydrated:

```json
  "data": {
    "bucket_name": "my-prefect-results",
    "credentials": {
      "aws_access_key_id": "access-key-id",
      "aws_secret_access_key": "********",
      "region_name": "us-east-1"
    }
  },
```

this causes a no-op change to ALWAYS detect a plan update

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # prefect_block.my_prefect_results will be updated in-place
  ~ resource "prefect_block" "my_prefect_results" {
      ~ data      = (sensitive value)
        id        = "0551754e-cdca-4a45-8926-6b4c9c1f927b"
        name      = "my-prefect-results"
      ~ updated   = "2024-12-20T04:26:28Z" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

before this PR, we already omitted persisting the API value for `.data` in both `Create()` and `Update()` calls for similar reasons (Create will always return masked data, so it will always conflict with the user provided values.  Update runs into the `$ref` issue)

here, we'll omit persisting the API `.data` across the board.  this means that the user HCL is the source of truth.  The tradeoff here is that remote changes (eg. someone goes to the Prefect UI and updates a Block value) won't get pulled down during plans to detect drift -- management of this attribute becomes one direction only