### PR TITLE
feat: support basic auth

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -75,7 +75,7 @@ Most production use-cases will call for using a dedicated Service Account's API 
 <br>
 
 After creating the Service Account, the API Key will be generated and displayed for you in the UI.
-m
+
 ### User Keys
 
 API Keys can also be generated to represent a User - look to this option if you want to use the provider to manage a Personal Account, where the Service Account feature is not available.
@@ -88,6 +88,19 @@ Note that any User API Keys will inherit the Account/Organization Role of the Us
 
 <img src="https://raw.githubusercontent.com/PrefectHQ/terraform-provider-prefect/main/docs/images/user-api-key-example.png" alt="User API Key Example" align="center" width="400">
 
+### Using basic authorization
+
+Self-hosted Prefect servers can use [basic authorization](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings).
+To allow the provider to connect in this situation, configure `endpoint` and `basic_auth_key`:
+
+```terraform
+provider "prefect" {
+  endpoint       = "http://localhost:4200"
+  basic_auth_key = "admin:password"
+}
+```
+
+The provider will automatically base64 encode the value you provide for `basic_auth_key`.
 
 ## RBAC + Permissions
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -88,9 +88,9 @@ Note that any User API Keys will inherit the Account/Organization Role of the Us
 
 <img src="https://raw.githubusercontent.com/PrefectHQ/terraform-provider-prefect/main/docs/images/user-api-key-example.png" alt="User API Key Example" align="center" width="400">
 
-### Using basic authorization
+### Using basic authentication
 
-Self-hosted Prefect servers can use [basic authorization](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings).
+Self-hosted Prefect servers can use [basic authentication](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings).
 To allow the provider to connect in this situation, configure `endpoint` and `basic_auth_key`:
 
 ```terraform

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,5 +57,6 @@ provider "prefect" {
 
 - `account_id` (String) Default Prefect Cloud Account ID. Can also be set via the `PREFECT_CLOUD_ACCOUNT_ID` environment variable.
 - `api_key` (String, Sensitive) Prefect Cloud API Key. Can also be set via the `PREFECT_API_KEY` environment variable.
+- `basic_auth_key` (String, Sensitive) Prefect basic auth key. Can also be set via the `PREFECT_BASIC_AUTH_KEY` environment variable.
 - `endpoint` (String) Prefect API URL. Can also be set via the `PREFECT_API_URL` environment variable. Defaults to `https://api.prefect.cloud`
 - `workspace_id` (String) Default Prefect Cloud Workspace ID.

--- a/internal/client/account_memberships.go
+++ b/internal/client/account_memberships.go
@@ -12,9 +12,10 @@ import (
 var _ = api.AccountMembershipsClient(&AccountMembershipsClient{})
 
 type AccountMembershipsClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // AccountMemberships is a factory that initializes and returns a AccountMembershipsClient.
@@ -26,9 +27,10 @@ func (c *Client) AccountMemberships(accountID uuid.UUID) (api.AccountMemberships
 	}
 
 	return &AccountMembershipsClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getAccountScopedURL(c.endpoint, accountID, "account_memberships"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getAccountScopedURL(c.endpoint, accountID, "account_memberships"),
 	}, nil
 }
 
