### PR TITLE
chore(acceptance tests): use Terraform 1.11

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -42,7 +42,7 @@ jobs:
           go-version-file: 'go.mod'
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: '1.5.*'
+          terraform_version: '1.11.*'
           terraform_wrapper: false
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest


### PR DESCRIPTION
### Summary

The 'removed' block is only supported in Terraform 1.7 and higher, but we were pinning to 1.5. We're currently using 1.11 in .mise.toml, so let's just match them.

Related to https://linear.app/prefect/issue/PLA-1193/cycle-14-catch-all

Related to https://github.com/PrefectHQ/terraform-provider-prefect/pull/402#discussion_r1982472715

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review
