### PR TITLE
chore(tests): standardize imports and their tests

### DIFF
--- a/docs/resources/automation.md
+++ b/docs/resources/automation.md
@@ -527,14 +527,9 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-# prefect_automation resources can be imported by the Automation ID
+# prefect_automation resources can be imported by the automation_id
 terraform import prefect_automation.my_automation 00000000-0000-0000-0000-000000000000
-
-# Pass an optional, comma-separated value following the identifier
-# if you need to import a resource in a different workspace
-# from the one that your provider is configured with
-# NOTE: you must specify the workspace_id attribute in the addressed resource
 #
-# <automation_id>,<workspace_id>
+# or from a different workspace via automation_id,workspace_id
 terraform import prefect_automation.my_automation 00000000-0000-0000-0000-000000000000,11111111-1111-1111-1111-111111111111
 ```

--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -133,14 +133,9 @@ For more information on the `$ref` syntax definition, see the
 Import is supported using the following syntax:
 
 ```shell
-# prefect_block resources can be imported by the Block ID
+# prefect_block resources can be imported by the block_id
 terraform import prefect_block.my_block 00000000-0000-0000-0000-000000000000
-
-# Pass an optional, comma-separated value following the identifier
-# if you need to import a resource in a different workspace
-# from the one that your provider is configured with
-# NOTE: you must specify the workspace_id attribute in the addressed resource
 #
-# <block_id>,<workspace_id>
+# or from a different workspace via block_id,workspace_id
 terraform import prefect_block.my_block 00000000-0000-0000-0000-000000000000,11111111-1111-1111-1111-111111111111
 ```

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -158,7 +158,7 @@ Import is supported using the following syntax:
 # Prefect Deployments can be imported via deployment_id
 terraform import prefect_deployment.example 00000000-0000-0000-0000-000000000000
 
-# or via deployment_id,workspace_id
+# or from a different workspace via deployment_id,workspace_id
 terraform import prefect_deployment.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000
 ```
 

