### PR TITLE
fix(CI): set environment for sweepers action

### DIFF
--- a/.github/workflows/acceptance-tests-sweepers.yaml
+++ b/.github/workflows/acceptance-tests-sweepers.yaml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
     name: Run Sweepers
+    environment: 'Acceptance Tests (main)'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The sweepers need access to the Prefect environment secrets, which are scoped to a GitHub environment.

Related to https://linear.app/prefect/issue/PLA-642/ensure-ephemeral-workspaces-are-cleaned-up-consistently