### PR TITLE
docs(webhook,work-pool): example for jsonencoding file input

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,12 @@ repos:
   - repo: local
     hooks:
       - id: make-docs
-        name: Build Terraform Docs
-        # only run if charts/ is modified
+        name: Terraform Provider Docs
+        # only run if these files are modified:
+        # - .go files
+        # - docs/
+        # - templates/
+        # - examples/
         files: ^(.*\.go|docs/.*|templates/.*|examples/.*)$
         entry: make
         args: [docs]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,17 @@
 fail_fast: false
 
 repos:
+  - repo: local
+    hooks:
+      - id: make-docs
+        name: Build Terraform Docs
+        # only run if charts/ is modified
+        files: ^(.*\.go|docs/.*|templates/.*|examples/.*)$
+        entry: make
+        args: [docs]
+        language: system
+        pass_filenames: false
+
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.83.5
     hooks:
@@ -16,7 +27,6 @@ repos:
       - id: golangci-lint
       - id: go-unit-tests
       - id: go-mod-tidy
-      - id: go-generate
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
       - id: golangci-lint
       - id: go-unit-tests
       - id: go-mod-tidy
+      - id: go-generate
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.1
     hooks:

--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -47,7 +47,7 @@ resource "prefect_block" "aws_credentials_from_file" {
   type_slug = "aws-credentials"
 
   # prefect block type inspect aws-credentials
-  data = jsonencode(file("./aws-credentials.json"))
+  data = file("./aws-credentials.json")
 }
 
 # example:

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -47,6 +47,18 @@ resource "prefect_webhook" "example_with_service_account" {
   enabled            = true
   template           = file("./webhook-template.json")
   service_account_id = prefect_service_account.authorized.id
+# When importing an existing Webhook resource
+# and using a `file()` input for `template`,
+# you may encounter inconsequential plan update diffs
+# due to minor whitespace changes. This is because
+# Terraform's `file()` input does not perform any encoding
+# to normalize the input. If this is a problem for you, you
+# can wrap the file input in a jsonencode/jsondecode call:
+resource "prefect_webhook" "example_with_file_encoded" {
+  name        = "my-webhook"
+  description = "This is a webhook"
+  enabled     = true
+  template    = jsonencode(jsondecode(file("./webhook-template.json")))
 }
 
 # Access the endpoint of the webhook.

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -47,6 +47,8 @@ resource "prefect_webhook" "example_with_service_account" {
   enabled            = true
   template           = file("./webhook-template.json")
   service_account_id = prefect_service_account.authorized.id
+}
+
 # When importing an existing Webhook resource
 # and using a `file()` input for `template`,
 # you may encounter inconsequential plan update diffs

--- a/docs/resources/work_pool.md
+++ b/docs/resources/work_pool.md
@@ -23,8 +23,9 @@ resource "prefect_work_pool" "example" {
   workspace_id = "my-workspace-id"
 }
 
-# Use a JSON file to load a base job configuration
-resource "prefect_work_pool" "example" {
+# Use a JSON file to load a custom base job template,
+# since it will likely be a large JSON object.
+resource "prefect_work_pool" "example_with_file" {
   name              = "test-k8s-pool"
   type              = "kubernetes"
   workspace_id      = data.prefect_workspace.prd.id
@@ -32,11 +33,26 @@ resource "prefect_work_pool" "example" {
   base_job_template = file("./base-job-template.json")
 }
 
-# Or use the prefect_worker_metadata datasource
-# to load a default base job configuration
+# When importing an existing Work Pool resource
+# and using a `file()` input for `base_job_template`,
+# you may encounter inconsequential plan update diffs
+# due to minor whitespace changes. This is because
+# Terraform's `file()` input does not perform any encoding
+# to normalize the input. If this is a problem for you, you
+# can wrap the file input in a jsonencode/jsondecode call:
+resource "prefect_work_pool" "example_with_file_encoded" {
+  name              = "test-k8s-pool"
+  type              = "kubernetes"
+  workspace_id      = data.prefect_workspace.prd.id
+  paused            = false
+  base_job_template = jsonencode(jsondecode(file("./base-job-template.json")))
+}
+
+# Alternatively, use the prefect_worker_metadata datasource
+# to load a default base job configuration dynamically.
 data "prefect_worker_metadata" "d" {}
 
-resource "prefect_work_pool" "example" {
+resource "prefect_work_pool" "example_with_datasource" {
   name              = "test-k8s-pool"
   type              = "kubernetes"
   workspace_id      = data.prefect_workspace.prd.id

--- a/examples/resources/prefect_block/resource.tf
+++ b/examples/resources/prefect_block/resource.tf
@@ -22,7 +22,7 @@ resource "prefect_block" "aws_credentials_from_file" {
   type_slug = "aws-credentials"
 
   # prefect block type inspect aws-credentials
-  data = jsonencode(file("./aws-credentials.json"))
+  data = file("./aws-credentials.json")
 }
 
 # example:

--- a/examples/resources/prefect_webhook/resource.tf
+++ b/examples/resources/prefect_webhook/resource.tf
@@ -34,6 +34,20 @@ resource "prefect_webhook" "example_with_service_account" {
   service_account_id = prefect_service_account.authorized.id
 }
 
+# When importing an existing Webhook resource
+# and using a `file()` input for `template`,
+# you may encounter inconsequential plan update diffs
+# due to minor whitespace changes. This is because
+# Terraform's `file()` input does not perform any encoding
+# to normalize the input. If this is a problem for you, you
+# can wrap the file input in a jsonencode/jsondecode call:
+resource "prefect_webhook" "example_with_file_encoded" {
+  name        = "my-webhook"
+  description = "This is a webhook"
+  enabled     = true
+  template    = jsonencode(jsondecode(file("./webhook-template.json")))
+}
+
 # Access the endpoint of the webhook.
 output "endpoints" {
   value = {

--- a/examples/resources/prefect_work_pool/resource.tf
+++ b/examples/resources/prefect_work_pool/resource.tf
@@ -5,7 +5,8 @@ resource "prefect_work_pool" "example" {
   workspace_id = "my-workspace-id"
 }
 
-# Use a JSON file to load a base job configuration
+# Use a JSON file to load a custom base job template,
+# since it will likely be a large JSON object.
 resource "prefect_work_pool" "example" {
   name              = "test-k8s-pool"
   type              = "kubernetes"
@@ -14,8 +15,23 @@ resource "prefect_work_pool" "example" {
   base_job_template = file("./base-job-template.json")
 }
 
-# Or use the prefect_worker_metadata datasource
-# to load a default base job configuration
+# When importing an existing Work Pool resource
+# and using a `file()` input for `base_job_template`,
+# you may encounter inconsequential plan update diffs
+# due to minor whitespace changes. This is because
+# Terraform's `file()` input does not perform any encoding
+# to normalize the input. If this is a problem for you, you
+# can wrap the file input in a jsonencode/jsondecode call:
+resource "prefect_work_pool" "example" {
+  name              = "test-k8s-pool"
+  type              = "kubernetes"
+  workspace_id      = data.prefect_workspace.prd.id
+  paused            = false
+  base_job_template = jsonencode(jsondecode(file("./base-job-template.json")))
+}
+
+# Alternatively, use the prefect_worker_metadata datasource
+# to load a default base job configuration dynamically.
 data "prefect_worker_metadata" "d" {}
 
 resource "prefect_work_pool" "example" {

--- a/examples/resources/prefect_work_pool/resource.tf
+++ b/examples/resources/prefect_work_pool/resource.tf
@@ -7,7 +7,7 @@ resource "prefect_work_pool" "example" {
 
 # Use a JSON file to load a custom base job template,
 # since it will likely be a large JSON object.
-resource "prefect_work_pool" "example" {
+resource "prefect_work_pool" "example_with_file" {
   name              = "test-k8s-pool"
   type              = "kubernetes"
   workspace_id      = data.prefect_workspace.prd.id
@@ -22,7 +22,7 @@ resource "prefect_work_pool" "example" {
 # Terraform's `file()` input does not perform any encoding
 # to normalize the input. If this is a problem for you, you
 # can wrap the file input in a jsonencode/jsondecode call:
-resource "prefect_work_pool" "example" {
+resource "prefect_work_pool" "example_with_file_encoded" {
   name              = "test-k8s-pool"
   type              = "kubernetes"
   workspace_id      = data.prefect_workspace.prd.id
@@ -34,7 +34,7 @@ resource "prefect_work_pool" "example" {
 # to load a default base job configuration dynamically.
 data "prefect_worker_metadata" "d" {}
 
-resource "prefect_work_pool" "example" {
+resource "prefect_work_pool" "example_with_datasource" {
   name              = "test-k8s-pool"
   type              = "kubernetes"
   workspace_id      = data.prefect_workspace.prd.id


### PR DESCRIPTION
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/259

in #340, @mitchnielsen updated our baseJobTemplate handling to rely on the json.NormalizedType semantic equality checking.  By definition, this type should do the following:

>  Semantic equality logic is defined for Normalized such that inconsequential differences between JSON strings are ignored (whitespace, property order, etc). If you need strict, byte-for-byte, string equality, consider using ExactType.

however, there is an edge case with `file()` + resource imports, as our provider logic's equality checking only kicks in after the provider framework computes plan diffs (diff check = compare HCL to State object).  Therefore, when importing a resource + using `file()`, you will still get plan diffs from inconsequential whitespace changes:

```
➜ terraform import prefect_work_pool.import c63d708d-b4d7-49a7-92b1-e067e65c99d7,import-me
prefect_work_pool.import: Importing from ID "c63d708d-b4d7-49a7-92b1-e067e65c99d7,import-me"...
prefect_work_pool.import: Import prepared!
  Prepared prefect_work_pool for import
prefect_work_pool.import: Refreshing state...

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

➜ terraform plan
prefect_work_pool.import: Refreshing state... [id=7ccace8a-ea08-405b-8625-c3a67156f140]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # prefect_work_pool.import will be updated in-place
  ~ resource "prefect_work_pool" "import" {
      ~ base_job_template = jsonencode( # whitespace changes
            {
                job_configuration = {
                    cluster_config            = "{{ cluster_config }}"
                    command                   = "{{ command }}"

# ...
```

when we use `file()`, the framework interprets this input as raw, non-normalized byte strings.  so when we import a resource:
1. TF will `Read()` the existing API object, save the value to State - this includes the `base_job_template` string for example as a `json.NormalizedType`
2. Subsequent `terraform plan` will read our HCL, which uses `file()` - this is pulled in as the raw byte string, without any knowledge that this is normalized JSON
3. The framework will detect a plan diff before stepping into our provider logic, where the `json.NormalizedType` semantic equality check can be performed and deemed a no-op

This diff behavior is better explained by this comment in the TF core repo, stating that `file()` inputs can only be evaluated via exact character matching due to how different OS-es handled file encodings

https://github.com/hashicorp/terraform/issues/23928#issuecomment-577781506

If we want to be able to treat `file()` as semantically equal to their JSON representations in a remote environment, there's a few ways to do this via PlanModifiers.  But, I'd like to first expand our documented cases to suggest wrapping `file()` with a `jsonencode(jsondecode(file(...)))` chain, which achieves this same effect for our users.  This is a pattern surfaced in one of the AWS providers

https://github.com/hashicorp/terraform-provider-aws/issues/25340#issuecomment-1681108658

Essentially, we're coercing the file input to be normalized JSON via `jsonencode()` -- this will allow our underlying type system to do what we'd expect moving forward, and result in a no-op after an import