--- a/docs/resources/flow.md
+++ b/docs/resources/flow.md
@@ -49,6 +49,9 @@ resource "prefect_flow" "flow" {
 Import is supported using the following syntax:
 
 ```shell
-# Prefect Flows can be imported via flow_id,workspace_id
+# Prefect Flows can be imported via flow_id
+terraform import prefect_flow.example 00000000-0000-0000-0000-000000000000
+
+# or from a different workspace via flow_id,workspace_id
 terraform import prefect_flow.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/global_concurrency_limit.md
+++ b/docs/resources/global_concurrency_limit.md
@@ -50,3 +50,12 @@ resource "prefect_global_concurrency_limit" "test" {
 - `created` (String) Timestamp of when the resource was created (RFC3339)
 - `id` (String) Global concurrency limit ID (UUID)
 - `updated` (String) Timestamp of when the resource was updated (RFC3339)
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Prefect global concurrency limits can be imported via id,workspace_id
+terraform import prefect_global_concurrency_limit.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000
+```

--- a/docs/resources/global_concurrency_limit.md
+++ b/docs/resources/global_concurrency_limit.md
@@ -56,6 +56,9 @@ resource "prefect_global_concurrency_limit" "test" {
 Import is supported using the following syntax:
 
 ```shell
-# Prefect global concurrency limits can be imported via id,workspace_id
+# Prefect global concurrency limits can be imported via global_concurrency_limit_id
+terraform import prefect_global_concurrency_limit.example 00000000-0000-0000-0000-000000000000
+
+# or from a different workspace via global_concurrency_limit_id,workspace_id
 terraform import prefect_global_concurrency_limit.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -102,9 +102,9 @@ resource "prefect_service_account" "example_old_key_expires_later" {
 Import is supported using the following syntax:
 
 ```shell
-# Prefect Service Accounts can be imported via name in the form `name/my-bot-name`
+# Prefect Service Accounts can be imported by name in the form `name/my-bot-name`
 terraform import prefect_service_account.example name/my-bot-name
 
-# Prefect Service Accounts can also be imported via UUID
+# or via UUID
 terraform import prefect_service_account.example 00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/task_run_concurrency_limit.md
+++ b/docs/resources/task_run_concurrency_limit.md
@@ -63,3 +63,12 @@ if __name__ == "__main__":
 - `created` (String) Timestamp of when the resource was created (RFC3339)
 - `id` (String) Task run concurrency limit ID (UUID)
 - `updated` (String) Timestamp of when the resource was updated (RFC3339)
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Prefect task run concurrency limits can be imported via id,workspace_id
+terraform import prefect_task_run_concurrency_limit.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000
+```

--- a/docs/resources/task_run_concurrency_limit.md
+++ b/docs/resources/task_run_concurrency_limit.md
@@ -69,6 +69,9 @@ if __name__ == "__main__":
 Import is supported using the following syntax:
 
 ```shell
-# Prefect task run concurrency limits can be imported via id,workspace_id
+# Prefect task run concurrency limits can be imported via task_run_concurrency_limit_id
+terraform import prefect_task_run_concurrency_limit.example 00000000-0000-0000-0000-000000000000
+
+# or from a different workspace via task_run_concurrency_limit_id,workspace_id
 terraform import prefect_task_run_concurrency_limit.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -47,16 +47,12 @@ Import is supported using the following syntax:
 # prefect_variable resources can be imported by the `name/name_of_variable` identifier
 terraform import prefect_variable.example name/name_of_variable
 
-# Alternatively, they can be imported by the variable's ID
+# or via variable_id
 terraform import prefect_variable.example 00000000-0000-0000-0000-000000000000
 
-# Pass an optional, comma-separated value following the identifier
-# if you need to import a resource in a different workspace
-# from the one that your provider is configured with
-# NOTE: you must specify the workspace_id attribute in the addressed resource
-#
-# name/<variable_name>,<workspace_id>
+# or from a different workspace via name/variable_name,workspace_id
 terraform import prefect_variable.example name/name_of_variable,11111111-1111-1111-1111-111111111111
-# <variable_id>,<workspace_id>
+
+# or from a different workspace via variable_id,workspace_id
 terraform import prefect_variable.example 00000000-0000-0000-0000-000000000000,11111111-1111-1111-1111-111111111111
 ```

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -101,9 +101,9 @@ output "endpoints" {
 Import is supported using the following syntax:
 
 ```shell
-# Prefect Webhooks can be imported using the format `id,workspace_id`
-terraform import prefect_webhook.example 11111111-1111-1111-1111-111111111111,00000000-0000-0000-0000-000000000000
+# Prefect Webhooks can be imported using the webhook_id
+terraform import prefect_webhook.example 11111111-1111-1111-1111-111111111111
 
-# You can also import by id only if you have a workspace_id set in your provider
-terraform import prefect_webhook.example 00000000-0000-0000-0000-000000000000
+# or from a different workspace via the webhook_id,workspace_id
+terraform import prefect_webhook.example 11111111-1111-1111-1111-111111111111,00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -101,7 +101,7 @@ output "endpoints" {
 Import is supported using the following syntax:
 
 ```shell
-# Prefect Webhooks can be imported using the format `workspace_id,id`
+# Prefect Webhooks can be imported using the format `id,workspace_id`
 terraform import prefect_webhook.example 11111111-1111-1111-1111-111111111111,00000000-0000-0000-0000-000000000000
 
 # You can also import by id only if you have a workspace_id set in your provider

--- a/docs/resources/work_pool.md
+++ b/docs/resources/work_pool.md
@@ -90,9 +90,9 @@ resource "prefect_work_pool" "example_with_datasource" {
 Import is supported using the following syntax:
 
 ```shell
-# Prefect Work Pools can be imported using the format `name,workspace_id`
-terraform import prefect_work_pool.example kubernetes-work-pool,00000000-0000-0000-0000-000000000000
-
-# You can also import by name only if you have a workspace_id set in your provider
+# Prefect Work Pools can be imported using the name
 terraform import prefect_work_pool.example kubernetes-work-pool
+
+# or from a different workspace via name,workspace_id
+terraform import prefect_work_pool.example kubernetes-work-pool,00000000-0000-0000-0000-000000000000
 ```

--- a/docs/resources/work_pool.md
+++ b/docs/resources/work_pool.md
@@ -90,8 +90,8 @@ resource "prefect_work_pool" "example_with_datasource" {
 Import is supported using the following syntax:
 
 ```shell
-# Prefect Work Pools can be imported using the format `workspace_id,name`
-terraform import prefect_work_pool.example 00000000-0000-0000-0000-000000000000,kubernetes-work-pool
+# Prefect Work Pools can be imported using the format `name,workspace_id`
+terraform import prefect_work_pool.example kubernetes-work-pool,00000000-0000-0000-0000-000000000000
 
 # You can also import by name only if you have a workspace_id set in your provider
 terraform import prefect_work_pool.example kubernetes-work-pool

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -43,9 +43,9 @@ resource "prefect_workspace" "example" {
 Import is supported using the following syntax:
 
 ```shell
-# Prefect Workspaces can be imported via handle in the form `handle/workspace-handle`
+# Prefect Workspaces can be imported via `handle/workspace-handle`
 terraform import prefect_workspace.example handle/workspace-handle
 
-# Prefect Workspaces can also be imported via UUID
+# or via workspace_id
 terraform import prefect_workspace.example 00000000-0000-0000-0000-000000000000
 ```

--- a/examples/resources/prefect_automation/import.sh
+++ b/examples/resources/prefect_automation/import.sh
@@ -1,11 +1,6 @@
-# prefect_automation resources can be imported by the Automation ID
+# prefect_automation resources can be imported by the automation_id
 terraform import prefect_automation.my_automation 00000000-0000-0000-0000-000000000000
-
-# Pass an optional, comma-separated value following the identifier
-# if you need to import a resource in a different workspace
-# from the one that your provider is configured with
-# NOTE: you must specify the workspace_id attribute in the addressed resource
 #
-# <automation_id>,<workspace_id>
+# or from a different workspace via automation_id,workspace_id
 terraform import prefect_automation.my_automation 00000000-0000-0000-0000-000000000000,11111111-1111-1111-1111-111111111111
 

--- a/examples/resources/prefect_block/import.sh
+++ b/examples/resources/prefect_block/import.sh
@@ -1,11 +1,6 @@
-# prefect_block resources can be imported by the Block ID
+# prefect_block resources can be imported by the block_id
 terraform import prefect_block.my_block 00000000-0000-0000-0000-000000000000
-
-# Pass an optional, comma-separated value following the identifier
-# if you need to import a resource in a different workspace
-# from the one that your provider is configured with
-# NOTE: you must specify the workspace_id attribute in the addressed resource
 #
-# <block_id>,<workspace_id>
+# or from a different workspace via block_id,workspace_id
 terraform import prefect_block.my_block 00000000-0000-0000-0000-000000000000,11111111-1111-1111-1111-111111111111
 

--- a/examples/resources/prefect_deployment/import.sh
+++ b/examples/resources/prefect_deployment/import.sh
@@ -1,5 +1,5 @@
 # Prefect Deployments can be imported via deployment_id
 terraform import prefect_deployment.example 00000000-0000-0000-0000-000000000000
 
-# or via deployment_id,workspace_id
+# or from a different workspace via deployment_id,workspace_id
 terraform import prefect_deployment.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_flow/import.sh
+++ b/examples/resources/prefect_flow/import.sh
@@ -1,2 +1,5 @@
-# Prefect Flows can be imported via flow_id,workspace_id
+# Prefect Flows can be imported via flow_id
+terraform import prefect_flow.example 00000000-0000-0000-0000-000000000000
+
+# or from a different workspace via flow_id,workspace_id
 terraform import prefect_flow.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_global_concurrency_limit/import.sh
+++ b/examples/resources/prefect_global_concurrency_limit/import.sh
@@ -1,0 +1,2 @@
+# Prefect global concurrency limits can be imported via id,workspace_id
+terraform import prefect_global_concurrency_limit.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_global_concurrency_limit/import.sh
+++ b/examples/resources/prefect_global_concurrency_limit/import.sh
@@ -1,2 +1,5 @@
-# Prefect global concurrency limits can be imported via id,workspace_id
+# Prefect global concurrency limits can be imported via global_concurrency_limit_id
+terraform import prefect_global_concurrency_limit.example 00000000-0000-0000-0000-000000000000
+
+# or from a different workspace via global_concurrency_limit_id,workspace_id
 terraform import prefect_global_concurrency_limit.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_service_account/import.sh
+++ b/examples/resources/prefect_service_account/import.sh
@@ -1,5 +1,5 @@
-# Prefect Service Accounts can be imported via name in the form `name/my-bot-name`
+# Prefect Service Accounts can be imported by name in the form `name/my-bot-name`
 terraform import prefect_service_account.example name/my-bot-name
 
-# Prefect Service Accounts can also be imported via UUID
+# or via UUID
 terraform import prefect_service_account.example 00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_task_run_concurrency_limit/import.sh
+++ b/examples/resources/prefect_task_run_concurrency_limit/import.sh
@@ -1,0 +1,2 @@
+# Prefect task run concurrency limits can be imported via id,workspace_id
+terraform import prefect_task_run_concurrency_limit.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_task_run_concurrency_limit/import.sh
+++ b/examples/resources/prefect_task_run_concurrency_limit/import.sh
@@ -1,2 +1,5 @@
-# Prefect task run concurrency limits can be imported via id,workspace_id
+# Prefect task run concurrency limits can be imported via task_run_concurrency_limit_id
+terraform import prefect_task_run_concurrency_limit.example 00000000-0000-0000-0000-000000000000
+
+# or from a different workspace via task_run_concurrency_limit_id,workspace_id
 terraform import prefect_task_run_concurrency_limit.example 00000000-0000-0000-0000-000000000000,00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_variable/import.sh
+++ b/examples/resources/prefect_variable/import.sh
@@ -1,16 +1,12 @@
 # prefect_variable resources can be imported by the `name/name_of_variable` identifier
 terraform import prefect_variable.example name/name_of_variable
 
-# Alternatively, they can be imported by the variable's ID
+# or via variable_id
 terraform import prefect_variable.example 00000000-0000-0000-0000-000000000000
 
-# Pass an optional, comma-separated value following the identifier
-# if you need to import a resource in a different workspace
-# from the one that your provider is configured with
-# NOTE: you must specify the workspace_id attribute in the addressed resource
-#
-# name/<variable_name>,<workspace_id>
+# or from a different workspace via name/variable_name,workspace_id
 terraform import prefect_variable.example name/name_of_variable,11111111-1111-1111-1111-111111111111
-# <variable_id>,<workspace_id>
+
+# or from a different workspace via variable_id,workspace_id
 terraform import prefect_variable.example 00000000-0000-0000-0000-000000000000,11111111-1111-1111-1111-111111111111
 

--- a/examples/resources/prefect_webhook/import.sh
+++ b/examples/resources/prefect_webhook/import.sh
@@ -1,4 +1,4 @@
-# Prefect Webhooks can be imported using the format `workspace_id,id`
+# Prefect Webhooks can be imported using the format `id,workspace_id`
 terraform import prefect_webhook.example 11111111-1111-1111-1111-111111111111,00000000-0000-0000-0000-000000000000
 
 # You can also import by id only if you have a workspace_id set in your provider

--- a/examples/resources/prefect_webhook/import.sh
+++ b/examples/resources/prefect_webhook/import.sh
@@ -1,5 +1,5 @@
-# Prefect Webhooks can be imported using the format `id,workspace_id`
-terraform import prefect_webhook.example 11111111-1111-1111-1111-111111111111,00000000-0000-0000-0000-000000000000
+# Prefect Webhooks can be imported using the webhook_id
+terraform import prefect_webhook.example 11111111-1111-1111-1111-111111111111
 
-# You can also import by id only if you have a workspace_id set in your provider
-terraform import prefect_webhook.example 00000000-0000-0000-0000-000000000000
+# or from a different workspace via the webhook_id,workspace_id
+terraform import prefect_webhook.example 11111111-1111-1111-1111-111111111111,00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_work_pool/import.sh
+++ b/examples/resources/prefect_work_pool/import.sh
@@ -1,5 +1,5 @@
-# Prefect Work Pools can be imported using the format `workspace_id,name`
-terraform import prefect_work_pool.example 00000000-0000-0000-0000-000000000000,kubernetes-work-pool
+# Prefect Work Pools can be imported using the format `name,workspace_id`
+terraform import prefect_work_pool.example kubernetes-work-pool,00000000-0000-0000-0000-000000000000
 
 # You can also import by name only if you have a workspace_id set in your provider
 terraform import prefect_work_pool.example kubernetes-work-pool

--- a/examples/resources/prefect_work_pool/import.sh
+++ b/examples/resources/prefect_work_pool/import.sh
@@ -1,5 +1,5 @@
-# Prefect Work Pools can be imported using the format `name,workspace_id`
-terraform import prefect_work_pool.example kubernetes-work-pool,00000000-0000-0000-0000-000000000000
-
-# You can also import by name only if you have a workspace_id set in your provider
+# Prefect Work Pools can be imported using the name
 terraform import prefect_work_pool.example kubernetes-work-pool
+
+# or from a different workspace via name,workspace_id
+terraform import prefect_work_pool.example kubernetes-work-pool,00000000-0000-0000-0000-000000000000

--- a/examples/resources/prefect_workspace/import.sh
+++ b/examples/resources/prefect_workspace/import.sh
@@ -1,5 +1,5 @@
-# Prefect Workspaces can be imported via handle in the form `handle/workspace-handle`
+# Prefect Workspaces can be imported via `handle/workspace-handle`
 terraform import prefect_workspace.example handle/workspace-handle
 
-# Prefect Workspaces can also be imported via UUID
+# or via workspace_id
 terraform import prefect_workspace.example 00000000-0000-0000-0000-000000000000

--- a/internal/provider/helpers/import_state.go
+++ b/internal/provider/helpers/import_state.go
@@ -50,14 +50,14 @@ func importState(ctx context.Context, req resource.ImportStateRequest, resp *res
 	}
 }
 
-// ImportState imports the resource into Terraform state.
+// ImportStateByID imports the resource into Terraform state.
 //
 // Allows input values in the form of:
 // - "id,workspace_id"
 // - "id"
 //
 // To import by name instead of ID, see ImportStateByName.
-func ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func ImportStateByID(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	importState(ctx, req, resp, "id")
 }
 
@@ -67,7 +67,7 @@ func ImportState(ctx context.Context, req resource.ImportStateRequest, resp *res
 // - "name,workspace_id"
 // - "name"
 //
-// To import by ID instead of name, see ImportState.
+// To import by ID instead of name, see ImportStateByID.
 func ImportStateByName(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	importState(ctx, req, resp, "name")
 }

--- a/internal/provider/helpers/import_state.go
+++ b/internal/provider/helpers/import_state.go
@@ -34,6 +34,10 @@ func importState(ctx context.Context, req resource.ImportStateRequest, resp *res
 		return
 	}
 
+	// Set the attribute for the given identifier.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(identifier), inputParts[0])...)
+
+	// Set the attribute for the workspace_id, if provided.
 	if len(inputParts) == maxInputCount {
 		workspaceID, err := uuid.Parse(inputParts[1])
 		if err != nil {
@@ -42,10 +46,7 @@ func importState(ctx context.Context, req resource.ImportStateRequest, resp *res
 			return
 		}
 
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(identifier), inputParts[0])...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID.String())...)
-	} else {
-		resource.ImportStatePassthroughID(ctx, path.Root(identifier), req, resp)
 	}
 }
 

--- a/internal/provider/helpers/import_state.go
+++ b/internal/provider/helpers/import_state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
@@ -34,11 +35,15 @@ func importState(ctx context.Context, req resource.ImportStateRequest, resp *res
 	}
 
 	if len(inputParts) == maxInputCount {
-		id := inputParts[0]
-		workspaceID := inputParts[1]
+		workspaceID, err := uuid.Parse(inputParts[1])
+		if err != nil {
+			resp.Diagnostics.Append(ParseUUIDErrorDiagnostic("Import", err))
 
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(identifier), id)...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID)...)
+			return
+		}
+
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(identifier), inputParts[0])...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID.String())...)
 	} else {
 		resource.ImportStatePassthroughID(ctx, path.Root(identifier), req, resp)
 	}