@@ -42,6 +44,7 @@ func (c *AccountMembershipsClient) List(ctx context.Context, emails []string) ([
 		method:       http.MethodPost,
 		body:         filterQuery,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 

--- a/internal/client/account_roles.go
+++ b/internal/client/account_roles.go
@@ -13,9 +13,10 @@ import (
 var _ = api.AccountRolesClient(&AccountRolesClient{})
 
 type AccountRolesClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // AccountRoles is a factory that initializes and returns a AccountRolesClient.
@@ -27,9 +28,10 @@ func (c *Client) AccountRoles(accountID uuid.UUID) (api.AccountRolesClient, erro
 	}
 
 	return &AccountRolesClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getAccountScopedURL(c.endpoint, accountID, "account_roles"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getAccountScopedURL(c.endpoint, accountID, "account_roles"),
 	}, nil
 }
 
@@ -43,6 +45,7 @@ func (c *AccountRolesClient) List(ctx context.Context, roleNames []string) ([]*a
 		method:       http.MethodPost,
 		body:         filterQuery,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -62,6 +65,7 @@ func (c *AccountRolesClient) Get(ctx context.Context, roleID uuid.UUID) (*api.Ac
 		body:         http.NoBody,
 		successCodes: successCodesStatusOK,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	var accountRole api.AccountRole

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -13,9 +13,10 @@ var _ = api.AccountsClient(&AccountsClient{})
 
 // AccountsClient is a client for working with accounts.
 type AccountsClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // Accounts returns an AccountsClient.
@@ -31,9 +32,10 @@ func (c *Client) Accounts(accountID uuid.UUID) (api.AccountsClient, error) {
 	}
 
 	return &AccountsClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getAccountScopedURL(c.endpoint, accountID, ""),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getAccountScopedURL(c.endpoint, accountID, ""),
 	}, nil
 }
 
@@ -44,6 +46,7 @@ func (c *AccountsClient) Get(ctx context.Context) (*api.AccountResponse, error) 
 		url:          c.routePrefix,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -62,6 +65,7 @@ func (c *AccountsClient) Update(ctx context.Context, data api.AccountUpdate) err
 		url:          c.routePrefix,
 		body:         data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: []int{http.StatusOK, http.StatusNoContent},
 	}
 
@@ -81,6 +85,7 @@ func (c *AccountsClient) UpdateSettings(ctx context.Context, data api.AccountSet
 		url:          c.routePrefix + "settings",
 		body:         data.AccountSettings,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 
@@ -100,6 +105,7 @@ func (c *AccountsClient) Delete(ctx context.Context) error {
 		url:          c.routePrefix,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 

--- a/internal/client/automations.go
+++ b/internal/client/automations.go
@@ -12,9 +12,10 @@ import (
 var _ = api.AutomationsClient(&AutomationsClient{})
 
 type AutomationsClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // Automations is a factory that initializes and returns a AutomationsClient.
@@ -34,9 +35,10 @@ func (c *Client) Automations(accountID uuid.UUID, workspaceID uuid.UUID) (api.Au
 	}
 
 	return &AutomationsClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "automations"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "automations"),
 	}, nil
 }
 
@@ -46,6 +48,7 @@ func (c *AutomationsClient) Get(ctx context.Context, id uuid.UUID) (*api.Automat
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, id),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -63,6 +66,7 @@ func (c *AutomationsClient) Create(ctx context.Context, payload api.AutomationUp
 		url:          c.routePrefix + "/",
 		body:         payload,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -80,6 +84,7 @@ func (c *AutomationsClient) Update(ctx context.Context, id uuid.UUID, payload ap
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, id),
 		body:         payload,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 
@@ -98,6 +103,7 @@ func (c *AutomationsClient) Delete(ctx context.Context, id uuid.UUID) error {
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, id),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 

--- a/internal/client/block_documents.go
+++ b/internal/client/block_documents.go
@@ -13,9 +13,10 @@ import (
 var _ = api.BlockDocumentClient(&BlockDocumentClient{})
 
 type BlockDocumentClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // BlockDocuments is a factory that initializes and returns a BlockDocumentClient.
@@ -35,9 +36,10 @@ func (c *Client) BlockDocuments(accountID uuid.UUID, workspaceID uuid.UUID) (api
 	}
 
 	return &BlockDocumentClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "block_documents"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "block_documents"),
 	}, nil
 }
 
@@ -50,6 +52,7 @@ func (c *BlockDocumentClient) Get(ctx context.Context, id uuid.UUID) (*api.Block
 		url:          reqURL,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -72,6 +75,7 @@ func (c *BlockDocumentClient) GetByName(ctx context.Context, typeSlug, name stri
 		url:          reqURL,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -89,6 +93,7 @@ func (c *BlockDocumentClient) Create(ctx context.Context, payload api.BlockDocum
 		url:          c.routePrefix + "/",
 		body:         payload,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -106,6 +111,7 @@ func (c *BlockDocumentClient) Update(ctx context.Context, id uuid.UUID, payload 
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, id.String()),
 		body:         payload,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 
@@ -124,6 +130,7 @@ func (c *BlockDocumentClient) Delete(ctx context.Context, id uuid.UUID) error {
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, id.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 
@@ -144,6 +151,7 @@ func (c *BlockDocumentClient) GetAccess(ctx context.Context, id uuid.UUID) (*api
 		url:          reqURL,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -161,6 +169,7 @@ func (c *BlockDocumentClient) UpsertAccess(ctx context.Context, id uuid.UUID, pa
 		url:          fmt.Sprintf("%s/%s/access", c.routePrefix, id.String()),
 		body:         payload,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 

--- a/internal/client/block_schemas.go
+++ b/internal/client/block_schemas.go
@@ -11,9 +11,10 @@ import (
 
 // BlockSchemaClient is a client for working with block schemas.
 type BlockSchemaClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // BlockSchemas returns a BlockSchemaClient.
@@ -32,9 +33,10 @@ func (c *Client) BlockSchemas(accountID uuid.UUID, workspaceID uuid.UUID) (api.B
 	}
 
 	return &BlockSchemaClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "block_schemas"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "block_schemas"),
 	}, nil
 }
 
@@ -48,6 +50,7 @@ func (c *BlockSchemaClient) List(ctx context.Context, blockTypeIDs []uuid.UUID) 
 		url:          c.routePrefix + "/filter",
 		body:         filterQuery,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 

--- a/internal/client/block_types.go
+++ b/internal/client/block_types.go
@@ -13,9 +13,10 @@ var _ = api.BlockTypeClient(&BlockTypeClient{})
 
 // BlockTypeClient is a client for working with block types.
 type BlockTypeClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // BlockTypes returns a BlockTypeClient.
@@ -34,9 +35,10 @@ func (c *Client) BlockTypes(accountID uuid.UUID, workspaceID uuid.UUID) (api.Blo
 	}
 
 	return &BlockTypeClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "block_types"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "block_types"),
 	}, nil
 }
 
@@ -47,6 +49,7 @@ func (c *BlockTypeClient) GetBySlug(ctx context.Context, slug string) (*api.Bloc
 		url:          c.routePrefix + "/slug/" + slug,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -90,6 +90,15 @@ func WithAPIKey(apiKey string) Option {
 	}
 }
 
+// WithBasicAuthKey configures the basic auth key to use to authenticate to Prefect.
+func WithBasicAuthKey(basicAuthKey string) Option {
+	return func(client *Client) error {
+		client.basicAuthKey = basicAuthKey
+
+		return nil
+	}
+}
+
 // WithDefaults configures the default account and workspace ID.
 func WithDefaults(accountID uuid.UUID, workspaceID uuid.UUID) Option {
 	return func(client *Client) error {

--- a/internal/client/collections.go
+++ b/internal/client/collections.go
@@ -13,9 +13,10 @@ import (
 var _ = api.CollectionsClient(&CollectionsClient{})
 
 type CollectionsClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // Collections returns an CollectionsClient.
@@ -35,9 +36,10 @@ func (c *Client) Collections(accountID, workspaceID uuid.UUID) (api.CollectionsC
 	}
 
 	return &CollectionsClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "collections"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "collections"),
 	}, nil
 }
 
@@ -56,6 +58,7 @@ func (c *CollectionsClient) GetWorkerMetadataViews(ctx context.Context) (api.Wor
 		url:          url,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 

--- a/internal/client/deployment_access.go
+++ b/internal/client/deployment_access.go
@@ -12,9 +12,10 @@ import (
 var _ = api.DeploymentAccessClient(&DeploymentAccessClient{})
 
 type DeploymentAccessClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // DeploymentAccess returns a DeploymentAccessClient.
@@ -34,9 +35,10 @@ func (c *Client) DeploymentAccess(accountID uuid.UUID, workspaceID uuid.UUID) (a
 	}
 
 	return &DeploymentAccessClient{
-		hc:          c.hc,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "deployments"),
-		apiKey:      c.apiKey,
+		hc:           c.hc,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "deployments"),
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}, nil
 }
 
