### PR TITLE
feat(accounts): support account domains

### DIFF
--- a/docs/data-sources/account.md
+++ b/docs/data-sources/account.md
@@ -38,6 +38,7 @@ data "prefect_account" "my_organization" {}
 
 - `billing_email` (String) Billing email to apply to the account's Stripe customer
 - `created` (String) Timestamp of when the resource was created (RFC3339)
+- `domain_names` (List of String) The list of domain names for enabling SSO in Prefect Cloud.
 - `handle` (String) Unique handle of the account
 - `link` (String) An optional for an external url associated with the account, e.g. https://prefect.io/
 - `location` (String) An optional physical location for the account, e.g. Washington, D.C.

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -38,7 +38,6 @@ resource "prefect_account" "example" {
 
 ### Optional
 
-- `auth_expiration_seconds` (Number) The number of seconds a user should be considered to be authenticated against this Account.
 - `billing_email` (String) Billing email to apply to the account's Stripe customer
 - `domain_names` (List of String) The list of domain names for enabling SSO in Prefect Cloud.
 - `link` (String) An optional for an external url associated with the account, e.g. https://prefect.io/

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -40,6 +40,7 @@ resource "prefect_account" "example" {
 
 - `auth_expiration_seconds` (Number) The number of seconds a user should be considered to be authenticated against this Account.
 - `billing_email` (String) Billing email to apply to the account's Stripe customer
+- `domain_names` (List of String) The list of domain names for enabling SSO in Prefect Cloud.
 - `link` (String) An optional for an external url associated with the account, e.g. https://prefect.io/
 - `location` (String) An optional physical location for the account, e.g. Washington, D.C.
 - `settings` (Attributes) Group of settings related to accounts (see [below for nested schema](#nestedatt--settings))

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -38,6 +38,7 @@ resource "prefect_account" "example" {
 
 ### Optional
 
+- `auth_expiration_seconds` (Number) The number of seconds a user should be considered to be authenticated against this Account.
 - `billing_email` (String) Billing email to apply to the account's Stripe customer
 - `link` (String) An optional for an external url associated with the account, e.g. https://prefect.io/
 - `location` (String) An optional physical location for the account, e.g. Washington, D.C.

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -26,16 +26,18 @@ type Account struct {
 	Handle                string          `json:"handle"`
 	Location              *string         `json:"location"`
 	Link                  *string         `json:"link"`
-	ImageLocation         *string         `json:"image_location"`
 	AuthExpirationSeconds *int64          `json:"auth_expiration_seconds"`
-	BillingEmail          *string         `json:"billing_email"`
 	Settings              AccountSettings `json:"settings"`
-	SSOState              string          `json:"sso_state"`
-	Features              []string        `json:"features"`
-	PlanType              string          `json:"plan_type"`
-	RunRetentionDays      int64           `json:"run_retention_days"`
-	AuditLogRetentionDays int64           `json:"audit_log_retention_days"`
-	AutomationsLimit      int64           `json:"automations_limit"`
+	BillingEmail          *string         `json:"billing_email"`
+
+	// Read-only fields
+	ImageLocation         *string  `json:"image_location"`
+	SSOState              string   `json:"sso_state"`
+	Features              []string `json:"features"`
+	PlanType              string   `json:"plan_type"`
+	RunRetentionDays      int64    `json:"run_retention_days"`
+	AuditLogRetentionDays int64    `json:"audit_log_retention_days"`
+	AutomationsLimit      int64    `json:"automations_limit"`
 }
 
 // AccountUpdate is the data sent when updating an account.

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -27,21 +27,15 @@ type Account struct {
 	Location              *string         `json:"location"`
 	Link                  *string         `json:"link"`
 	ImageLocation         *string         `json:"image_location"`
-	StripeCustomerID      *string         `json:"stripe_customer_id"`
-	WorkOSDirectoryIDs    []string        `json:"workos_directory_ids"`
-	WorkOSOrganizationID  *string         `json:"workos_organization_id"`
-	WorkOSConnectionIDs   []string        `json:"workos_connection_ids"`
 	AuthExpirationSeconds *int64          `json:"auth_expiration_seconds"`
+	BillingEmail          *string         `json:"billing_email"`
 	Settings              AccountSettings `json:"settings"`
 	SSOState              string          `json:"sso_state"`
 	Features              []string        `json:"features"`
-	BillingEmail          *string         `json:"billing_email"`
 	PlanType              string          `json:"plan_type"`
-	SelfServe             bool            `json:"self_serve"`
 	RunRetentionDays      int64           `json:"run_retention_days"`
 	AuditLogRetentionDays int64           `json:"audit_log_retention_days"`
 	AutomationsLimit      int64           `json:"automations_limit"`
-	SCIMState             string          `json:"scim_state"`
 }
 
 // AccountUpdate is the data sent when updating an account.

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -7,8 +7,10 @@ import (
 // AccountsClient is a client for working with accounts.
 type AccountsClient interface {
 	Get(ctx context.Context) (*Account, error)
+	GetDomains(ctx context.Context) (*AccountDomainsUpdate, error)
 	Update(ctx context.Context, data AccountUpdate) error
 	UpdateSettings(ctx context.Context, data AccountSettingsUpdate) error
+	UpdateDomains(ctx context.Context, data AccountDomainsUpdate) error
 	Delete(ctx context.Context) error
 }
 
@@ -25,6 +27,7 @@ type Account struct {
 	AccountUpdate
 
 	Settings AccountSettings `json:"settings"`
+	Domains  []string        `json:"domain_names"`
 
 	// Read-only fields
 	ImageLocation         *string  `json:"image_location"`
@@ -49,4 +52,9 @@ type AccountUpdate struct {
 // AccountSettingsUpdate is the data sent when updating an account's settings.
 type AccountSettingsUpdate struct {
 	AccountSettings `json:"settings"`
+}
+
+// AccountDomainsUpdate is the data sent when updating an account's domain names.
+type AccountDomainsUpdate struct {
+	DomainNames []string `json:"domain_names,omitempty"`
 }

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -6,7 +6,7 @@ import (
 
 // AccountsClient is a client for working with accounts.
 type AccountsClient interface {
-	Get(ctx context.Context) (*AccountResponse, error)
+	Get(ctx context.Context) (*Account, error)
 	Update(ctx context.Context, data AccountUpdate) error
 	UpdateSettings(ctx context.Context, data AccountSettingsUpdate) error
 	Delete(ctx context.Context) error
@@ -33,20 +33,15 @@ type Account struct {
 	WorkOSConnectionIDs   []string        `json:"workos_connection_ids"`
 	AuthExpirationSeconds *int64          `json:"auth_expiration_seconds"`
 	Settings              AccountSettings `json:"settings"`
-}
-
-// AccountResponse is the data about an account returned by the Accounts API.
-type AccountResponse struct {
-	Account
-	PlanType              string   `json:"plan_type"`
-	SelfServe             bool     `json:"self_serve"`
-	RunRetentionDays      int64    `json:"run_retention_days"`
-	AuditLogRetentionDays int64    `json:"audit_log_retention_days"`
-	AutomationsLimit      int64    `json:"automations_limit"`
-	SCIMState             string   `json:"scim_state"`
-	SSOState              string   `json:"sso_state"`
-	BillingEmail          *string  `json:"billing_email"`
-	Features              []string `json:"features"`
+	SSOState              string          `json:"sso_state"`
+	Features              []string        `json:"features"`
+	BillingEmail          *string         `json:"billing_email"`
+	PlanType              string          `json:"plan_type"`
+	SelfServe             bool            `json:"self_serve"`
+	RunRetentionDays      int64           `json:"run_retention_days"`
+	AuditLogRetentionDays int64           `json:"audit_log_retention_days"`
+	AutomationsLimit      int64           `json:"automations_limit"`
+	SCIMState             string          `json:"scim_state"`
 }
 
 // AccountUpdate is the data sent when updating an account.

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -22,13 +22,9 @@ type AccountSettings struct {
 // Account is a representation of an account.
 type Account struct {
 	BaseModel
-	Name                  string          `json:"name"`
-	Handle                string          `json:"handle"`
-	Location              *string         `json:"location"`
-	Link                  *string         `json:"link"`
-	AuthExpirationSeconds *int64          `json:"auth_expiration_seconds"`
-	Settings              AccountSettings `json:"settings"`
-	BillingEmail          *string         `json:"billing_email"`
+	AccountUpdate
+
+	Settings AccountSettings `json:"settings"`
 
 	// Read-only fields
 	ImageLocation         *string  `json:"image_location"`
@@ -42,8 +38,8 @@ type Account struct {
 
 // AccountUpdate is the data sent when updating an account.
 type AccountUpdate struct {
-	Name                  *string `json:"name"`
-	Handle                *string `json:"handle"`
+	Name                  string  `json:"name"`
+	Handle                string  `json:"handle"`
 	Location              *string `json:"location"`
 	Link                  *string `json:"link"`
 	AuthExpirationSeconds *int64  `json:"auth_expiration_seconds"`

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -55,6 +55,24 @@ func (c *AccountsClient) Get(ctx context.Context) (*api.Account, error) {
 	return &account, nil
 }
 
+// GetDomains returns domain names for an account by ID.
+func (c *AccountsClient) GetDomains(ctx context.Context) (*api.AccountDomainsUpdate, error) {
+	cfg := requestConfig{
+		method:       http.MethodGet,
+		url:          c.routePrefix + "domains",
+		body:         http.NoBody,
+		apiKey:       c.apiKey,
+		successCodes: successCodesStatusOK,
+	}
+
+	var accountDomains api.AccountDomainsUpdate
+	if err := requestWithDecodeResponse(ctx, c.hc, cfg, &accountDomains.DomainNames); err != nil {
+		return nil, fmt.Errorf("failed to get account domains: %w", err)
+	}
+
+	return &accountDomains, nil
+}
+
 // Update modifies an existing account by ID.
 func (c *AccountsClient) Update(ctx context.Context, data api.AccountUpdate) error {
 	cfg := requestConfig{
@@ -87,6 +105,25 @@ func (c *AccountsClient) UpdateSettings(ctx context.Context, data api.AccountSet
 	resp, err := request(ctx, c.hc, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to update account settings: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+// UpdateDomains modifies an existing account's domain names.
+func (c *AccountsClient) UpdateDomains(ctx context.Context, data api.AccountDomainsUpdate) error {
+	cfg := requestConfig{
+		method:       http.MethodPatch,
+		url:          c.routePrefix + "domains",
+		body:         data.DomainNames,
+		apiKey:       c.apiKey,
+		successCodes: successCodesStatusNoContent,
+	}
+
+	resp, err := request(ctx, c.hc, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to update account domains: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -65,6 +65,7 @@ func (c *AccountsClient) GetDomains(ctx context.Context) (*api.AccountDomainsUpd
 		url:          c.routePrefix + "domains",
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -123,6 +124,7 @@ func (c *AccountsClient) UpdateDomains(ctx context.Context, data api.AccountDoma
 		url:          c.routePrefix + "domains",
 		body:         data.DomainNames,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -38,7 +38,7 @@ func (c *Client) Accounts(accountID uuid.UUID) (api.AccountsClient, error) {
 }
 
 // Get returns details for an account by ID.
-func (c *AccountsClient) Get(ctx context.Context) (*api.AccountResponse, error) {
+func (c *AccountsClient) Get(ctx context.Context) (*api.Account, error) {
 	cfg := requestConfig{
 		method:       http.MethodGet,
 		url:          c.routePrefix,
@@ -47,7 +47,7 @@ func (c *AccountsClient) Get(ctx context.Context) (*api.AccountResponse, error) 
 		successCodes: successCodesStatusOK,
 	}
 
-	var account api.AccountResponse
+	var account api.Account
 	if err := requestWithDecodeResponse(ctx, c.hc, cfg, &account); err != nil {
 		return nil, fmt.Errorf("failed to get account: %w", err)
 	}

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -34,12 +34,13 @@ type AccountResource struct {
 type AccountResourceModel struct {
 	BaseModel
 
-	Name         types.String `tfsdk:"name"`
-	Handle       types.String `tfsdk:"handle"`
-	Location     types.String `tfsdk:"location"`
-	Link         types.String `tfsdk:"link"`
-	Settings     types.Object `tfsdk:"settings"`
-	BillingEmail types.String `tfsdk:"billing_email"`
+	Name                  types.String `tfsdk:"name"`
+	Handle                types.String `tfsdk:"handle"`
+	Location              types.String `tfsdk:"location"`
+	Link                  types.String `tfsdk:"link"`
+	Settings              types.Object `tfsdk:"settings"`
+	BillingEmail          types.String `tfsdk:"billing_email"`
+	AuthExpirationSeconds types.Int64  `tfsdk:"auth_expiration_seconds"`
 }
 
 // NewAccountResource returns a new AccountResource.
@@ -120,6 +121,10 @@ func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description: "An optional for an external url associated with the account, e.g. https://prefect.io/",
 				Optional:    true,
 			},
+			"auth_expiration_seconds": schema.Int64Attribute{
+				Description: "The number of seconds a user should be considered to be authenticated against this Account.",
+				Optional:    true,
+			},
 			"settings": schema.SingleNestedAttribute{
 				Description: "Group of settings related to accounts",
 				Optional:    true,
@@ -162,6 +167,7 @@ func copyAccountToModel(_ context.Context, account *api.Account, tfModel *Accoun
 	tfModel.Link = types.StringPointerValue(account.Link)
 	tfModel.Location = types.StringPointerValue(account.Location)
 	tfModel.Name = types.StringValue(account.Name)
+	tfModel.AuthExpirationSeconds = types.Int64PointerValue(account.AuthExpirationSeconds)
 
 	settingsObject, diags := types.ObjectValue(
 		map[string]attr.Type{
@@ -247,11 +253,12 @@ func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	err = client.Update(ctx, api.AccountUpdate{
-		Name:         plan.Name.ValueString(),
-		Handle:       plan.Handle.ValueString(),
-		Location:     plan.Location.ValueStringPointer(),
-		Link:         plan.Link.ValueStringPointer(),
-		BillingEmail: plan.BillingEmail.ValueStringPointer(),
+		Name:                  plan.Name.ValueString(),
+		Handle:                plan.Handle.ValueString(),
+		Location:              plan.Location.ValueStringPointer(),
+		Link:                  plan.Link.ValueStringPointer(),
+		BillingEmail:          plan.BillingEmail.ValueStringPointer(),
+		AuthExpirationSeconds: plan.AuthExpirationSeconds.ValueInt64Pointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Account", "update", err))

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -247,8 +247,8 @@ func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	err = client.Update(ctx, api.AccountUpdate{
-		Name:         plan.Name.ValueStringPointer(),
-		Handle:       plan.Handle.ValueStringPointer(),
+		Name:         plan.Name.ValueString(),
+		Handle:       plan.Handle.ValueString(),
 		Location:     plan.Location.ValueStringPointer(),
 		Link:         plan.Link.ValueStringPointer(),
 		BillingEmail: plan.BillingEmail.ValueStringPointer(),

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -34,14 +34,13 @@ type AccountResource struct {
 type AccountResourceModel struct {
 	BaseModel
 
-	Name                  types.String `tfsdk:"name"`
-	Handle                types.String `tfsdk:"handle"`
-	Location              types.String `tfsdk:"location"`
-	Link                  types.String `tfsdk:"link"`
-	Settings              types.Object `tfsdk:"settings"`
-	BillingEmail          types.String `tfsdk:"billing_email"`
-	AuthExpirationSeconds types.Int64  `tfsdk:"auth_expiration_seconds"`
-	DomainNames           types.List   `tfsdk:"domain_names"`
+	Name         types.String `tfsdk:"name"`
+	Handle       types.String `tfsdk:"handle"`
+	Location     types.String `tfsdk:"location"`
+	Link         types.String `tfsdk:"link"`
+	Settings     types.Object `tfsdk:"settings"`
+	BillingEmail types.String `tfsdk:"billing_email"`
+	DomainNames  types.List   `tfsdk:"domain_names"`
 }
 
 // NewAccountResource returns a new AccountResource.
@@ -122,10 +121,6 @@ func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description: "An optional for an external url associated with the account, e.g. https://prefect.io/",
 				Optional:    true,
 			},
-			"auth_expiration_seconds": schema.Int64Attribute{
-				Description: "The number of seconds a user should be considered to be authenticated against this Account.",
-				Optional:    true,
-			},
 			"settings": schema.SingleNestedAttribute{
 				Description: "Group of settings related to accounts",
 				Optional:    true,
@@ -173,7 +168,6 @@ func copyAccountToModel(_ context.Context, account *api.Account, tfModel *Accoun
 	tfModel.Link = types.StringPointerValue(account.Link)
 	tfModel.Location = types.StringPointerValue(account.Location)
 	tfModel.Name = types.StringValue(account.Name)
-	tfModel.AuthExpirationSeconds = types.Int64PointerValue(account.AuthExpirationSeconds)
 
 	settingsObject, diags := types.ObjectValue(
 		map[string]attr.Type{
@@ -283,12 +277,11 @@ func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	err = client.Update(ctx, api.AccountUpdate{
-		Name:                  plan.Name.ValueString(),
-		Handle:                plan.Handle.ValueString(),
-		Location:              plan.Location.ValueStringPointer(),
-		Link:                  plan.Link.ValueStringPointer(),
-		BillingEmail:          plan.BillingEmail.ValueStringPointer(),
-		AuthExpirationSeconds: plan.AuthExpirationSeconds.ValueInt64Pointer(),
+		Name:         plan.Name.ValueString(),
+		Handle:       plan.Handle.ValueString(),
+		Location:     plan.Location.ValueStringPointer(),
+		Link:         plan.Link.ValueStringPointer(),
+		BillingEmail: plan.BillingEmail.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Account", "update", err))

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -152,7 +152,7 @@ func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 
 // copyAccountToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
-func copyAccountToModel(_ context.Context, account *api.AccountResponse, tfModel *AccountResourceModel) diag.Diagnostics {
+func copyAccountToModel(_ context.Context, account *api.Account, tfModel *AccountResourceModel) diag.Diagnostics {
 	tfModel.ID = types.StringValue(account.ID.String())
 	tfModel.Created = customtypes.NewTimestampPointerValue(account.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(account.Updated)

--- a/internal/provider/resources/service_account.go
+++ b/internal/provider/resources/service_account.go
@@ -184,9 +184,9 @@ func (r *ServiceAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 	}
 }
 
-// copyServiceAccountResponseToModel maps an API response to a model that is saved in Terraform state.
+// copyServiceAccountToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
-func copyServiceAccountResponseToModel(serviceAccount *api.ServiceAccount, tfModel *ServiceAccountResourceModel) {
+func copyServiceAccountToModel(serviceAccount *api.ServiceAccount, tfModel *ServiceAccountResourceModel) {
 	// NOTE: the API Key is attached to the resource model outside of this helper,
 	// as it is only returned on Create/Update operations.
 	tfModel.ID = types.StringValue(serviceAccount.ID.String())
@@ -267,7 +267,7 @@ func (r *ServiceAccountResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	copyServiceAccountResponseToModel(serviceAccount, &plan)
+	copyServiceAccountToModel(serviceAccount, &plan)
 
 	// The API Key is only returned on Create or when rotating the key, so we'll attach it to
 	// the model outside of the helper function, so that we can prevent the value from being
@@ -344,7 +344,7 @@ func (r *ServiceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	copyServiceAccountResponseToModel(serviceAccount, &state)
+	copyServiceAccountToModel(serviceAccount, &state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -461,7 +461,7 @@ func (r *ServiceAccountResource) Update(ctx context.Context, req resource.Update
 	}
 
 	// Update the model with latest service account details (from the Get call above)
-	copyServiceAccountResponseToModel(serviceAccount, &plan)
+	copyServiceAccountToModel(serviceAccount, &plan)
 
 	// The API Key is only returned on Create or when rotating the key, so we'll attach it to
 	// the model outside of the helper function, so that we can prevent the value from being


### PR DESCRIPTION
## Summary

Related to https://linear.app/prefect/issue/PLA-354/add-support-for-accounts

Implements the [account domains API](https://app.prefect.cloud/api/docs#tag/Accounts/operation/read_account_domains_api_accounts__account_id__domains_get) to finish up the remaining fields we should expose on the Accounts resource and datasource. This is related to [configuring SSO](https://docs.prefect.io/v3/manage/cloud/manage-users/configure-sso).

There are many other fields, but most of them are only relevant to Prefect-internal teams. We can focus on exposing the main fields from the UI as well as a couple others like domains and settings that may be helpful:

![image](https://github.com/user-attachments/assets/52472e7d-2b5c-45e1-b029-85dcf24bb1c7)