--- a/internal/provider/helpers/import_state.go
+++ b/internal/provider/helpers/import_state.go
@@ -1,0 +1,53 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// ImportState imports the resource into Terraform state.
+//
+// We'll allow input values in the form of:
+// - "id,workspace_id"
+// - "id"
+//
+// This is the most common import pattern. If the import pattern for
+// a resource differs, define it in that resource's `ImportState` method.
+func ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	maxInputCount := 2
+	inputParts := strings.Split(req.ID, ",")
+
+	// eg. "foo,bar,baz"
+	if len(inputParts) > maxInputCount {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
+		)
+
+		return
+	}
+
+	// eg. ",foo" or "foo,"
+	if len(inputParts) == maxInputCount && (inputParts[0] == "" || inputParts[1] == "") {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected non-empty import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
+		)
+
+		return
+	}
+
+	if len(inputParts) == maxInputCount {
+		id := inputParts[0]
+		workspaceID := inputParts[1]
+
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID)...)
+	} else {
+		resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	}
+}

--- a/internal/provider/helpers/import_state.go
+++ b/internal/provider/helpers/import_state.go
@@ -9,15 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-// ImportState imports the resource into Terraform state.
-//
-// We'll allow input values in the form of:
-// - "id,workspace_id"
-// - "id"
-//
-// This is the most common import pattern. If the import pattern for
-// a resource differs, define it in that resource's `ImportState` method.
-func ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func importState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse, identifier string) {
 	maxInputCount := 2
 	inputParts := strings.Split(req.ID, ",")
 
@@ -25,7 +17,7 @@ func ImportState(ctx context.Context, req resource.ImportStateRequest, resp *res
 	if len(inputParts) > maxInputCount {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
+			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `%s,workspace_id`. Got %q", identifier, req.ID),
 		)
 
 		return
@@ -35,7 +27,7 @@ func ImportState(ctx context.Context, req resource.ImportStateRequest, resp *res
 	if len(inputParts) == maxInputCount && (inputParts[0] == "" || inputParts[1] == "") {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected non-empty import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
+			fmt.Sprintf("Expected non-empty import identifiers, in the form of `%s,workspace_id`. Got %q", identifier, req.ID),
 		)
 
 		return
@@ -45,9 +37,31 @@ func ImportState(ctx context.Context, req resource.ImportStateRequest, resp *res
 		id := inputParts[0]
 		workspaceID := inputParts[1]
 
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(identifier), id)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID)...)
 	} else {
-		resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+		resource.ImportStatePassthroughID(ctx, path.Root(identifier), req, resp)
 	}
