### PR TITLE
chore(tests): use RenderTemplate in tests with longer templates

### DIFF
--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -200,3 +200,18 @@ If the trailing slash is not provided, it can lead to errors such as 404, 405, 3
 A helper script is available in `../scripts/trailing-slash-routes`. Running this will produce JSON output that
 lists which routes end with a slash, along with the method and description to more easily identify which functions
 to check under `../internal/client/*.go`.
+
+### Test fixture helpers
+
+Test fixtures are used to create resources in the test environment. They are typically used to create resources
+that are used in the test, such as a workspace, account, or deployment.
+
+The `internal/provider/helpers` package contains a helper function named `RenderTemplate` that can be used to
+create test fixtures that contain multiple resources. This function is especially useful for creating test fixtures that
+contain multiple resources, making it easier to visually understand where each variable is inserted when compared to
+using `fmt.Sprintf`.
+
+- If the fixture is fairly short and has fewer than 3-5 variables, `fmt.Sprintf` is usually sufficient.
+- If the fixture is longer, or has more than 3-5 variables, `RenderTemplate` is a better choice.
+
+For examples for both approaches, see `internal/provider/{resources,datasources}/*_test.go` files.

--- a/internal/provider/datasources/block_test.go
+++ b/internal/provider/datasources/block_test.go
@@ -1,52 +1,58 @@
 package datasources_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccBlockByName(workspace, name string) string {
-	aID := os.Getenv("PREFECT_CLOUD_ACCOUNT_ID")
+type blockFixtureConfig struct {
+	AccountID string
+	Workspace string
+	BlockName string
+}
 
-	return fmt.Sprintf(`
-%s
+func fixtureAccBlock(cfg blockFixtureConfig) string {
+	tmpl := `
+{{ .Workspace }}
 
-resource "prefect_block" "%s" {
-  name      = "%s"
+resource "prefect_block" "{{ .BlockName }}" {
+  name      = "{{ .BlockName }}"
   type_slug = "secret"
 
   data = jsonencode({
     "someKey" = "someValue"
   })
 
-  account_id = "%s"
+  account_id = "{{ .AccountID }}"
   workspace_id = prefect_workspace.test.id
 }
 
 data "prefect_block" "my_existing_secret_by_id" {
-  id = prefect_block.%s.id
+  id = prefect_block.{{ .BlockName }}.id
 
-  account_id = "%s"
+  account_id = "{{ .AccountID }}"
   workspace_id = prefect_workspace.test.id
 
-  depends_on = [prefect_block.%s]
+  depends_on = [prefect_block.{{ .BlockName }}]
 }
 
 data "prefect_block" "my_existing_secret_by_name" {
-  name      = "%s"
+  name      = "{{ .BlockName }}"
   type_slug = "secret"
 
-  account_id = "%s"
+  account_id = "{{ .AccountID }}"
   workspace_id = prefect_workspace.test.id
 
-  depends_on = [prefect_block.%s]
+  depends_on = [prefect_block.{{ .BlockName }}]
 }
-`, workspace, name, name, aID, name, aID, name, name, aID, name)
+`
+
+	return helpers.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -59,13 +65,19 @@ func TestAccDatasource_block(t *testing.T) {
 	blockName := "my-block"
 	blockValue := "{\"someKey\":\"someValue\"}"
 
+	cfg := blockFixtureConfig{
+		Workspace: workspace.Resource,
+		BlockName: blockName,
+		AccountID: os.Getenv("PREFECT_CLOUD_ACCOUNT_ID"),
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				// Test block datasource by ID.
-				Config: fixtureAccBlockByName(workspace.Resource, blockName),
+				Config: fixtureAccBlock(cfg),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNotNull(datasourceNameByID, "id"),
 					testutils.ExpectKnownValue(datasourceNameByID, "name", blockName),
@@ -74,7 +86,7 @@ func TestAccDatasource_block(t *testing.T) {
 			},
 			{
 				// Test block datasource by name.
-				Config: fixtureAccBlockByName(workspace.Resource, blockName),
+				Config: fixtureAccBlock(cfg),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNotNull(datasourceNameByName, "id"),
 					testutils.ExpectKnownValue(datasourceNameByName, "name", blockName),

--- a/internal/provider/resources/block_test.go
+++ b/internal/provider/resources/block_test.go
@@ -84,25 +84,17 @@ func TestAccResource_block(t *testing.T) {
 	// and it will be shared between the TestSteps via pointer.
 	var blockDocument api.BlockDocument
 
-	cfg := blockFixtureConfig{
-		Workspace:  workspace.Resource,
-		BlockName:  randomName,
-		BlockValue: randomValue,
-	}
-
-	cfgUpdate := cfg
-	cfgUpdate.BlockValue = randomValue2
-
-	cfgRef := cfgUpdate
-	cfgRef.RefBlockValue = fmt.Sprintf(`{"block_document_id":prefect_block.%s.id}`, randomName)
-
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			// Check creation + existence of the block resource
 			{
-				Config: fixtureAccBlock(cfg),
+				Config: fixtureAccBlock(blockFixtureConfig{
+					Workspace:  workspace.Resource,
+					BlockName:  randomName,
+					BlockValue: randomValue,
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBlockExists(blockResourceName, &blockDocument),
 					testAccCheckBlockValues(&blockDocument, ExpectedBlockValues{
@@ -119,7 +111,11 @@ func TestAccResource_block(t *testing.T) {
 			},
 			// Check updating the value of the block resource
 			{
-				Config: fixtureAccBlock(cfgUpdate),
+				Config: fixtureAccBlock(blockFixtureConfig{
+					Workspace:  workspace.Resource,
+					BlockName:  randomName,
+					BlockValue: randomValue2,
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBlockExists(blockResourceName, &blockDocument),
 					testAccCheckBlockValues(&blockDocument, ExpectedBlockValues{
@@ -137,7 +133,12 @@ func TestAccResource_block(t *testing.T) {
 			// Next two tests using `fixtureAccBlockWithRef` will be used to test
 			// that using the $ref syntax won't result in an Update plan if no changes are made.
 			{
-				Config: fixtureAccBlockWithRef(cfgRef),
+				Config: fixtureAccBlockWithRef(blockFixtureConfig{
+					Workspace:     workspace.Resource,
+					BlockName:     randomName,
+					BlockValue:    randomValue2,
+					RefBlockValue: fmt.Sprintf(`{"block_document_id":prefect_block.%s.id}`, randomName),
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBlockExists("prefect_block.with_ref", &blockDocument),
 				),
@@ -147,7 +148,12 @@ func TestAccResource_block(t *testing.T) {
 				},
 			},
 			{
-				Config:             fixtureAccBlockWithRef(cfgRef),
+				Config: fixtureAccBlockWithRef(blockFixtureConfig{
+					Workspace:     workspace.Resource,
+					BlockName:     randomName,
+					BlockValue:    randomValue2,
+					RefBlockValue: fmt.Sprintf(`{"block_document_id":prefect_block.%s.id}`, randomName),
+				}),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},

--- a/internal/provider/resources/block_test.go
+++ b/internal/provider/resources/block_test.go
@@ -11,31 +11,43 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccBlock(workspace, blockName, blockValue string) string {
-	return fmt.Sprintf(`
-%s
-resource "prefect_block" "%s" {
-	name = "%s"
+type blockFixtureConfig struct {
+	Workspace     string
+	BlockName     string
+	BlockValue    string
+	RefBlockValue string
+}
+
+func fixtureAccBlock(cfg blockFixtureConfig) string {
+	tmpl := `
+{{ .Workspace }}
+
+resource "prefect_block" "{{ .BlockName }}" {
+	name = "{{ .BlockName }}"
 	type_slug = "secret"
 	data = jsonencode({
-		"value" = "%s"
+		"value" = "{{ .BlockValue }}"
 	})
 	workspace_id = prefect_workspace.test.id
 	depends_on = [prefect_workspace.test]
-}`, workspace, blockName, blockName, blockValue)
+}`
+
+	return helpers.RenderTemplate(tmpl, cfg)
 }
 
-func fixtureAccBlockWithRef(workspace, blockName, blockValue string, refBlockValue string) string {
-	return fmt.Sprintf(`
-%s
-resource "prefect_block" "%s" {
-	name = "%s"
+func fixtureAccBlockWithRef(cfg blockFixtureConfig) string {
+	tmpl := `
+{{ .Workspace }}
+
+resource "prefect_block" "{{ .BlockName }}" {
+	name = "{{ .BlockName }}"
 	type_slug = "secret"
 	data = jsonencode({
-		"value" = "%s"
+		"value" = "{{ .BlockValue }}"
 	})
 	workspace_id = prefect_workspace.test.id
 	depends_on = [prefect_workspace.test]
@@ -47,13 +59,15 @@ resource "prefect_block" "with_ref" {
 
   data = jsonencode({
     bucket_name = "my-bucket"
-    credentials = { "$ref" : %s }
+    credentials = { "$ref" : {{ .RefBlockValue }} }
   })
-	workspace_id = prefect_workspace.test.id
-	depends_on = [prefect_workspace.test]
-}
 
-`, workspace, blockName, blockName, blockValue, refBlockValue)
+  workspace_id = prefect_workspace.test.id
+  depends_on = [prefect_workspace.test]
+}
+`
+
+	return helpers.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -70,13 +84,25 @@ func TestAccResource_block(t *testing.T) {
 	// and it will be shared between the TestSteps via pointer.
 	var blockDocument api.BlockDocument
 
+	cfg := blockFixtureConfig{
+		Workspace:  workspace.Resource,
+		BlockName:  randomName,
+		BlockValue: randomValue,
+	}
+
+	cfgUpdate := cfg
+	cfgUpdate.BlockValue = randomValue2
+
+	cfgRef := cfgUpdate
+	cfgRef.RefBlockValue = fmt.Sprintf(`{"block_document_id":prefect_block.%s.id}`, randomName)
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			// Check creation + existence of the block resource
 			{
-				Config: fixtureAccBlock(workspace.Resource, randomName, randomValue),
+				Config: fixtureAccBlock(cfg),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBlockExists(blockResourceName, &blockDocument),
 					testAccCheckBlockValues(&blockDocument, ExpectedBlockValues{
@@ -93,7 +119,7 @@ func TestAccResource_block(t *testing.T) {
 			},
 			// Check updating the value of the block resource
 			{
-				Config: fixtureAccBlock(workspace.Resource, randomName, randomValue2),
+				Config: fixtureAccBlock(cfgUpdate),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBlockExists(blockResourceName, &blockDocument),
 					testAccCheckBlockValues(&blockDocument, ExpectedBlockValues{
@@ -111,7 +137,7 @@ func TestAccResource_block(t *testing.T) {
 			// Next two tests using `fixtureAccBlockWithRef` will be used to test
 			// that using the $ref syntax won't result in an Update plan if no changes are made.
 			{
-				Config: fixtureAccBlockWithRef(workspace.Resource, randomName, randomValue2, fmt.Sprintf(`{"block_document_id":prefect_block.%s.id}`, randomName)),
+				Config: fixtureAccBlockWithRef(cfgRef),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckBlockExists("prefect_block.with_ref", &blockDocument),
 				),
@@ -121,7 +147,7 @@ func TestAccResource_block(t *testing.T) {
 				},
 			},
 			{
-				Config:             fixtureAccBlockWithRef(workspace.Resource, randomName, randomValue2, fmt.Sprintf(`{"block_document_id":prefect_block.%s.id}`, randomName)),
+				Config:             fixtureAccBlockWithRef(cfgRef),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},


### PR DESCRIPTION
## Summary

Longer templates benefit from using the RenderTemplate helper, which makes it easier to understand where variables are inserted into the template.

Related to https://linear.app/prefect/issue/PLA-1000/standardize-test-case-formats