### PR TITLE
fix(docs): add docs/ to link paths

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,9 +10,9 @@ description: |-
 
 Use the [Prefect](https://prefect.io) provider to configure your Prefect infrastructure.
 
-See [getting started](./guides/getting-started.md) for more information on setting up the provider.
+See [getting started](./docs/guides/getting-started.md) for more information on setting up the provider.
 
-See [troubleshoting](./guides/troubleshooting.md) for resources to address potential errors.
+See [troubleshoting](./docs/guides/troubleshooting.md) for resources to address potential errors.
 
 ## Example Usage
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -10,9 +10,9 @@ description: |-
 
 {{.Description}}
 
-See [getting started](./guides/getting-started.md) for more information on setting up the provider.
+See [getting started](./docs/guides/getting-started.md) for more information on setting up the provider.
 
-See [troubleshoting](./guides/troubleshooting.md) for resources to address potential errors.
+See [troubleshoting](./docs/guides/troubleshooting.md) for resources to address potential errors.
 
 ## Example Usage
 


### PR DESCRIPTION
The docs get generated into the docs/ subdirectory, so we need to specify that for the hyperlink to work correctly from registry.terraform.io.

Related to https://linear.app/prefect/issue/PLA-1193/cycle-14-catch-all

### Summary

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