+}
+
+// ImportState imports the resource into Terraform state.
+//
+// Allows input values in the form of:
+// - "id,workspace_id"
+// - "id"
+//
+// To import by name instead of ID, see ImportStateByName.
+func ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	importState(ctx, req, resp, "id")
+}
+
+// ImportState imports the resource into Terraform state.
+//
+// Allows input values in the form of:
+// - "name,workspace_id"
+// - "name"
+//
+// To import by ID instead of name, see ImportState.
+func ImportStateByName(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	importState(ctx, req, resp, "name")
 }

--- a/internal/provider/resources/automation_resource.go
+++ b/internal/provider/resources/automation_resource.go
@@ -248,7 +248,7 @@ func (r *AutomationResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 // ImportState imports the resource into Terraform state.
 func (r *AutomationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	helpers.ImportState(ctx, req, resp)
+	helpers.ImportStateByID(ctx, req, resp)
 
 	// We need to set the trigger to an empty TriggerModel during import
 	// to avoid null value errors (Value Conversion Errors) from the provider framework.

--- a/internal/provider/resources/automation_resource.go
+++ b/internal/provider/resources/automation_resource.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -248,33 +247,8 @@ func (r *AutomationResource) Delete(ctx context.Context, req resource.DeleteRequ
 }
 
 // ImportState imports the resource into Terraform state.
-// Valid import IDs:
-// <automation_id>
-// <automation_id>,<workspace_id>.
 func (r *AutomationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts := strings.Split(req.ID, ",")
-
-	if len(parts) > 2 || len(parts) == 0 {
-		resp.Diagnostics.AddError(
-			"Error importing Automation",
-			"Import ID must be in the format of <automation_id> OR <automation_id>,<workspace_id>",
-		)
-
-		return
-	}
-
-	automationID := parts[0]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), automationID)...)
-
-	if len(parts) == 2 && parts[1] != "" {
-		workspaceID, err := uuid.Parse(parts[1])
-		if err != nil {
-			resp.Diagnostics.Append(helpers.ParseUUIDErrorDiagnostic("Workspace", err))
-
-			return
-		}
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID.String())...)
-	}
+	helpers.ImportState(ctx, req, resp)
 
 	// We need to set the trigger to an empty TriggerModel during import
 	// to avoid null value errors (Value Conversion Errors) from the provider framework.

