### PR TITLE
fix(webhooks): add optional service_account_id for authZ

### DIFF
--- a/create-dev-testfile.sh
+++ b/create-dev-testfile.sh
@@ -18,7 +18,7 @@ main() {
 
   resource="prefect_${resource}"
 
-  dev_file_target="./dev/${name}"
+  dev_file_target="${PWD}/dev/${name}"
 
   mkdir -p $dev_file_target
 

--- a/docs/data-sources/webhook.md
+++ b/docs/data-sources/webhook.md
@@ -43,6 +43,7 @@ data "prefect_webhook" "example_by_name" {
 - `created` (String) Timestamp of when the resource was created (RFC3339)
 - `description` (String) Description of the webhook
 - `enabled` (Boolean) Whether the webhook is enabled
+- `service_account_id` (String) ID of the Service Account to which this webhook belongs. `Pro` and `Enterprise` customers can assign a Service Account to a webhook to enhance security.
 - `slug` (String) Slug of the webhook
 - `template` (String) Template used by the webhook
 - `updated` (String) Timestamp of when the resource was updated (RFC3339)

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -27,7 +27,7 @@ resource "prefect_webhook" "example" {
   })
 }
 
-# Use a JSON file to load a more complex template
+# Optionally, use a JSON file to load a more complex template
 resource "prefect_webhook" "example_with_file" {
   name        = "my-webhook"
   description = "This is a webhook"
@@ -35,9 +35,27 @@ resource "prefect_webhook" "example_with_file" {
   template    = file("./webhook-template.json")
 }
 
+# Pro / Enterprise customers can assign a Service Account to a webhook to enhance security.
+# If set, the webhook request will be authorized with the Service Account's API key.
+# NOTE: if the Service Account is deleted, the associated Webhook is also deleted.
+resource "prefect_service_account" "authorized" {
+  name = "my-service-account"
+}
+resource "prefect_webhook" "example_with_service_account" {
+  name               = "my-webhook-with-auth"
+  description        = "This is an authorized webhook"
+  enabled            = true
+  template           = file("./webhook-template.json")
+  service_account_id = prefect_service_account.authorized.id
+}
+
 # Access the endpoint of the webhook.
-output "endpoint" {
-  value = prefect_webhook.example_with_file.endpoint
+output "endpoints" {
+  value = {
+    example                      = prefect_webhook.example.endpoint
+    example_with_file            = prefect_webhook.example_with_file.endpoint
+    example_with_service_account = prefect_webhook.example_with_service_account.endpoint
+  }
 }
 ```
 
@@ -54,6 +72,7 @@ output "endpoint" {
 - `account_id` (String) Account ID (UUID), defaults to the account set in the provider
 - `description` (String) Description of the webhook
 - `enabled` (Boolean) Whether the webhook is enabled
+- `service_account_id` (String) ID of the Service Account to which this webhook belongs. `Pro` and `Enterprise` customers can assign a Service Account to a webhook to enhance security. If set, the webhook request will be authorized with the Service Account's API key.
 - `workspace_id` (String) Workspace ID (UUID), defaults to the workspace set in the provider
 
 ### Read-Only

--- a/examples/resources/prefect_webhook/resource.tf
+++ b/examples/resources/prefect_webhook/resource.tf
@@ -12,7 +12,7 @@ resource "prefect_webhook" "example" {
   })
 }
 
-# Use a JSON file to load a more complex template
+# Optionally, use a JSON file to load a more complex template
 resource "prefect_webhook" "example_with_file" {
   name        = "my-webhook"
   description = "This is a webhook"
@@ -20,7 +20,25 @@ resource "prefect_webhook" "example_with_file" {
   template    = file("./webhook-template.json")
 }
 
+# Pro / Enterprise customers can assign a Service Account to a webhook to enhance security.
+# If set, the webhook request will be authorized with the Service Account's API key.
+# NOTE: if the Service Account is deleted, the associated Webhook is also deleted.
+resource "prefect_service_account" "authorized" {
+  name = "my-service-account"
+}
+resource "prefect_webhook" "example_with_service_account" {
+  name               = "my-webhook-with-auth"
+  description        = "This is an authorized webhook"
+  enabled            = true
+  template           = file("./webhook-template.json")
+  service_account_id = prefect_service_account.authorized.id
+}
+
 # Access the endpoint of the webhook.
-output "endpoint" {
-  value = prefect_webhook.example_with_file.endpoint
+output "endpoints" {
+  value = {
+    example                      = prefect_webhook.example.endpoint
+    example_with_file            = prefect_webhook.example_with_file.endpoint
+    example_with_service_account = prefect_webhook.example_with_service_account.endpoint
+  }
 }

--- a/internal/api/webhooks.go
+++ b/internal/api/webhooks.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 )
@@ -15,32 +14,27 @@ type WebhooksClient interface {
 	Delete(ctx context.Context, webhookID string) error
 }
 
-/*** REQUEST DATA STRUCTS ***/
+type WebhookCore struct {
+	Name             string     `json:"name"`
+	Description      string     `json:"description,omitempty"`
+	Enabled          bool       `json:"enabled"`
+	Template         string     `json:"template"`
+	ServiceAccountID *uuid.UUID `json:"service_account_id"`
+}
 
+// Request Schemas.
 type WebhookCreateRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Enabled     bool   `json:"enabled"`
-	Template    string `json:"template"`
+	WebhookCore
 }
 
 type WebhookUpdateRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Enabled     bool   `json:"enabled"`
-	Template    string `json:"template"`
+	WebhookCore
 }
 
-/*** RESPONSE DATA STRUCTS ***/
-
+// Response Schemas.
 type Webhook struct {
-	ID          uuid.UUID `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description,omitempty"`
-	Enabled     bool      `json:"enabled"`
-	Template    string    `json:"template"`
-	Created     time.Time `json:"created"`
-	Updated     time.Time `json:"updated"`
+	BaseModel
+	WebhookCore
 	AccountID   uuid.UUID `json:"account"`
 	WorkspaceID uuid.UUID `json:"workspace"`
 	Slug        string    `json:"slug"`

--- a/internal/provider/datasources/webhooks.go
+++ b/internal/provider/datasources/webhooks.go
@@ -22,16 +22,17 @@ type WebhookDataSource struct {
 
 // WebhookDataSourceModel defines the Terraform data source model.
 type WebhookDataSourceModel struct {
-	ID          customtypes.UUIDValue      `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	Name        types.String               `tfsdk:"name"`
-	Description types.String               `tfsdk:"description"`
-	Enabled     types.Bool                 `tfsdk:"enabled"`
-	Template    types.String               `tfsdk:"template"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
-	Slug        types.String               `tfsdk:"slug"`
+	ID               customtypes.UUIDValue      `tfsdk:"id"`
+	Created          customtypes.TimestampValue `tfsdk:"created"`
+	Updated          customtypes.TimestampValue `tfsdk:"updated"`
+	Name             types.String               `tfsdk:"name"`
+	Description      types.String               `tfsdk:"description"`
+	Enabled          types.Bool                 `tfsdk:"enabled"`
+	Template         types.String               `tfsdk:"template"`
+	AccountID        customtypes.UUIDValue      `tfsdk:"account_id"`
+	WorkspaceID      customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	Slug             types.String               `tfsdk:"slug"`
+	ServiceAccountID customtypes.UUIDValue      `tfsdk:"service_account_id"`
 }
 
 // NewWebhookDataSource returns a new WebhookDataSource.
@@ -109,6 +110,11 @@ var webhookAttributes = map[string]schema.Attribute{
 	"slug": schema.StringAttribute{
 		Computed:    true,
 		Description: "Slug of the webhook",
+	},
+	"service_account_id": schema.StringAttribute{
+		CustomType:  customtypes.UUIDType{},
+		Description: "ID of the Service Account to which this webhook belongs. `Pro` and `Enterprise` customers can assign a Service Account to a webhook to enhance security.",
+		Computed:    true,
 	},
 }
 
@@ -189,8 +195,8 @@ func (d *WebhookDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	model.ID = customtypes.NewUUIDValue(webhook.ID)
-	model.Created = customtypes.NewTimestampPointerValue(&webhook.Created)
-	model.Updated = customtypes.NewTimestampPointerValue(&webhook.Updated)
+	model.Created = customtypes.NewTimestampPointerValue(webhook.Created)
+	model.Updated = customtypes.NewTimestampPointerValue(webhook.Updated)
 
 	model.Name = types.StringValue(webhook.Name)
 	model.Description = types.StringValue(webhook.Description)
@@ -199,6 +205,7 @@ func (d *WebhookDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	model.AccountID = customtypes.NewUUIDValue(webhook.AccountID)
 	model.WorkspaceID = customtypes.NewUUIDValue(webhook.WorkspaceID)
 	model.Slug = types.StringValue(webhook.Slug)
+	model.ServiceAccountID = customtypes.NewUUIDPointerValue(webhook.ServiceAccountID)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &model)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/resources/webhooks.go
+++ b/internal/provider/resources/webhooks.go
@@ -29,16 +29,17 @@ type WebhookResource struct {
 }
 
 type WebhookResourceModel struct {
-	ID          types.String               `tfsdk:"id"`
-	Created     customtypes.TimestampValue `tfsdk:"created"`
-	Updated     customtypes.TimestampValue `tfsdk:"updated"`
-	Name        types.String               `tfsdk:"name"`
-	Description types.String               `tfsdk:"description"`
-	Enabled     types.Bool                 `tfsdk:"enabled"`
-	Template    types.String               `tfsdk:"template"`
-	AccountID   customtypes.UUIDValue      `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue      `tfsdk:"workspace_id"`
-	Endpoint    types.String               `tfsdk:"endpoint"`
+	ID               types.String               `tfsdk:"id"`
+	Created          customtypes.TimestampValue `tfsdk:"created"`
+	Updated          customtypes.TimestampValue `tfsdk:"updated"`
+	Name             types.String               `tfsdk:"name"`
+	Description      types.String               `tfsdk:"description"`
+	Enabled          types.Bool                 `tfsdk:"enabled"`
+	Template         types.String               `tfsdk:"template"`
+	AccountID        customtypes.UUIDValue      `tfsdk:"account_id"`
+	WorkspaceID      customtypes.UUIDValue      `tfsdk:"workspace_id"`
+	Endpoint         types.String               `tfsdk:"endpoint"`
+	ServiceAccountID customtypes.UUIDValue      `tfsdk:"service_account_id"`
 }
 
 // NewWebhookResource returns a new WebhookResource.
@@ -128,6 +129,11 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"endpoint": schema.StringAttribute{
 				Computed:    true,
 				Description: "The fully-formed webhook endpoint, eg. `https://api.prefect.cloud/hooks/<slug>`",
+			},
+			"service_account_id": schema.StringAttribute{
+				Optional:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "ID of the Service Account to which this webhook belongs. If set, the webhook request will be authorized with the Service Account's API key.",
 			},
 		},
 	}


### PR DESCRIPTION
resolves #346 
resolves https://linear.app/prefect/issue/PLA-864/support-service-account-on-webhooks

in #261 , we didn't include the option to set a service_account_id, which is required if the account has Webhook Auth enabled
<img width="922" alt="image" src="https://github.com/user-attachments/assets/c759fbdb-5110-4621-8154-ec96359eef86" />

cc: @EmilRex 

## Testing

```hcl
resource "prefect_service_account" "service_account" {
  name              = "service-account"
  account_role_name = "Member"
}

resource "prefect_webhook" "target_webhook" {
  name    = "webhook"
  enabled = true
  template = jsonencode({
    event = "prefect.event.received"
    resource = {
      "prefect.resource.id"   = "prefect.event"
      "prefect.resource.name" = "Prefect Event"
    }
    data = "{{ body }}"
  })

  service_account_id = prefect_service_account.service_account.id
}

# ensure that the datasource also has the correct attribute set
data "prefect_webhook" "target_webhook" {
  id = prefect_webhook.target_webhook.id
}
output "service_account_id" {
  value = data.prefect_webhook.target_webhook.service_account_id
}
```

result:
```
➜ terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.prefect_webhook.target_webhook will be read during apply
  # (config refers to values not yet known)
 <= data "prefect_webhook" "target_webhook" {
      + created            = (known after apply)
      + description        = (known after apply)
      + enabled            = (known after apply)
      + id                 = (known after apply)
      + name               = (known after apply)
      + service_account_id = (known after apply)
      + slug               = (known after apply)
      + template           = (known after apply)
      + updated            = (known after apply)
    }

  # prefect_service_account.service_account will be created
  + resource "prefect_service_account" "service_account" {
      + account_id                 = (known after apply)
      + account_role_name          = "Member"
      + actor_id                   = (known after apply)
      + api_key                    = (sensitive value)
      + api_key_created            = (known after apply)
      + api_key_id                 = (known after apply)
      + api_key_name               = (known after apply)
      + created                    = (known after apply)
      + id                         = (known after apply)
      + name                       = "service-account"
      + old_key_expires_in_seconds = 0
      + updated                    = (known after apply)
    }

  # prefect_webhook.target_webhook will be created
  + resource "prefect_webhook" "target_webhook" {
      + account_id         = (known after apply)
      + created            = (known after apply)
      + enabled            = true
      + endpoint           = (known after apply)
      + id                 = (known after apply)
      + name               = "webhook"
      + service_account_id = (known after apply)
      + template           = jsonencode(
            {
              + data     = "{{ body }}"
              + event    = "prefect.event.received"
              + resource = {
                  + "prefect.resource.id"   = "prefect.event"
                  + "prefect.resource.name" = "Prefect Event"
                }
            }
        )
      + updated            = (known after apply)
      + workspace_id       = (known after apply)
        # (1 unchanged attribute hidden)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + service_account_id = (known after apply)
prefect_service_account.service_account: Creating...
prefect_service_account.service_account: Creation complete after 0s [id=6bf0eada-f6f0-4e9a-ac60-c29ba137c85c]
prefect_webhook.target_webhook: Creating...
prefect_webhook.target_webhook: Creation complete after 1s [id=7b9f4f3d-4c87-489b-b773-5f84aa7c1915]
data.prefect_webhook.target_webhook: Reading...
data.prefect_webhook.target_webhook: Read complete after 0s [id=7b9f4f3d-4c87-489b-b773-5f84aa7c1915]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

service_account_id = "6bf0eada-f6f0-4e9a-ac60-c29ba137c85c"
```