### PR TITLE
feat(client): add GetEndpointHost utility getter

### DIFF
--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -59,7 +59,7 @@ output "endpoint" {
 ### Read-Only
 
 - `created` (String) Timestamp of when the resource was created (RFC3339)
-- `endpoint` (String) The fully-formed webhook endpoint, eg. https://api.prefect.cloud/SLUG
+- `endpoint` (String) The fully-formed webhook endpoint, eg. https://api.prefect.cloud/hooks/SLUG
 - `id` (String) Webhook ID (UUID)
 - `updated` (String) Timestamp of when the resource was updated (RFC3339)
 

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -59,7 +59,7 @@ output "endpoint" {
 ### Read-Only
 
 - `created` (String) Timestamp of when the resource was created (RFC3339)
-- `endpoint` (String) The fully-formed webhook endpoint, eg. https://api.prefect.cloud/hooks/SLUG
+- `endpoint` (String) The fully-formed webhook endpoint, eg. `https://api.prefect.cloud/hooks/<slug>`
 - `id` (String) Webhook ID (UUID)
 - `updated` (String) Timestamp of when the resource was updated (RFC3339)
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -6,8 +6,10 @@ import "github.com/google/uuid"
 //
 //nolint:interfacebloat // we'll accept a larger PrefectClient interface
 type PrefectClient interface {
+	// Utility methods on the Client interface
 	GetEndpointHost() string
 
+	// API Client Factories - for instantiating a client for each API resource
 	Accounts(accountID uuid.UUID) (AccountsClient, error)
 	Automations(accountID uuid.UUID, workspaceID uuid.UUID) (AutomationsClient, error)
 	AccountMemberships(accountID uuid.UUID) (AccountMembershipsClient, error)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -6,6 +6,8 @@ import "github.com/google/uuid"
 //
 //nolint:interfacebloat // we'll accept a larger PrefectClient interface
 type PrefectClient interface {
+	GetEndpointHost() string
+
 	Accounts(accountID uuid.UUID) (AccountsClient, error)
 	Automations(accountID uuid.UUID, workspaceID uuid.UUID) (AutomationsClient, error)
 	AccountMemberships(accountID uuid.UUID) (AccountMembershipsClient, error)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -63,7 +63,7 @@ func New(opts ...Option) (*Client, error) {
 
 // WithEndpoint configures the client to communicate with a self-hosted
 // Prefect server or Prefect Cloud.
-func WithEndpoint(endpoint string) Option {
+func WithEndpoint(endpoint string, host string) Option {
 	return func(client *Client) error {
 		_, err := url.Parse(endpoint)
 		if err != nil {
@@ -75,6 +75,7 @@ func WithEndpoint(endpoint string) Option {
 		}
 
 		client.endpoint = endpoint
+		client.endpointHost = host
 
 		return nil
 	}

--- a/internal/client/getters.go
+++ b/internal/client/getters.go
@@ -1,0 +1,7 @@
+package client
+
+// GetEndpointHost returns the endpoint host.
+// eg. https://api.prefect.cloud
+func (c *Client) GetEndpointHost() string {
+	return c.endpointHost
+}

--- a/internal/client/getters.go
+++ b/internal/client/getters.go
@@ -1,6 +1,7 @@
 package client
 
-// GetEndpointHost returns the endpoint host.
+// GetEndpointHost returns the endpoint host,
+// which is the API domain without the trailing subpath.
 // eg. https://api.prefect.cloud
 func (c *Client) GetEndpointHost() string {
 	return c.endpointHost

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -9,6 +9,7 @@ import (
 type Client struct {
 	hc                 *http.Client
 	endpoint           string
+	endpointHost       string
 	apiKey             string
 	defaultAccountID   uuid.UUID
 	defaultWorkspaceID uuid.UUID

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -141,6 +141,13 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	}
 	isPrefectCloudEndpoint := helpers.IsCloudEndpoint(endpointURL.Host)
 
+	// Extracts the host (without the /api suffix),
+	// so we can store it on the Client object in addition to the endpoint.
+	// For non-Cloud endpoints, it will likely be the same as .endpoint.
+	// This is useful for certain resources where we need access to the
+	// endpoint host to construct custom URLs as a resource attribute.
+	endpointHost := fmt.Sprintf("%s://%s", endpointURL.Scheme, endpointURL.Host)
+
 	// Extract the API Key from configuration or environment variable.
 	var apiKey string
 	if !config.APIKey.IsNull() {
@@ -201,7 +208,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	tflog.Debug(ctx, "Creating Prefect client")
 
 	prefectClient, err := client.New(
-		client.WithEndpoint(endpoint),
+		client.WithEndpoint(endpoint, endpointHost),
 		client.WithAPIKey(apiKey),
 		client.WithDefaults(accountID, config.WorkspaceID.ValueUUID()),
 	)

--- a/internal/provider/resources/webhooks.go
+++ b/internal/provider/resources/webhooks.go
@@ -127,7 +127,7 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"endpoint": schema.StringAttribute{
 				Computed:    true,
-				Description: "The fully-formed webhook endpoint, eg. https://api.prefect.cloud/SLUG",
+				Description: "The fully-formed webhook endpoint, eg. https://api.prefect.cloud/hooks/SLUG",
 			},
 		},
 	}

--- a/internal/provider/resources/webhooks.go
+++ b/internal/provider/resources/webhooks.go
@@ -127,7 +127,7 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"endpoint": schema.StringAttribute{
 				Computed:    true,
-				Description: "The fully-formed webhook endpoint, eg. https://api.prefect.cloud/hooks/SLUG",
+				Description: "The fully-formed webhook endpoint, eg. `https://api.prefect.cloud/hooks/<slug>`",
 			},
 		},
 	}

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -74,8 +75,11 @@ func NewTestClient() (api.PrefectClient, error) {
 		endpoint = fmt.Sprintf("%s/api", endpoint)
 	}
 
+	endpointURL, _ := url.Parse(endpoint)
+	endpointHost := fmt.Sprintf("%s://%s", endpointURL.Scheme, endpointURL.Host)
+
 	prefectClient, _ := client.New(
-		client.WithEndpoint(endpoint),
+		client.WithEndpoint(endpoint, endpointHost),
 		client.WithAPIKey(apiKey),
 		client.WithDefaults(accountID, uuid.Nil),
 	)


### PR DESCRIPTION
resolves https://linear.app/prefect/issue/PLA-841/extract-path-suffix-less-api-endpoint-into-webhook-resource
resolves #333 

this PR adds an endpointHost (host only, so no prefix) attribute to the PrefectClient, as well as a getter method on the interface.  we use this to construct the full webhook endpoint, since the API only stashes the slug portion, and we'll want to expose a fully formed endpoint based on the API that the provider is initialized with