--- a/internal/provider/resources/automation_test.go
+++ b/internal/provider/resources/automation_test.go
@@ -332,7 +332,7 @@ func TestAccResource_automation(t *testing.T) {
 			{
 				ImportState:       true,
 				ResourceName:      eventTriggerAutomationResourceNameAndPath,
-				ImportStateIdFunc: getAutomationImportStateID(eventTriggerAutomationResourceNameAndPath),
+				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(eventTriggerAutomationResourceNameAndPath),
 				ImportStateVerify: true,
 			},
 			{
@@ -365,7 +365,7 @@ func TestAccResource_automation(t *testing.T) {
 			{
 				ImportState:       true,
 				ResourceName:      metricTriggerAutomationResourceNameAndPath,
-				ImportStateIdFunc: getAutomationImportStateID(metricTriggerAutomationResourceNameAndPath),
+				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(metricTriggerAutomationResourceNameAndPath),
 				ImportStateVerify: true,
 			},
 			{
@@ -508,23 +508,5 @@ func testAccCheckAutomationResourceExists(automationResourceName string, automat
 		*automation = *fetchedAutomation
 
 		return nil
-	}
-}
-
-func getAutomationImportStateID(automationResourceName string) resource.ImportStateIdFunc {
-	return func(state *terraform.State) (string, error) {
-		workspaceResource, exists := state.RootModule().Resources[testutils.WorkspaceResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", testutils.WorkspaceResourceName)
-		}
-		workspaceID, _ := uuid.Parse(workspaceResource.Primary.ID)
-
-		automationResource, exists := state.RootModule().Resources[automationResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", automationResourceName)
-		}
-		automationID := automationResource.Primary.ID
-
-		return fmt.Sprintf("%s,%s", automationID, workspaceID), nil
 	}
 }

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -450,5 +450,5 @@ func (r *BlockResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 // ImportState imports the resource into Terraform state.
 func (r *BlockResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	helpers.ImportState(ctx, req, resp)
+	helpers.ImportStateByID(ctx, req, resp)
 }

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -3,13 +3,11 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -451,31 +449,6 @@ func (r *BlockResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 }
 
 // ImportState imports the resource into Terraform state.
-// Valid import IDs:
-// <block_id>
-// <block_id>,<workspace_id>.
 func (r *BlockResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts := strings.Split(req.ID, ",")
-
-	if len(parts) > 2 || len(parts) == 0 {
-		resp.Diagnostics.AddError(
-			"Error importing Block",
-			"Import ID must be in the format of <block identifier> OR <block identifier>,<workspace_id>",
-		)
-
-		return
-	}
-
-	blockIdentifier := parts[0]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), blockIdentifier)...)
-
-	if len(parts) == 2 && parts[1] != "" {
-		workspaceID, err := uuid.Parse(parts[1])
-		if err != nil {
-			resp.Diagnostics.Append(helpers.ParseUUIDErrorDiagnostic("Workspace", err))
-
-			return
-		}
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID.String())...)
-	}
+	helpers.ImportState(ctx, req, resp)
 }

--- a/internal/provider/resources/block_test.go
+++ b/internal/provider/resources/block_test.go
@@ -131,7 +131,7 @@ func TestAccResource_block(t *testing.T) {
 			{
 				ImportState:       true,
 				ResourceName:      blockResourceName,
-				ImportStateIdFunc: getBlockImportStateID(blockResourceName),
+				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(blockResourceName),
 				ImportStateVerify: false,
 			},
 		},
@@ -197,25 +197,5 @@ func testAccCheckBlockValues(fetchedBlockDocument *api.BlockDocument, expectedVa
 		}
 
 		return nil
-	}
-}
-
-// getBlockImportStateID generates the Import ID used in the test assertion,
-// since we need to construct one that includes the Block ID and the Workspace ID.
-func getBlockImportStateID(blockResourceName string) resource.ImportStateIdFunc {
-	return func(state *terraform.State) (string, error) {
-		workspaceResource, exists := state.RootModule().Resources[testutils.WorkspaceResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", testutils.WorkspaceResourceName)
-		}
-		workspaceID, _ := uuid.Parse(workspaceResource.Primary.ID)
-
-		blockResource, exists := state.RootModule().Resources[blockResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", blockResourceName)
-		}
-		blockID, _ := uuid.Parse(blockResource.Primary.ID)
-
-		return fmt.Sprintf("%s,%s", blockID, workspaceID), nil
 	}
 }

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -924,7 +924,7 @@ func (r *DeploymentResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 // ImportState imports the resource into Terraform state.
 func (r *DeploymentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	helpers.ImportState(ctx, req, resp)
+	helpers.ImportStateByID(ctx, req, resp)
 }
 
 // pathExpressionsForAttributes provides a list of path expressions

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -925,44 +924,7 @@ func (r *DeploymentResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 // ImportState imports the resource into Terraform state.
 func (r *DeploymentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// we'll allow input values in the form of:
-	// - "id,workspace_id"
-	// - "id"
-	maxInputCount := 2
-	inputParts := strings.Split(req.ID, ",")
-
-	// eg. "foo,bar,baz"
-	if len(inputParts) > maxInputCount {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	// eg. ",foo" or "foo,"
-	if len(inputParts) == maxInputCount && (inputParts[0] == "" || inputParts[1] == "") {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected non-empty import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	identifier := inputParts[0]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), identifier)...)
-
-	if len(inputParts) == 2 && inputParts[1] != "" {
-		workspaceID, err := uuid.Parse(inputParts[1])
-		if err != nil {
-			resp.Diagnostics.Append(helpers.ParseUUIDErrorDiagnostic("Deployment", err))
-
-			return
-		}
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID.String())...)
-	}
+	helpers.ImportState(ctx, req, resp)
 }
 
 // pathExpressionsForAttributes provides a list of path expressions

