### PR TITLE
chore: acceptance test refactoring and docs

### DIFF
--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -206,7 +206,7 @@ to check under `../internal/client/*.go`.
 Test fixtures are used to create resources in the test environment. They are typically used to create resources
 that are used in the test, such as a workspace, account, or deployment.
 
-The `internal/provider/helpers` package contains a helper function named `RenderTemplate` that can be used to
+The `internal/provider/testutils` package contains a helper function named `RenderTemplate` that can be used to
 create test fixtures that contain multiple resources. This function is especially useful for creating test fixtures that
 contain multiple resources, making it easier to visually understand where each variable is inserted when compared to
 using `fmt.Sprintf`.

--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -119,6 +119,27 @@ This means that the target Prefect environment needs to allow for multiple works
 contribute tests to your pull request and a Prefect team member will review and approve them to run in our internal
 infrastructure.
 
+Here are some general guidelines for writing **datasource** acceptance tests
+
+- Test that the datasource works with each supported identifier, usually `name` and `id`
+
+Here are some general guidelines for writing **resource** acceptance tests
+
+- Test that the resource can be created
+- Test that the resource can be updated (either by modifying the inputs to a test fixture, or defining a second test fixture with different values)
+- Test that the resource can be imported (with a test for each supported identifier, often `id` and `name`)
+- (Optional, preferred) Test that a resource _cannot_ be created without all required fields
+- (Optional, preferred) Test that a resource _cannot_ be created with invalid values for a field
+
+Finally, here are some general guidelines for both datasources and resources:
+
+- Use the `testutils.Expect*` helper functions to verify values in the Terraform state for state config checks
+- Use the `testutils.GetResourceWorkspaceImportStateID` helper function to get the import ID for a resource for import tests
+
+Reference existing tests in `internal/provider/{datasources,resources}/*_test.go` for examples.
+
+For more information, see the [Terraform testing patterns documentation](https://developer.hashicorp.com/terraform/plugin/testing/testing-patterns).
+
 ### Manual testing
 
 You can also test against a local instance of Prefect. An example of this setup using Docker Compose is available in the [Terraform Provider tutorial](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider).

--- a/internal/provider/datasources/automation_test.go
+++ b/internal/provider/datasources/automation_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
@@ -69,7 +68,7 @@ data "prefect_automation" "{{ .AutomationResourceName }}" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccAutomationResourceMetricTrigger(cfg automationFixtureConfig) string {
@@ -118,7 +117,7 @@ data "prefect_automation" "{{ .AutomationResourceName }}" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccAutomationResourceCompoundTrigger(cfg automationFixtureConfig) string {
@@ -190,7 +189,7 @@ data "prefect_automation" "{{ .AutomationResourceName }}" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccAutomationResourceSequenceTrigger(cfg automationFixtureConfig) string {
@@ -269,7 +268,7 @@ data "prefect_automation" "{{ .AutomationResourceName }}" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/datasources/block_test.go
+++ b/internal/provider/datasources/block_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
@@ -52,7 +51,7 @@ data "prefect_block" "my_existing_secret_by_name" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/datasources/deployment_test.go
+++ b/internal/provider/datasources/deployment_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
@@ -57,7 +56,7 @@ data "prefect_deployment" "test_by_name" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/resources/automation_test.go
+++ b/internal/provider/resources/automation_test.go
@@ -327,8 +327,8 @@ func TestAccResource_automation(t *testing.T) {
 					testutils.ExpectKnownValue(eventTriggerAutomationResourceNameAndPath, "actions.0.job_variables", testutils.NormalizedValueForJSON(t, `{"string_var":"value1","int_var":2,"bool_var":true}`)),
 				},
 			},
-			// Import State checks - import by automation_id
 			{
+				// Import State checks - import by automation_id
 				ImportState:       true,
 				ResourceName:      eventTriggerAutomationResourceNameAndPath,
 				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(eventTriggerAutomationResourceNameAndPath),
@@ -360,8 +360,8 @@ func TestAccResource_automation(t *testing.T) {
 					testutils.ExpectKnownValue(metricTriggerAutomationResourceNameAndPath, "actions.0.message", "Flow run failed"),
 				},
 			},
-			// Import State checks - import by automation_id
 			{
+				// Import State checks - import by automation_id
 				ImportState:       true,
 				ResourceName:      metricTriggerAutomationResourceNameAndPath,
 				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(metricTriggerAutomationResourceNameAndPath),

--- a/internal/provider/resources/automation_test.go
+++ b/internal/provider/resources/automation_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
@@ -80,7 +79,7 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccAutomationResourceMetricTrigger(cfg automationFixtureConfig) string {
@@ -124,7 +123,7 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccAutomationResourceCompoundTrigger(cfg automationFixtureConfig) string {
@@ -204,7 +203,7 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccAutomationResourceSequenceTrigger(cfg automationFixtureConfig) string {
@@ -278,7 +277,7 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/resources/block_test.go
+++ b/internal/provider/resources/block_test.go
@@ -87,8 +87,8 @@ func TestAccResource_block(t *testing.T) {
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
-			// Check creation + existence of the block resource
 			{
+				// Check creation + existence of the block resource
 				Config: fixtureAccBlock(blockFixtureConfig{
 					Workspace:  workspace.Resource,
 					BlockName:  randomName,
@@ -108,8 +108,8 @@ func TestAccResource_block(t *testing.T) {
 					testutils.ExpectKnownValue(blockResourceName, "data", fmt.Sprintf(`{"value":%q}`, randomValue)),
 				},
 			},
-			// Check updating the value of the block resource
 			{
+				// Check updating the value of the block resource
 				Config: fixtureAccBlock(blockFixtureConfig{
 					Workspace:  workspace.Resource,
 					BlockName:  randomName,

--- a/internal/provider/resources/block_test.go
+++ b/internal/provider/resources/block_test.go
@@ -156,14 +156,14 @@ func TestAccResource_block(t *testing.T) {
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
-			// Import State checks - import by block_id,workspace_id (dynamic)
-			// NOTE: the ImportStateVerify is set to false, as we need to omit the .Data
-			// field when we hydrate the state from the API.
 			{
+				// Import State checks - import by block_id,workspace_id (dynamic)
 				ImportState:       true,
 				ResourceName:      blockResourceName,
 				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(blockResourceName),
-				ImportStateVerify: false,
+				ImportStateVerify: true,
+				// We ignore the .Data field because when we hydrate the state from the API.
+				ImportStateVerifyIgnore: []string{"data"},
 			},
 		},
 	})

--- a/internal/provider/resources/block_test.go
+++ b/internal/provider/resources/block_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
@@ -36,7 +35,7 @@ resource "prefect_block" "{{ .BlockName }}" {
 	depends_on = [prefect_workspace.test]
 }`
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccBlockWithRef(cfg blockFixtureConfig) string {
@@ -67,7 +66,7 @@ resource "prefect_block" "with_ref" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/resources/deployment_access_test.go
+++ b/internal/provider/resources/deployment_access_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
@@ -74,7 +73,7 @@ resource "prefect_deployment_access" "test" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/resources/deployment_schedule_test.go
+++ b/internal/provider/resources/deployment_schedule_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
@@ -45,7 +44,7 @@ resource "prefect_deployment_schedule" "test" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccDeploymentScheduleIntervalUpdate(cfg fixtureConfig) string {
@@ -79,7 +78,7 @@ resource "prefect_deployment_schedule" "test" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccDeploymentScheduleCron(cfg fixtureConfig) string {
@@ -107,7 +106,7 @@ resource "prefect_deployment_schedule" "test" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccDeploymentScheduleRRule(cfg fixtureConfig) string {
@@ -134,7 +133,7 @@ resource "prefect_deployment_schedule" "test" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 func fixtureAccDeploymentScheduleMultiple(cfg fixtureConfig) string {
@@ -169,7 +168,7 @@ resource "prefect_deployment_schedule" "test_rrule" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/resources/deployment_schedule_test.go
+++ b/internal/provider/resources/deployment_schedule_test.go
@@ -186,8 +186,8 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
-			// Test interval schedule
 			{
+				// Test interval schedule
 				Config: fixtureAccDeploymentScheduleInterval(fixtureCfg),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDeploymentExists("prefect_deployment.test", &api.Deployment{}),
@@ -199,8 +199,8 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 					testutils.ExpectKnownValue(resourceName, "timezone", "America/New_York"),
 				},
 			},
-			// Test interval schedule update
 			{
+				// Test interval schedule update
 				Config: fixtureAccDeploymentScheduleIntervalUpdate(fixtureCfg),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDeploymentExists("prefect_deployment.test", &api.Deployment{}),
@@ -212,8 +212,8 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 					testutils.ExpectKnownValue(resourceName, "timezone", "America/Chicago"),
 				},
 			},
-			// Test cron schedule
 			{
+				// Test cron schedule
 				Config: fixtureAccDeploymentScheduleCron(fixtureCfg),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDeploymentExists("prefect_deployment.test", &api.Deployment{}),
@@ -223,8 +223,8 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 					testutils.ExpectKnownValueBool(resourceName, "day_or", true),
 				},
 			},
-			// Test rrule schedule
 			{
+				// Test rrule schedule
 				Config: fixtureAccDeploymentScheduleRRule(fixtureCfg),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDeploymentExists("prefect_deployment.test", &api.Deployment{}),
@@ -233,8 +233,8 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 					testutils.ExpectKnownValue(resourceName, "rrule", "FREQ=DAILY;BYHOUR=10;BYMINUTE=30"),
 				},
 			},
-			// Test multiple schedules for one deployment
 			{
+				// Test multiple schedules for one deployment
 				Config: fixtureAccDeploymentScheduleMultiple(fixtureCfg),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDeploymentExists("prefect_deployment.test", &api.Deployment{}),

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -365,8 +365,8 @@ func TestAccResource_deployment(t *testing.T) {
 					testutils.ExpectKnownValueNotNull(cfgUpdate.DeploymentResourceName, "storage_document_id"),
 				},
 			},
-			// Import State checks - import by ID (default)
 			{
+				// Import State checks - import by ID (default)
 				ImportState:       true,
 				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(cfgCreate.DeploymentResourceName),
 				ResourceName:      cfgCreate.DeploymentResourceName,

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
-	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 	"k8s.io/utils/ptr"
 )
@@ -183,7 +182,7 @@ resource "prefect_deployment" "{{.DeploymentName}}" {
 }
 `
 
-	return helpers.RenderTemplate(tmpl, cfg)
+	return testutils.RenderTemplate(tmpl, cfg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/resources/flow_test.go
+++ b/internal/provider/resources/flow_test.go
@@ -47,8 +47,8 @@ func TestAccResource_flow(t *testing.T) {
 					testutils.ExpectKnownValueList(resourceName, "tags", []string{"test2"}),
 				},
 			},
-			// Import State checks - import by ID (default)
 			{
+				// Import State checks - import by ID (default)
 				ImportState:       true,
 				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(resourceName),
 				ResourceName:      resourceName,

--- a/internal/provider/resources/global_concurrency_limit_test.go
+++ b/internal/provider/resources/global_concurrency_limit_test.go
@@ -43,8 +43,8 @@ func TestAccResource_global_concurrency_limit(t *testing.T) {
 					testutils.ExpectKnownValueFloat(resourceName, "slot_decay_per_second", 1.5),
 				},
 			},
-			// Check updating the resource
 			{
+				// Check updating the resource
 				Config: fixtureAccGlobalConcurrencyLimitCreate(workspace.Resource, "test2", 20, false, 1, 2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValue(resourceName, "name", "test2"),
@@ -54,8 +54,8 @@ func TestAccResource_global_concurrency_limit(t *testing.T) {
 					testutils.ExpectKnownValueFloat(resourceName, "slot_decay_per_second", 2),
 				},
 			},
-			// Import State checks - import by ID (default)
 			{
+				// Import State checks - import by ID (default)
 				ImportState:       true,
 				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(resourceName),
 				ResourceName:      resourceName,

--- a/internal/provider/resources/service_account_test.go
+++ b/internal/provider/resources/service_account_test.go
@@ -185,8 +185,8 @@ func TestAccResource_service_account(t *testing.T) {
 					testutils.ExpectKnownValue(botResourceName, "name", botRandomName2),
 				},
 			},
-			// Import State checks - import by name
 			{
+				// Import State checks - import by name
 				ImportState:                          true,
 				ImportStateId:                        botRandomName2,
 				ImportStateIdPrefix:                  "name/",
@@ -195,8 +195,8 @@ func TestAccResource_service_account(t *testing.T) {
 				ImportStateVerifyIdentifierAttribute: "name",
 				ImportStateVerifyIgnore:              []string{"api_key", "old_key_expires_in_seconds"},
 			},
-			// Import State checks - import by ID (default)
 			{
+				// Import State checks - import by ID (default)
 				ImportState:             true,
 				ResourceName:            botResourceName,
 				ImportStateVerify:       true,

--- a/internal/testutils/template.go
+++ b/internal/testutils/template.go
@@ -1,4 +1,4 @@
-package helpers
+package testutils
 
 import (
 	"bytes"


### PR DESCRIPTION
## Summary

- Moves RenderTemplate to `testutils` package
- Moves test comments inside the test structs
- Tests block import state, but ignores .Data, instead of skipping entirely
- Documents test standards in the contribution guide

Related to https://linear.app/prefect/issue/PLA-1000/standardize-test-case-formats