### PR TITLE
fix(accounts): fix the account domains payload

### DIFF
--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -7,7 +7,7 @@ import (
 // AccountsClient is a client for working with accounts.
 type AccountsClient interface {
 	Get(ctx context.Context) (*Account, error)
-	GetDomains(ctx context.Context) (*AccountDomainsUpdate, error)
+	GetDomains(ctx context.Context) ([]*AccountDomain, error)
 	Update(ctx context.Context, data AccountUpdate) error
 	UpdateSettings(ctx context.Context, data AccountSettingsUpdate) error
 	UpdateDomains(ctx context.Context, data AccountDomainsUpdate) error
@@ -52,6 +52,14 @@ type AccountUpdate struct {
 // AccountSettingsUpdate is the data sent when updating an account's settings.
 type AccountSettingsUpdate struct {
 	AccountSettings `json:"settings"`
+}
+
+// AccountDomain is the data retrieved when getting an account's domain names.
+type AccountDomain struct {
+	Name string `json:"name"`
+
+	// The fields below are present in the response but are currently ignored.
+	// id, created, updated, account_id
 }
 
 // AccountDomainsUpdate is the data sent when updating an account's domain names.

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -122,7 +122,7 @@ func (c *AccountsClient) UpdateDomains(ctx context.Context, data api.AccountDoma
 	cfg := requestConfig{
 		method:       http.MethodPatch,
 		url:          c.routePrefix + "domains",
-		body:         data.DomainNames,
+		body:         data,
 		apiKey:       c.apiKey,
 		basicAuthKey: c.basicAuthKey,
 		successCodes: successCodesStatusNoContent,

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -59,7 +59,7 @@ func (c *AccountsClient) Get(ctx context.Context) (*api.Account, error) {
 }
 
 // GetDomains returns domain names for an account by ID.
-func (c *AccountsClient) GetDomains(ctx context.Context) (*api.AccountDomainsUpdate, error) {
+func (c *AccountsClient) GetDomains(ctx context.Context) ([]*api.AccountDomain, error) {
 	cfg := requestConfig{
 		method:       http.MethodGet,
 		url:          c.routePrefix + "domains",
@@ -69,12 +69,12 @@ func (c *AccountsClient) GetDomains(ctx context.Context) (*api.AccountDomainsUpd
 		successCodes: successCodesStatusOK,
 	}
 
-	var accountDomains api.AccountDomainsUpdate
-	if err := requestWithDecodeResponse(ctx, c.hc, cfg, &accountDomains.DomainNames); err != nil {
-		return nil, fmt.Errorf("failed to get account domains: %w", err)
+	var accountDomains []*api.AccountDomain
+	if err := requestWithDecodeResponse(ctx, c.hc, cfg, &accountDomains); err != nil {
+		return nil, fmt.Errorf("hey failed to get account domains: %w", err)
 	}
 
-	return &accountDomains, nil
+	return accountDomains, nil
 }
 
 // Update modifies an existing account by ID.

--- a/internal/provider/datasources/account_test.go
+++ b/internal/provider/datasources/account_test.go
@@ -31,6 +31,10 @@ func TestAccDatasource_account(t *testing.T) {
 					testutils.ExpectKnownValue(datasourceName, "id", os.Getenv("PREFECT_CLOUD_ACCOUNT_ID")),
 					testutils.ExpectKnownValueNotNull(datasourceName, "name"),
 					testutils.ExpectKnownValueNotNull(datasourceName, "handle"),
+
+					// These domain names were manually added to the account, because we're using a pre-existing account
+					// due to the fact that accounts cannot be created with the API/Terraform.
+					testutils.ExpectKnownValueList(datasourceName, "domain_names", []string{"example.com", "foobar.com"}),
 				},
 			},
 		},

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -189,8 +189,14 @@ func copyAccountToModel(_ context.Context, account *api.Account, tfModel *Accoun
 
 // copyAccountDomainsToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
-func copyAccountDomainsToModel(ctx context.Context, accountDomains *api.AccountDomainsUpdate, tfModel *AccountResourceModel) diag.Diagnostics {
-	domainNames, diags := types.ListValueFrom(ctx, types.StringType, accountDomains.DomainNames)
+func copyAccountDomainsToModel(ctx context.Context, accountDomains []*api.AccountDomain, tfModel *AccountResourceModel) diag.Diagnostics {
+	// Convert the list of AccountDomain to a list of names as strings.
+	names := make([]string, 0, len(accountDomains))
+	for _, name := range accountDomains {
+		names = append(names, name.Name)
+	}
+
+	domainNames, diags := types.ListValueFrom(ctx, types.StringType, names)
 	if diags.HasError() {
 		return diags
 	}


### PR DESCRIPTION
## Summary

Fixes the payload type of account domains.

The API docs don't show the structure of the response, so we mistakenly assumed it was the same as the request payload - a list of strings.

It's actually a list of objects, and the name is one of the fields in those objects.

So this change accounts for that structure, and extracts the names from it.

Follow-up to https://github.com/PrefectHQ/terraform-provider-prefect/pull/382

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/390

## Testing

You can't create accounts with Terraform, and to test SSO it has to be enabled on a paid account, so I used the existing `github-ci-tests` account we have in staging:

```terraform
terraform {
  required_providers {
    prefect = {
      source = "registry.terraform.io/prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint = "https://api.stg.prefect.dev"
  account_id = "bb19c492-73c2-4ecd-9cd7-d82c4aac08e6"
  api_key = "<redacted>"
}

resource "prefect_account" "test" {
  name   = "github-ci-tests"
  handle = "github-ci-tests"
  # Added "update.com"
  domain_names = ["example.com", "foobar.com", "update.com"]
  settings = {
    ai_log_summaries        = true
    allow_public_workspaces = false
    managed_execution       = true
  }
}
```

Per the comment, I added `update.com` to my Terraform (the first two existed already because I manually set them to satisfy the datasource acceptance test).

I applied the change and it added the value as expected:

```
Terraform will perform the following actions:

  # prefect_account.test will be updated in-place
  ~ resource "prefect_account" "test" {
      ~ domain_names = [
            # (1 unchanged element hidden)
            "foobar.com",
          + "update.com",
        ]
        id           = "bb19c492-73c2-4ecd-9cd7-d82c4aac08e6"
        name         = "github-ci-tests"
      ~ updated      = "2025-02-28T22:41:58Z" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

prefect_account.test: Modifying... [id=bb19c492-73c2-4ecd-9cd7-d82c4aac08e6]
prefect_account.test: Modifications complete after 1s [id=bb19c492-73c2-4ecd-9cd7-d82c4aac08e6]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

<img width="556" alt="image" src="https://github.com/user-attachments/assets/35f25a9f-9272-40cf-b4c4-9367c62f2ba1" />

This covers the resource testing. The datasource testing, as mentioned, is part of the acceptance test suite as of this PR.

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
- [x] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [x] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