--- a/internal/provider/resources/flow.go
+++ b/internal/provider/resources/flow.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 var (
@@ -306,42 +306,5 @@ func (r *FlowResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 // ImportState imports the resource into Terraform state.
 func (r *FlowResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// we'll allow input values in the form of:
-	// - "id,workspace_id"
-	// - "id"
-	maxInputCount := 2
-	inputParts := strings.Split(req.ID, ",")
-
-	// eg. "foo,bar,baz"
-	if len(inputParts) > maxInputCount {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `name,workspace_id`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	// eg. ",foo" or "foo,"
-	if len(inputParts) == maxInputCount && (inputParts[0] == "" || inputParts[1] == "") {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected non-empty import identifiers, in the form of `workspace_id,name`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	identifier := inputParts[0]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), identifier)...)
-
-	if len(inputParts) == 2 && inputParts[1] != "" {
-		workspaceID, err := uuid.Parse(inputParts[1])
-		if err != nil {
-			resp.Diagnostics.AddError("problem parsing workspace ID", "see details")
-
-			return
-		}
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID.String())...)
-	}
+	helpers.ImportState(ctx, req, resp)
 }

--- a/internal/provider/resources/flow.go
+++ b/internal/provider/resources/flow.go
@@ -306,5 +306,5 @@ func (r *FlowResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 // ImportState imports the resource into Terraform state.
 func (r *FlowResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	helpers.ImportState(ctx, req, resp)
+	helpers.ImportStateByID(ctx, req, resp)
 }

--- a/internal/provider/resources/global_concurrency_limit.go
+++ b/internal/provider/resources/global_concurrency_limit.go
@@ -303,5 +303,5 @@ func (r *GlobalConcurrencyLimitResource) Update(ctx context.Context, req resourc
 
 // ImportState imports a global concurrency limit.
 func (r *GlobalConcurrencyLimitResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	helpers.ImportState(ctx, req, resp)
+	helpers.ImportStateByID(ctx, req, resp)
 }

--- a/internal/provider/resources/global_concurrency_limit.go
+++ b/internal/provider/resources/global_concurrency_limit.go
@@ -2,14 +2,10 @@ package resources
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -307,42 +303,5 @@ func (r *GlobalConcurrencyLimitResource) Update(ctx context.Context, req resourc
 
 // ImportState imports a global concurrency limit.
 func (r *GlobalConcurrencyLimitResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// we'll allow input values in the form of:
-	// - "id,workspace_id"
-	// - "id"
-	maxInputCount := 2
-	inputParts := strings.Split(req.ID, ",")
-
-	// eg. "foo,bar,baz"
-	if len(inputParts) > maxInputCount {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	// eg. ",foo" or "foo,"
-	if len(inputParts) == maxInputCount && (inputParts[0] == "" || inputParts[1] == "") {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected non-empty import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	identifier := inputParts[0]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), identifier)...)
-
-	if len(inputParts) == 2 && inputParts[1] != "" {
-		workspaceID, err := uuid.Parse(inputParts[1])
-		if err != nil {
-			resp.Diagnostics.Append(helpers.ParseUUIDErrorDiagnostic("Global Concurrency Limit", err))
-
-			return
-		}
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID.String())...)
-	}
+	helpers.ImportState(ctx, req, resp)
 }

--- a/internal/provider/resources/task_run_concurrency_limit.go
+++ b/internal/provider/resources/task_run_concurrency_limit.go
@@ -2,12 +2,8 @@ package resources
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -233,40 +229,5 @@ func (r *TaskRunConcurrencyLimitResource) Update(_ context.Context, _ resource.U
 
 // ImportState imports the resource into Terraform state.
 func (r *TaskRunConcurrencyLimitResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// we'll allow input values in the form of:
-	// - "id,workspace_id"
-	// - "id"
-	maxInputCount := 2
-	inputParts := strings.Split(req.ID, ",")
-
-	// eg. ",foo" or "foo,"
-	if len(inputParts) == maxInputCount && (inputParts[0] == "" || inputParts[1] == "") {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected non-empty import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
-		)
-
-		return
-	}
-	if len(inputParts) > maxInputCount {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `id,workspace_id`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	identifier := inputParts[0]
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), identifier)...)
-
-	if len(inputParts) == 2 && inputParts[1] != "" {
-		workspaceID, err := uuid.Parse(inputParts[1])
-		if err != nil {
-			resp.Diagnostics.Append(helpers.ParseUUIDErrorDiagnostic("Concurrency Limit", err))
-
-			return
-		}
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID.String())...)
-	}
+	helpers.ImportState(ctx, req, resp)
 }

--- a/internal/provider/resources/task_run_concurrency_limit.go
+++ b/internal/provider/resources/task_run_concurrency_limit.go
@@ -229,5 +229,5 @@ func (r *TaskRunConcurrencyLimitResource) Update(_ context.Context, _ resource.U
 
 // ImportState imports the resource into Terraform state.
 func (r *TaskRunConcurrencyLimitResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	helpers.ImportState(ctx, req, resp)
+	helpers.ImportStateByID(ctx, req, resp)
 }

--- a/internal/provider/resources/variable_test.go
+++ b/internal/provider/resources/variable_test.go
@@ -130,6 +130,13 @@ func TestAccResource_variable(t *testing.T) {
 					testutils.ExpectKnownValueList(resourceName, "tags", []string{"foo", "bar"}),
 				},
 			},
+			{
+				ImportState:             true,
+				ResourceName:            resourceName,
+				ImportStateIdFunc:       testutils.GetResourceWorkspaceImportStateID(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value"},
+			},
 		},
 	})
 }

