### PR TITLE
fix(client): retry if response is empty

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -114,6 +114,12 @@ func WithDefaults(accountID uuid.UUID, workspaceID uuid.UUID) Option {
 }
 
 func checkRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	// If the response is empty, there was a problem with the request,
+	// so try again.
+	if resp == nil {
+		return true, err
+	}
+
 	// If the response is a 409 (StatusConflict), that means the request
 	// eventually succeeded and we don't need to make the request again.
 	if resp.StatusCode == http.StatusConflict {


### PR DESCRIPTION
## Summary

We were sometimes seeing a crash in the client requests's checkRetryPolicy. This was preventing helpful errors from the request from being returned in the Terraform logs.

For example:

```
│ Error: Plugin did not respond
│
│ The plugin encountered an error, and failed to respond to the plugin6.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-prefect plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x102681958]

goroutine 66 [running]:
github.com/prefecthq/terraform-provider-prefect/internal/client.checkRetryPolicy({0x102a1d4a8?, 0x140001c6540?}, 0x10?, {0x102a16f60?, 0x1400039d590?})
        /Users/mitch/code/github.com/prefecthq/terraform-provider-prefect/docs-clarify-env-vars/internal/client/client.go:119 +0x28
github.com/hashicorp/go-retryablehttp.(*Client).Do(0x1400012ad80, 0x140003becd8)
        /Users/mitch/go/pkg/mod/github.com/hashicorp/go-retryablehttp@v0.7.7/client.go:705 +0x294
```

This change ensures those requests get retried, and eventually returns the error if there is one.

For example:

```
│ Could not get Account, unexpected error: failed to get account: http error: Get "https://api.wrong.stg.prefect.cloud/api/accounts/9a67b081-4f14-4035-b000-1f715f46231b/": GET
│ https://api.wrong.stg.prefect.cloud/api/accounts/9a67b081-4f14-4035-b000-1f715f46231b/ giving up after 1 attempt(s): Get "https://api.wrong.stg.prefect.cloud/api/accounts/9a67b081-4f14-4035-b000-1f715f46231b/":
│ dial tcp: lookup api.wrong.stg.prefect.cloud: no such host
```

Related to https://linear.app/prefect/issue/PLA-1193/cycle-14-catch-all

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
