### PR TITLE
chore(compose): bump prefect version

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@
 # See ./_about/CONTRIBUTING.md.
 services:
   prefect:
-    image: prefecthq/prefect:2-latest
+    image: prefecthq/prefect:3-latest
     ports:
       - "4200:4200"
     environment:


### PR DESCRIPTION
Bumps the Prefect image tag from 2-latest to 3-latest in the Docker Compose file.

Related to https://linear.app/prefect/issue/PLA-983/cycle-12-catch-all