--- a/internal/provider/resources/webhooks.go
+++ b/internal/provider/resources/webhooks.go
@@ -333,5 +333,5 @@ func (r *WebhookResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 // ImportState imports the resource into Terraform state.
 func (r *WebhookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	helpers.ImportState(ctx, req, resp)
+	helpers.ImportStateByID(ctx, req, resp)
 }

--- a/internal/provider/resources/webhooks.go
+++ b/internal/provider/resources/webhooks.go
@@ -3,10 +3,8 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -335,39 +333,5 @@ func (r *WebhookResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 // ImportState imports the resource into Terraform state.
 func (r *WebhookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// we'll allow input values in the form of:
-	// - "workspace_id,id"
-	// - "id"
-	maxInputCount := 2
-	inputParts := strings.Split(req.ID, ",")
-
-	// eg. "foo,bar,baz"
-	if len(inputParts) > maxInputCount {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `workspace_id,name`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	// eg. ",foo" or "foo,"
-	if len(inputParts) == maxInputCount && (inputParts[0] == "" || inputParts[1] == "") {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected non-empty import identifiers, in the form of `workspace_id,name`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	if len(inputParts) == maxInputCount {
-		workspaceID := inputParts[0]
-		id := inputParts[1]
-
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID)...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
-	} else {
-		resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-	}
+	helpers.ImportState(ctx, req, resp)
 }

--- a/internal/provider/resources/webhooks_test.go
+++ b/internal/provider/resources/webhooks_test.go
@@ -134,7 +134,7 @@ func TestAccResource_webhook(t *testing.T) {
 			{
 				ImportState:       true,
 				ResourceName:      webhookResourceName,
-				ImportStateIdFunc: getWebhookImportStateID(webhookResourceName),
+				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(webhookResourceName),
 				ImportStateVerify: true,
 			},
 		},
@@ -186,23 +186,5 @@ func testAccCheckWebhookEndpoint(webhookResourceName string, webhook *api.Webhoo
 		}
 
 		return nil
-	}
-}
-
-func getWebhookImportStateID(webhookResourceName string) resource.ImportStateIdFunc {
-	return func(state *terraform.State) (string, error) {
-		workspaceResource, exists := state.RootModule().Resources[testutils.WorkspaceResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", testutils.WorkspaceResourceName)
-		}
-		workspaceID, _ := uuid.Parse(workspaceResource.Primary.ID)
-
-		webhookResource, exists := state.RootModule().Resources[webhookResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", webhookResourceName)
-		}
-		webhookID := webhookResource.Primary.ID
-
-		return fmt.Sprintf("%s,%s", workspaceID, webhookID), nil
 	}
 }

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -3,12 +3,9 @@ package resources
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -366,39 +363,5 @@ func (r *WorkPoolResource) Delete(ctx context.Context, req resource.DeleteReques
 
 // ImportState imports the resource into Terraform state.
 func (r *WorkPoolResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// we'll allow input values in the form of:
-	// - "workspace_id,name"
-	// - "name"
-	maxInputCount := 2
-	inputParts := strings.Split(req.ID, ",")
-
-	// eg. "foo,bar,baz"
-	if len(inputParts) > maxInputCount {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected a maximum of 2 import identifiers, in the form of `workspace_id,name`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	// eg. ",foo" or "foo,"
-	if len(inputParts) == maxInputCount && (inputParts[0] == "" || inputParts[1] == "") {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected non-empty import identifiers, in the form of `workspace_id,name`. Got %q", req.ID),
-		)
-
-		return
-	}
-
-	if len(inputParts) == maxInputCount {
-		workspaceID := inputParts[0]
-		name := inputParts[1]
-
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), workspaceID)...)
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
-	} else {
-		resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
-	}
+	helpers.ImportStateByName(ctx, req, resp)
 }

--- a/internal/provider/resources/work_pool_test.go
+++ b/internal/provider/resources/work_pool_test.go
@@ -129,7 +129,7 @@ func TestAccResource_work_pool(t *testing.T) {
 			{
 				ImportState:             true,
 				ResourceName:            workPoolResourceName2,
-				ImportStateIdFunc:       getWorkPoolImportStateID(workPoolResourceName2),
+				ImportStateIdFunc:       testutils.GetResourceWorkspaceImportStateID(workPoolResourceName2),
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"base_job_template"}, // we've already tested this, and we can't provide our unique equality check here
 			},
@@ -219,24 +219,6 @@ func testAccCheckIDsNotEqual(resourceName string, fetchedWorkPool *api.WorkPool)
 		}
 
 		return nil
-	}
-}
-
-func getWorkPoolImportStateID(workPoolResourceName string) resource.ImportStateIdFunc {
-	return func(state *terraform.State) (string, error) {
-		workspaceResource, exists := state.RootModule().Resources[testutils.WorkspaceResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", testutils.WorkspaceResourceName)
-		}
-		workspaceID, _ := uuid.Parse(workspaceResource.Primary.ID)
-
-		workPoolResource, exists := state.RootModule().Resources[workPoolResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", workPoolResourceName)
-		}
-		workPoolName := workPoolResource.Primary.Attributes["name"]
-
-		return fmt.Sprintf("%s,%s", workspaceID, workPoolName), nil
 	}
 }
 

--- a/internal/provider/resources/work_pool_test.go
+++ b/internal/provider/resources/work_pool_test.go
@@ -129,7 +129,7 @@ func TestAccResource_work_pool(t *testing.T) {
 			{
 				ImportState:             true,
 				ResourceName:            workPoolResourceName2,
-				ImportStateIdFunc:       testutils.GetResourceWorkspaceImportStateID(workPoolResourceName2),
+				ImportStateIdFunc:       getWorkPoolImportStateID(workPoolResourceName2),
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"base_job_template"}, // we've already tested this, and we can't provide our unique equality check here
 			},
@@ -219,6 +219,24 @@ func testAccCheckIDsNotEqual(resourceName string, fetchedWorkPool *api.WorkPool)
 		}
 
 		return nil
+	}
+}
+
+func getWorkPoolImportStateID(workPoolResourceName string) resource.ImportStateIdFunc {
+	return func(state *terraform.State) (string, error) {
+		workspaceResource, exists := state.RootModule().Resources[testutils.WorkspaceResourceName]
+		if !exists {
+			return "", fmt.Errorf("Resource not found in state: %s", testutils.WorkspaceResourceName)
+		}
+		workspaceID, _ := uuid.Parse(workspaceResource.Primary.ID)
+
+		workPoolResource, exists := state.RootModule().Resources[workPoolResourceName]
+		if !exists {
+			return "", fmt.Errorf("Resource not found in state: %s", workPoolResourceName)
+		}
+		workPoolName := workPoolResource.Primary.Attributes["name"]
+
+		return fmt.Sprintf("%s,%s", workspaceID, workPoolName), nil
 	}
 }
 

