### PR TITLE
fix(deployment): account for "null" response in parameter_openapi_schema

### DIFF
--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -619,7 +619,14 @@ func CopyDeploymentToModel(ctx context.Context, deployment *api.Deployment, mode
 	if err != nil {
 		return diag.Diagnostics{helpers.SerializeDataErrorDiagnostic("parameter_openapi_schema", "Deployment parameter OpenAPI schema", err)}
 	}
-	model.ParameterOpenAPISchema = jsontypes.NewNormalizedValue(string(parameterOpenAPISchemaByteSlice))
+
+	// OSS returns "null" for this field if it's empty, rather than an empty map of "{}".
+	// To avoid an "inconsistent result after apply" error, we will only attempt to parse the
+	// response if it is not "null". In this case, the value will fall back to the default
+	// set in the schema.
+	if string(parameterOpenAPISchemaByteSlice) != "null" {
+		model.ParameterOpenAPISchema = jsontypes.NewNormalizedValue(string(parameterOpenAPISchemaByteSlice))
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Summary

In OSS, the return value for parameter_openapi_schema is "null" instead of an empty map {}.

This leads to an inconsistent value error because the default value is the empty map "{}", but the response from the API tries to set "null".

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/399

Closes https://linear.app/prefect/issue/PLA-1204/resoure-prefect-deployment-error-provider-produced-inconsistent-result

### Testing

We need to test against both Cloud and OSS to ensure this logic supports both cases.

For Cloud:

```terraform
terraform {
  required_providers {
    prefect = {
      source = "registry.terraform.io/prefecthq/prefect"
    }
  }
}

# For a cloud instance
provider "prefect" {
  endpoint = "https://api.stg.prefect.dev"
  account_id   = "9a67b081-4f14-4035-b000-1f715f46231b"
  workspace_id = "85bad5d0-48ee-42be-9f72-8a2998512d85"
  api_key = "<redacted>"
}

resource "prefect_flow" "say_hello_flow" {
  name = "mitch-say-hello-flow"
}

resource "prefect_deployment" "hello_flow" {
  name                     = "mitch-hello-flow-deployment"
  flow_id                  = prefect_flow.say_hello_flow.id
  entrypoint               = "flows/hello_ecs_flow.py:say_hello_flow"
  version                  = "0.1"
  enforce_parameter_schema = true
  pull_steps = [
    {
      directory = "/opt/prefect"
      type      = "set_working_directory"
    },
  ]
}
```

You should be able to successfully apply the plan.

Next, test in OSS by modifying the compose file to match the reported version of Prefect:

```diff
diff --git a/compose.yml b/compose.yml
index b111531..b3b8fbd 100644
--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,8 @@
 # See ./_about/CONTRIBUTING.md.
 services:
   prefect:
-    image: prefecthq/prefect:3-latest
+    image: prefecthq/prefect:3.2.9-python3.12
     ports:
       - "4200:4200"
     environment:
```

Then update your Terraform config to point to a local instance:

```terraform
provider "prefect" {
  endpoint = "http://localhost:4200"
}
```

You should again be able to successfully apply the plan.

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
- [x] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [x] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