@@ -46,6 +48,7 @@ func (c *DeploymentAccessClient) Read(ctx context.Context, deploymentID uuid.UUI
 		url:          fmt.Sprintf("%s/%s/access", c.routePrefix, deploymentID.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -63,6 +66,7 @@ func (c *DeploymentAccessClient) Set(ctx context.Context, deploymentID uuid.UUID
 		url:          fmt.Sprintf("%s/%s/access", c.routePrefix, deploymentID.String()),
 		body:         &accessControl,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 

--- a/internal/client/deployment_schedule.go
+++ b/internal/client/deployment_schedule.go
@@ -12,9 +12,10 @@ import (
 var _ = api.DeploymentScheduleClient(&DeploymentScheduleClient{})
 
 type DeploymentScheduleClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // DeploymentSchedule returns a DeploymentScheduleClient.
@@ -34,9 +35,10 @@ func (c *Client) DeploymentSchedule(accountID, workspaceID uuid.UUID) (api.Deplo
 	}
 
 	return &DeploymentScheduleClient{
-		hc:          c.hc,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "deployments"),
-		apiKey:      c.apiKey,
+		hc:           c.hc,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "deployments"),
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}, nil
 }
 
@@ -46,6 +48,7 @@ func (c *DeploymentScheduleClient) Create(ctx context.Context, deploymentID uuid
 		url:          fmt.Sprintf("%s/%s/schedules", c.routePrefix, deploymentID.String()),
 		body:         &payload,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -63,6 +66,7 @@ func (c *DeploymentScheduleClient) Read(ctx context.Context, deploymentID uuid.U
 		url:          fmt.Sprintf("%s/%s/schedules", c.routePrefix, deploymentID.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -80,6 +84,7 @@ func (c *DeploymentScheduleClient) Update(ctx context.Context, deploymentID uuid
 		url:          fmt.Sprintf("%s/%s/%s/%s", c.routePrefix, deploymentID.String(), "schedules", scheduleID.String()),
 		body:         &payload,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 
@@ -98,6 +103,7 @@ func (c *DeploymentScheduleClient) Delete(ctx context.Context, deploymentID uuid
 		url:          fmt.Sprintf("%s/%s/%s/%s", c.routePrefix, deploymentID.String(), "schedules", scheduleID.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 

--- a/internal/client/deployments.go
+++ b/internal/client/deployments.go
@@ -14,9 +14,10 @@ var _ = api.DeploymentsClient(&DeploymentsClient{})
 
 // DeploymentsClient is a client for working with Deployments.
 type DeploymentsClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // Deployments returns a DeploymentsClient.
@@ -36,9 +37,10 @@ func (c *Client) Deployments(accountID uuid.UUID, workspaceID uuid.UUID) (api.De
 	}
 
 	return &DeploymentsClient{
-		hc:          c.hc,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "deployments"),
-		apiKey:      c.apiKey,
+		hc:           c.hc,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "deployments"),
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}, nil
 }
 
@@ -49,6 +51,7 @@ func (c *DeploymentsClient) Create(ctx context.Context, data api.DeploymentCreat
 		url:          c.routePrefix + "/",
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -67,6 +70,7 @@ func (c *DeploymentsClient) Get(ctx context.Context, deploymentID uuid.UUID) (*a
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, deploymentID.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -86,6 +90,7 @@ func (c *DeploymentsClient) GetByName(ctx context.Context, flowName, deploymentN
 		url:          url,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -104,6 +109,7 @@ func (c *DeploymentsClient) Update(ctx context.Context, id uuid.UUID, data api.D
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, id.String()),
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 
@@ -123,6 +129,7 @@ func (c *DeploymentsClient) Delete(ctx context.Context, deploymentID uuid.UUID) 
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, deploymentID.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 

--- a/internal/client/flows.go
+++ b/internal/client/flows.go
@@ -14,9 +14,10 @@ var _ = api.FlowsClient(&FlowsClient{})
 
 // FlowsClient is a client for working with Flows.
 type FlowsClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // Flows returns a FlowsClient.
@@ -36,9 +37,10 @@ func (c *Client) Flows(accountID uuid.UUID, workspaceID uuid.UUID) (api.FlowsCli
 	}
 
 	return &FlowsClient{
-		hc:          c.hc,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "flows"),
-		apiKey:      c.apiKey,
+		hc:           c.hc,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "flows"),
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}, nil
 }
 
@@ -49,6 +51,7 @@ func (c *FlowsClient) Create(ctx context.Context, data api.FlowCreate) (*api.Flo
 		url:          c.routePrefix + "/",
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -73,6 +76,7 @@ func (c *FlowsClient) List(ctx context.Context, handleNames []string) ([]*api.Fl
 		url:          fmt.Sprintf("%s/filter", c.routePrefix),
 		body:         &filterQuery,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -91,6 +95,7 @@ func (c *FlowsClient) Get(ctx context.Context, flowID uuid.UUID) (*api.Flow, err
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, flowID.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -109,6 +114,7 @@ func (c *FlowsClient) Update(ctx context.Context, flowID uuid.UUID, data api.Flo
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, flowID.String()),
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 
@@ -128,6 +134,7 @@ func (c *FlowsClient) Delete(ctx context.Context, flowID uuid.UUID) error {
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, flowID.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 

--- a/internal/client/global_concurrency_limits.go
+++ b/internal/client/global_concurrency_limits.go
@@ -13,9 +13,10 @@ var _ = api.GlobalConcurrencyLimitsClient(&GlobalConcurrencyLimitsClient{})
 
 // GlobalConcurrencyLimitsClient is a client for working with global concurrency limits.
 type GlobalConcurrencyLimitsClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // GlobalConcurrencyLimits returns a GlobalConcurrencyLimitsClient.
@@ -35,9 +36,10 @@ func (c *Client) GlobalConcurrencyLimits(accountID uuid.UUID, workspaceID uuid.U
 	}
 
 	return &GlobalConcurrencyLimitsClient{
-		hc:          c.hc,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "v2/concurrency_limits"),
-		apiKey:      c.apiKey,
+		hc:           c.hc,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "v2/concurrency_limits"),
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}, nil
 }
 
@@ -48,6 +50,7 @@ func (c *GlobalConcurrencyLimitsClient) Create(ctx context.Context, data api.Glo
 		url:          c.routePrefix + "/",
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -65,6 +68,7 @@ func (c *GlobalConcurrencyLimitsClient) Read(ctx context.Context, globalConcurre
 		method:       http.MethodGet,
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, globalConcurrencyLimitID),
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -83,6 +87,7 @@ func (c *GlobalConcurrencyLimitsClient) Update(ctx context.Context, globalConcur
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, globalConcurrencyLimitID),
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 
@@ -101,6 +106,7 @@ func (c *GlobalConcurrencyLimitsClient) Delete(ctx context.Context, globalConcur
 		method:       http.MethodDelete,
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, globalConcurrencyLimitID),
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 

--- a/internal/client/service_accounts.go
+++ b/internal/client/service_accounts.go
@@ -10,9 +10,10 @@ import (
 )
 
 type ServiceAccountsClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	routePrefix  string
+	basicAuthKey string
 }
 
 //nolint:ireturn // required to support PrefectClient mocking
@@ -34,9 +35,10 @@ func (c *Client) ServiceAccounts(accountID uuid.UUID) (api.ServiceAccountsClient
 	routePrefix := getAccountScopedURL(c.endpoint, accountID, "bots")
 
 	return &ServiceAccountsClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: routePrefix,
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  routePrefix,
 	}, nil
 }
 
@@ -46,6 +48,7 @@ func (sa *ServiceAccountsClient) Create(ctx context.Context, request api.Service
 		url:          sa.routePrefix + "/",
 		body:         &request,
 		apiKey:       sa.apiKey,
+		basicAuthKey: sa.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -66,6 +69,7 @@ func (sa *ServiceAccountsClient) List(ctx context.Context, names []string) ([]*a
 		url:          sa.routePrefix + "/filter",
 		body:         &filter,
 		apiKey:       sa.apiKey,
+		basicAuthKey: sa.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -83,6 +87,7 @@ func (sa *ServiceAccountsClient) Get(ctx context.Context, botID string) (*api.Se
 		url:          sa.routePrefix + "/" + botID,
 		body:         http.NoBody,
 		apiKey:       sa.apiKey,
+		basicAuthKey: sa.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -100,6 +105,7 @@ func (sa *ServiceAccountsClient) Update(ctx context.Context, botID string, reque
 		url:          sa.routePrefix + "/" + botID,
 		body:         &requestPayload,
 		apiKey:       sa.apiKey,
+		basicAuthKey: sa.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 
@@ -119,6 +125,7 @@ func (sa *ServiceAccountsClient) Delete(ctx context.Context, botID string) error
 		url:          sa.routePrefix + "/" + botID,
 		body:         http.NoBody,
 		apiKey:       sa.apiKey,
+		basicAuthKey: sa.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 
@@ -138,6 +145,7 @@ func (sa *ServiceAccountsClient) RotateKey(ctx context.Context, serviceAccountID
 		url:          fmt.Sprintf("%s/%s/rotate_api_key", sa.routePrefix, serviceAccountID),
 		body:         &data,
 		apiKey:       sa.apiKey,
+		basicAuthKey: sa.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 

--- a/internal/client/task_run_concurrency_limits.go
+++ b/internal/client/task_run_concurrency_limits.go
@@ -13,9 +13,10 @@ var _ = api.TaskRunConcurrencyLimitsClient(&TaskRunConcurrencyLimitsClient{})
 
 // TaskRunConcurrencyLimitsClient is a client for working with task run concurrency limits.
 type TaskRunConcurrencyLimitsClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // TaskRunConcurrencyLimits returns a TaskRunConcurrencyLimitsClient.
@@ -35,9 +36,10 @@ func (c *Client) TaskRunConcurrencyLimits(accountID uuid.UUID, workspaceID uuid.
 	}
 
 	return &TaskRunConcurrencyLimitsClient{
-		hc:          c.hc,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "concurrency_limits"),
-		apiKey:      c.apiKey,
+		hc:           c.hc,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "concurrency_limits"),
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}, nil
 }
 
@@ -48,6 +50,7 @@ func (c *TaskRunConcurrencyLimitsClient) Create(ctx context.Context, data api.Ta
 		url:          c.routePrefix + "/",
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -65,6 +68,7 @@ func (c *TaskRunConcurrencyLimitsClient) Read(ctx context.Context, taskRunConcur
 		method:       http.MethodGet,
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, taskRunConcurrencyLimitID),
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -82,6 +86,7 @@ func (c *TaskRunConcurrencyLimitsClient) Delete(ctx context.Context, taskRunConc
 		method:       http.MethodDelete,
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, taskRunConcurrencyLimitID),
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 

--- a/internal/client/teams.go
+++ b/internal/client/teams.go
@@ -12,9 +12,10 @@ import (
 var _ = api.TeamsClient(&TeamsClient{})
 
 type TeamsClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // Teams is a factory that initializes and returns a TeamsClient.
@@ -26,9 +27,10 @@ func (c *Client) Teams(accountID uuid.UUID) (api.TeamsClient, error) {
 	}
 
 	return &TeamsClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getAccountScopedURL(c.endpoint, accountID, "teams"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getAccountScopedURL(c.endpoint, accountID, "teams"),
 	}, nil
 }
 
@@ -42,6 +44,7 @@ func (c *TeamsClient) List(ctx context.Context, names []string) ([]*api.Team, er
 		url:          fmt.Sprintf("%s/filter", c.routePrefix),
 		body:         &filterQuery,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -11,6 +11,7 @@ type Client struct {
 	endpoint           string
 	endpointHost       string
 	apiKey             string
+	basicAuthKey       string
 	defaultAccountID   uuid.UUID
 	defaultWorkspaceID uuid.UUID
 }

--- a/internal/client/variables.go
+++ b/internal/client/variables.go
@@ -14,9 +14,10 @@ var _ = api.VariablesClient(&VariablesClient{})
 
 // VariablesClient is a client for working with variables.
 type VariablesClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // Variables returns a VariablesClient.
@@ -36,9 +37,10 @@ func (c *Client) Variables(accountID uuid.UUID, workspaceID uuid.UUID) (api.Vari
 	}
 
 	return &VariablesClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "variables"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "variables"),
 	}, nil
 }
 
@@ -49,6 +51,7 @@ func (c *VariablesClient) Create(ctx context.Context, data api.VariableCreate) (
 		url:          c.routePrefix + "/",
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -75,6 +78,7 @@ func (c *VariablesClient) Get(ctx context.Context, variableID uuid.UUID) (*api.V
 		url:          c.routePrefix + "/" + variableID.String(),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -93,6 +97,7 @@ func (c *VariablesClient) GetByName(ctx context.Context, name string) (*api.Vari
 		url:          c.routePrefix + "/name/" + name,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -111,6 +116,7 @@ func (c *VariablesClient) Update(ctx context.Context, variableID uuid.UUID, data
 		url:          c.routePrefix + "/" + variableID.String(),
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 
@@ -131,6 +137,7 @@ func (c *VariablesClient) Delete(ctx context.Context, variableID uuid.UUID) erro
 		url:          c.routePrefix + "/" + variableID.String(),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 

--- a/internal/client/webhooks.go
+++ b/internal/client/webhooks.go
@@ -13,9 +13,10 @@ var _ = api.WebhooksClient(&WebhooksClient{})
 
 // WebhooksClient is a client for working with webhooks.
 type WebhooksClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // Webhooks returns a WebhooksClient.
@@ -35,9 +36,10 @@ func (c *Client) Webhooks(accountID, workspaceID uuid.UUID) (api.WebhooksClient,
 	}
 
 	return &WebhooksClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "webhooks"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "webhooks"),
 	}, nil
 }
 
@@ -49,6 +51,7 @@ func (c *WebhooksClient) Create(ctx context.Context, createPayload api.WebhookCr
 		body:         &createPayload,
 		successCodes: successCodesStatusCreated,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	var webhook api.Webhook
@@ -67,6 +70,7 @@ func (c *WebhooksClient) Get(ctx context.Context, webhookID string) (*api.Webhoo
 		successCodes: successCodesStatusOK,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	var webhook api.Webhook
@@ -85,6 +89,7 @@ func (c *WebhooksClient) Update(ctx context.Context, webhookID string, updatePay
 		body:         &updatePayload,
 		successCodes: successCodesStatusOKOrNoContent,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	resp, err := request(ctx, c.hc, cfg)
@@ -104,6 +109,7 @@ func (c *WebhooksClient) Delete(ctx context.Context, webhookID string) error {
 		successCodes: successCodesStatusOKOrNoContent,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	resp, err := request(ctx, c.hc, cfg)
@@ -126,6 +132,7 @@ func (c *WebhooksClient) List(ctx context.Context, names []string) ([]*api.Webho
 		body:         http.NoBody,
 		successCodes: successCodesStatusOK,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	var webhooks []*api.Webhook

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -13,9 +13,10 @@ var _ = api.WorkPoolsClient(&WorkPoolsClient{})
 
 // WorkPoolsClient is a client for working with work pools.
 type WorkPoolsClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // WorkPools returns a WorkPoolsClient.
@@ -35,9 +36,10 @@ func (c *Client) WorkPools(accountID uuid.UUID, workspaceID uuid.UUID) (api.Work
 	}
 
 	return &WorkPoolsClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "work_pools"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "work_pools"),
 	}, nil
 }
 
@@ -49,6 +51,7 @@ func (c *WorkPoolsClient) Create(ctx context.Context, data api.WorkPoolCreate) (
 		body:         &data,
 		successCodes: successCodesStatusCreated,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	var pool api.WorkPool
@@ -67,6 +70,7 @@ func (c *WorkPoolsClient) List(ctx context.Context, filter api.WorkPoolFilter) (
 		body:         &filter,
 		successCodes: successCodesStatusOK,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	var pools []*api.WorkPool
@@ -85,6 +89,7 @@ func (c *WorkPoolsClient) Get(ctx context.Context, name string) (*api.WorkPool, 
 		successCodes: successCodesStatusOK,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	var pool api.WorkPool
@@ -103,6 +108,7 @@ func (c *WorkPoolsClient) Update(ctx context.Context, name string, data api.Work
 		body:         &data,
 		successCodes: successCodesStatusOKOrNoContent,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	resp, err := request(ctx, c.hc, cfg)
@@ -122,6 +128,7 @@ func (c *WorkPoolsClient) Delete(ctx context.Context, name string) error {
 		successCodes: successCodesStatusOKOrNoContent,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}
 
 	resp, err := request(ctx, c.hc, cfg)

--- a/internal/client/workspace_access.go
+++ b/internal/client/workspace_access.go
@@ -14,9 +14,10 @@ import (
 var _ = api.WorkspaceAccessClient(&WorkspaceAccessClient{})
 
 type WorkspaceAccessClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // WorkspaceAccess is a factory that initializes and returns a WorkspaceAccessClient.
@@ -36,9 +37,10 @@ func (c *Client) WorkspaceAccess(accountID uuid.UUID, workspaceID uuid.UUID) (ap
 	}
 
 	return &WorkspaceAccessClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: fmt.Sprintf("%s/accounts/%s/workspaces/%s", c.endpoint, accountID.String(), workspaceID.String()),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  fmt.Sprintf("%s/accounts/%s/workspaces/%s", c.endpoint, accountID.String(), workspaceID.String()),
 	}, nil
 }
 
@@ -82,6 +84,7 @@ func (c *WorkspaceAccessClient) Upsert(ctx context.Context, accessorType string,
 		url:          requestPath,
 		body:         &payloads,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -127,6 +130,7 @@ func (c *WorkspaceAccessClient) Get(ctx context.Context, accessorType string, ac
 		url:          requestPath,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -198,6 +202,7 @@ func (c *WorkspaceAccessClient) Delete(ctx context.Context, accessorType string,
 		url:          requestPath,
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 

--- a/internal/client/workspace_roles.go
+++ b/internal/client/workspace_roles.go
@@ -13,9 +13,10 @@ import (
 var _ = api.WorkspaceRolesClient(&WorkspaceRolesClient{})
 
 type WorkspaceRolesClient struct {
-	hc          *http.Client
-	apiKey      string
-	routePrefix string
+	hc           *http.Client
+	apiKey       string
+	basicAuthKey string
+	routePrefix  string
 }
 
 // WorkspaceRoles is a factory that initializes and returns a WorkspaceRolesClient.
@@ -27,9 +28,10 @@ func (c *Client) WorkspaceRoles(accountID uuid.UUID) (api.WorkspaceRolesClient, 
 	}
 
 	return &WorkspaceRolesClient{
-		hc:          c.hc,
-		apiKey:      c.apiKey,
-		routePrefix: getAccountScopedURL(c.endpoint, accountID, "workspace_roles"),
+		hc:           c.hc,
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
+		routePrefix:  getAccountScopedURL(c.endpoint, accountID, "workspace_roles"),
 	}, nil
 }
 
@@ -40,6 +42,7 @@ func (c *WorkspaceRolesClient) Create(ctx context.Context, data api.WorkspaceRol
 		url:          c.routePrefix + "/",
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -58,6 +61,7 @@ func (c *WorkspaceRolesClient) Update(ctx context.Context, workspaceRoleID uuid.
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, workspaceRoleID.String()),
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 
@@ -77,6 +81,7 @@ func (c *WorkspaceRolesClient) Delete(ctx context.Context, id uuid.UUID) error {
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, id.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,
 	}
 
@@ -99,6 +104,7 @@ func (c *WorkspaceRolesClient) List(ctx context.Context, roleNames []string) ([]
 		url:          fmt.Sprintf("%s/filter", c.routePrefix),
 		body:         &filterQuery,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -117,6 +123,7 @@ func (c *WorkspaceRolesClient) Get(ctx context.Context, id uuid.UUID) (*api.Work
 		url:          fmt.Sprintf("%s/%s", c.routePrefix, id.String()),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 

--- a/internal/client/workspaces.go
+++ b/internal/client/workspaces.go
@@ -14,9 +14,10 @@ var _ = api.WorkspacesClient(&WorkspacesClient{})
 
 // WorkspacesClient is a client for working with Workspaces.
 type WorkspacesClient struct {
-	hc          *http.Client
-	routePrefix string
-	apiKey      string
+	hc           *http.Client
+	routePrefix  string
+	apiKey       string
+	basicAuthKey string
 }
 
 // Workspaces returns a WorkspacesClient.
@@ -28,9 +29,10 @@ func (c *Client) Workspaces(accountID uuid.UUID) (api.WorkspacesClient, error) {
 	}
 
 	return &WorkspacesClient{
-		hc:          c.hc,
-		routePrefix: getAccountScopedURL(c.endpoint, accountID, "workspaces"),
-		apiKey:      c.apiKey,
+		hc:           c.hc,
+		routePrefix:  getAccountScopedURL(c.endpoint, accountID, "workspaces"),
+		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 	}, nil
 }
 
@@ -41,6 +43,7 @@ func (c *WorkspacesClient) Create(ctx context.Context, data api.WorkspaceCreate)
 		url:          c.routePrefix + "/",
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusCreated,
 	}
 
@@ -65,6 +68,7 @@ func (c *WorkspacesClient) List(ctx context.Context, handleNames []string) ([]*a
 		url:          fmt.Sprintf("%s/filter", c.routePrefix),
 		body:         &filterQuery,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -83,6 +87,7 @@ func (c *WorkspacesClient) Get(ctx context.Context, workspaceID uuid.UUID) (*api
 		url:          c.routePrefix + "/" + workspaceID.String(),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOK,
 	}
 
@@ -101,6 +106,7 @@ func (c *WorkspacesClient) Update(ctx context.Context, workspaceID uuid.UUID, da
 		url:          c.routePrefix + "/" + workspaceID.String(),
 		body:         &data,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 
@@ -120,6 +126,7 @@ func (c *WorkspacesClient) Delete(ctx context.Context, workspaceID uuid.UUID) er
 		url:          c.routePrefix + "/" + workspaceID.String(),
 		body:         http.NoBody,
 		apiKey:       c.apiKey,
+		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusOKOrNoContent,
 	}
 

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -14,8 +14,9 @@ type PrefectProvider struct {
 
 // PrefectProviderModel maps provider schema data to a Go type.
 type PrefectProviderModel struct {
-	Endpoint    types.String          `tfsdk:"endpoint"`
-	APIKey      types.String          `tfsdk:"api_key"`
-	AccountID   customtypes.UUIDValue `tfsdk:"account_id"`
-	WorkspaceID customtypes.UUIDValue `tfsdk:"workspace_id"`
+	Endpoint     types.String          `tfsdk:"endpoint"`
+	APIKey       types.String          `tfsdk:"api_key"`
+	BasicAuthKey types.String          `tfsdk:"basic_auth_key"`
+	AccountID    customtypes.UUIDValue `tfsdk:"account_id"`
+	WorkspaceID  customtypes.UUIDValue `tfsdk:"workspace_id"`
 }

--- a/templates/guides/getting-started.md
+++ b/templates/guides/getting-started.md
@@ -75,7 +75,7 @@ Most production use-cases will call for using a dedicated Service Account's API 
 <br>
 
 After creating the Service Account, the API Key will be generated and displayed for you in the UI.
-m
+
 ### User Keys
 
 API Keys can also be generated to represent a User - look to this option if you want to use the provider to manage a Personal Account, where the Service Account feature is not available.
@@ -88,6 +88,19 @@ Note that any User API Keys will inherit the Account/Organization Role of the Us
 
 <img src="https://raw.githubusercontent.com/PrefectHQ/terraform-provider-prefect/main/docs/images/user-api-key-example.png" alt="User API Key Example" align="center" width="400">
 
+### Using basic authorization
+
+Self-hosted Prefect servers can use [basic authorization](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings).
+To allow the provider to connect in this situation, configure `endpoint` and `basic_auth_key`:
+
+```terraform
+provider "prefect" {
+  endpoint       = "http://localhost:4200"
+  basic_auth_key = "admin:password"
+}
+```
+
+The provider will automatically base64 encode the value you provide for `basic_auth_key`.
 
 ## RBAC + Permissions
 

--- a/templates/guides/getting-started.md
+++ b/templates/guides/getting-started.md
@@ -88,9 +88,9 @@ Note that any User API Keys will inherit the Account/Organization Role of the Us
 
 <img src="https://raw.githubusercontent.com/PrefectHQ/terraform-provider-prefect/main/docs/images/user-api-key-example.png" alt="User API Key Example" align="center" width="400">
 
-### Using basic authorization
+### Using basic authentication
 
-Self-hosted Prefect servers can use [basic authorization](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings).
+Self-hosted Prefect servers can use [basic authentication](https://docs.prefect.io/v3/develop/settings-and-profiles#security-settings).
 To allow the provider to connect in this situation, configure `endpoint` and `basic_auth_key`:
 
 ```terraform


### PR DESCRIPTION
## Summary

Closes https://linear.app/prefect/issue/PLA-1054/support-accessing-prefect-oss-with-basic-auth

Supports setting either a `basic_auth_key` attribute or `PREFECT_BASIC_AUTH_KEY` environment variable to configure client calls with a basic auth header.

## Manual testing

Our test suite is set up to run against Prefect Cloud, where we don't have basic auth configured. So to mimic this situation, I set up the provider locally with auth enabled:

```diff
diff --git a/compose.yml b/compose.yml
index b111531..b937429 100644
--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,7 @@ services:
       - "4200:4200"
     environment:
       PREFECT_LOGGING_LEVEL: debug
+      PREFECT_SERVER_API_AUTH_STRING: "foo:bar"
     command:
       - prefect
       - server
```

Then I ran `docker-compose up -d` to start the server.

Next, I set up a manifest targeting that instance along with some resources:

```terraform
terraform {
  required_providers {
    prefect = {
      source = "registry.terraform.io/prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint       = "http://localhost:4200"
  basic_auth_key = "foo:bar"
}

resource "prefect_variable" "example" {
  name  = "example"
  value = "hello-world"
}

resource "prefect_block" "demo_github_repository" {
  name      = "demo-github-repository"
  type_slug = "github-repository"

  data = jsonencode({
    "repository_url" : "https://github.com/foo/bar",
    "reference" : "main"
  })
}

resource "prefect_flow" "flow" {
  name = "my-flow"
  tags = ["tf-test"]
}

resource "prefect_deployment" "deployment" {
  name        = "my-deployment"
  description = "string"
  flow_id     = prefect_flow.flow.id
  # entrypoint               = "hello_world.py:hello_world"
  # tags                     = ["test"]
  enforce_parameter_schema = true
  parameter_openapi_schema = jsonencode({
    "type" : "object",
    "properties" : {
      "some-parameter" : { "type" : "string" }
      "some-parameter2" : { "type" : "string" }
    }
  })
  storage_document_id = prefect_block.demo_github_repository.id
}
```

I installed the provider version locally and tested:

```bash
go install .
tf apply -auto-approve
```

```
prefect_block.demo_github_repository: Creating...
prefect_flow.flow: Creating...
prefect_variable.example: Creating...
prefect_flow.flow: Creation complete after 0s [id=fa6264c5-453c-473e-967e-2882d6a0e8b7]
prefect_variable.example: Creation complete after 0s [id=4e9a17f7-e53e-40d8-9f17-1aa321c5466e]
prefect_block.demo_github_repository: Creation complete after 0s [id=d8784cc2-0bad-478a-81b5-3307427c4278]
prefect_deployment.deployment: Creating...
prefect_deployment.deployment: Creation complete after 0s [id=5908dcba-99f8-4c79-b0ac-a22ae0d73e7d]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
```

Without the `basic_auth_key` set in the provider, you'll see this error:

> Could not create flow, unexpected error: failed to create flow: status code=401 Unauthorized, error={"exception_message":"Unauthorized"}