--- a/internal/provider/resources/work_pool_test.go
+++ b/internal/provider/resources/work_pool_test.go
@@ -129,7 +129,7 @@ func TestAccResource_work_pool(t *testing.T) {
 			{
 				ImportState:             true,
 				ResourceName:            workPoolResourceName2,
-				ImportStateIdFunc:       getWorkPoolImportStateID(workPoolResourceName2),
+				ImportStateIdFunc:       testutils.GetResourceWorkspaceImportStateIDByName(workPoolResourceName2),
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"base_job_template"}, // we've already tested this, and we can't provide our unique equality check here
 			},
@@ -219,24 +219,6 @@ func testAccCheckIDsNotEqual(resourceName string, fetchedWorkPool *api.WorkPool)
 		}
 
 		return nil
-	}
-}
-
-func getWorkPoolImportStateID(workPoolResourceName string) resource.ImportStateIdFunc {
-	return func(state *terraform.State) (string, error) {
-		workspaceResource, exists := state.RootModule().Resources[testutils.WorkspaceResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", testutils.WorkspaceResourceName)
-		}
-		workspaceID, _ := uuid.Parse(workspaceResource.Primary.ID)
-
-		workPoolResource, exists := state.RootModule().Resources[workPoolResourceName]
-		if !exists {
-			return "", fmt.Errorf("Resource not found in state: %s", workPoolResourceName)
-		}
-		workPoolName := workPoolResource.Primary.Attributes["name"]
-
-		return fmt.Sprintf("%s,%s", workspaceID, workPoolName), nil
 	}
 }
 

--- a/internal/testutils/import.go
+++ b/internal/testutils/import.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-// GetResourceWorkspaceImportStateID is a helper function that returns a resource.ImportStateIdFunc
-// that can be used to import a resource by its ID and workspace ID.
-func GetResourceWorkspaceImportStateID(resourceName string) resource.ImportStateIdFunc {
+// getResourceWorkspaceImportStateID is a helper function that standardizes the format used
+// for importing a resource in the format "<identifier>,<workspace_id>".
+func getResourceWorkspaceImportStateID(resourceName, identifier string) resource.ImportStateIdFunc {
 	return func(state *terraform.State) (string, error) {
 		workspace, exists := state.RootModule().Resources[WorkspaceResourceName]
 		if !exists {
@@ -23,6 +23,18 @@ func GetResourceWorkspaceImportStateID(resourceName string) resource.ImportState
 			return "", fmt.Errorf("resource not found in state: %s", resourceName)
 		}
 
-		return fmt.Sprintf("%s,%s", fetchedResource.Primary.Attributes["id"], workspaceID), nil
+		return fmt.Sprintf("%s,%s", fetchedResource.Primary.Attributes[identifier], workspaceID), nil
 	}
+}
+
+// GetResourceWorkspaceImportStateID is a helper function that returns a resource.ImportStateIdFunc
+// that can be used to import a resource by its ID and workspace ID.
+func GetResourceWorkspaceImportStateID(resourceName string) resource.ImportStateIdFunc {
+	return getResourceWorkspaceImportStateID(resourceName, "id")
+}
+
+// GetResourceWorkspaceImportStateIDByName is a helper function that returns a resource.ImportStateIdFunc
+// that can be used to import a resource by its name and workspace ID.
+func GetResourceWorkspaceImportStateIDByName(resourceName string) resource.ImportStateIdFunc {
+	return getResourceWorkspaceImportStateID(resourceName, "name")
 }

--- a/internal/testutils/import.go
+++ b/internal/testutils/import.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+// GetResourceWorkspaceImportStateID is a helper function that returns a resource.ImportStateIdFunc
+// that can be used to import a resource by its ID and workspace ID.
 func GetResourceWorkspaceImportStateID(resourceName string) resource.ImportStateIdFunc {
 	return func(state *terraform.State) (string, error) {
 		workspace, exists := state.RootModule().Resources[WorkspaceResourceName]


### PR DESCRIPTION
## Summary

Closes https://linear.app/prefect/issue/PLA-999/standardize-import-checks

- Introduces common `ImportStateBy{Name,ID}` functions to reuse among any resources that support importing by `id`/`name` and/or `workspace_id`
- Consistently uses `GetResourceWorkspaceImportStateID` instead of separate but very similar functions to do the same thing.
- Updates the import instructions to reflect the correct argument order.

## Notes

A few resources deviate from the `<identifier>,<workspace_id>` pattern:

```
$ rg 'name\/|handle\/' internal/provider/resources
internal/provider/resources/workspace.go:352:32:        if strings.HasPrefix(req.ID, "handle/") {
internal/provider/resources/workspace.go:353:41:                handle := strings.TrimPrefix(req.ID, "handle/")
internal/provider/resources/service_account_test.go:192:44:                             ImportStateIdPrefix:                  "name/",
internal/provider/resources/workspace_test.go:62:27:                            ImportStateIdPrefix: "handle/",
internal/provider/resources/service_account.go:508:32:  if strings.HasPrefix(req.ID, "name/") {
internal/provider/resources/service_account.go:509:39:          name := strings.TrimPrefix(req.ID, "name/")
internal/provider/resources/variable.go:504:4:// name/<variable_name>
internal/provider/resources/variable.go:505:4:// name/<variable_name>,<workspace_id>
internal/provider/resources/variable.go:522:44: if strings.HasPrefix(variableIdentifier, "name/") {
internal/provider/resources/variable.go:523:51:         name := strings.TrimPrefix(variableIdentifier, "name/")
```

So this includes workspaces, service accounts, and variables. These allow you to use a different prefix like `name/` or `handle/` to import the resource. The logic for these is fairly simple, so to keep this PR as small as possible I left those alone for now.

I also wanted to update the tests to import by ID alone, rather than ID + workspace ID. However, this didn't work because the test client doesn't have access to the `Config` resource to get the workspace value. Looks like this is related to https://github.com/hashicorp/terraform-plugin-testing/issues/11. I did build the provider and test against a real instance, though, and importing a resource by ID alone still worked.