### PR TITLE
feat(deployments): support updating parameter_openapi_schema

### DIFF
--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -75,6 +75,7 @@ type DeploymentUpdate struct {
 	Entrypoint             string                 `json:"entrypoint,omitempty"`
 	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
 	ManifestPath           string                 `json:"manifest_path,omitempty"`
+	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
 	Parameters             map[string]interface{} `json:"parameters,omitempty"`
 	Path                   string                 `json:"path,omitempty"`
 	Paused                 bool                   `json:"paused,omitempty"`

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -312,12 +312,6 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Computed:    true,
 				CustomType:  jsontypes.NormalizedType{},
 				Default:     stringdefault.StaticString("{}"),
-				// OpenAPI schema is also only set on create, and
-				// we do not support modifying this value. Therefore, any changes
-				// to this attribute will force a replacement.
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"concurrency_limit": schema.Int64Attribute{
 				Description: "The deployment's concurrency limit.",
@@ -832,6 +826,12 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	parameterOpenAPISchema, diags := helpers.UnmarshalOptional(model.ParameterOpenAPISchema)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	payload := api.DeploymentUpdate{
 		ConcurrencyLimit:       model.ConcurrencyLimit.ValueInt64Pointer(),
 		Description:            model.Description.ValueString(),
@@ -839,6 +839,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		Entrypoint:             model.Entrypoint.ValueString(),
 		JobVariables:           jobVariables,
 		ManifestPath:           model.ManifestPath.ValueString(),
+		ParameterOpenAPISchema: parameterOpenAPISchema,
 		Parameters:             parameters,
 		Path:                   model.Path.ValueString(),
 		Paused:                 model.Paused.ValueBool(),

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -194,6 +194,9 @@ func TestAccResource_deployment(t *testing.T) {
 	parameterOpenAPISchema := `{"type": "object", "properties": {"some-parameter": {"type": "string"}}}`
 	expectedParameterOpenAPISchema := testutils.NormalizedValueForJSON(t, parameterOpenAPISchema)
 
+	parameterOpenAPISchemaUpdate := `{"type": "object", "properties": {"some-parameter": {"type": "string"}, "some-other-parameter": {"type": "string"}}}`
+	expectedParameterOpenAPISchemaUpdate := testutils.NormalizedValueForJSON(t, parameterOpenAPISchemaUpdate)
+
 	cfgCreate := deploymentConfig{
 		DeploymentName:         deploymentName,
 		FlowName:               flowName,
@@ -234,17 +237,18 @@ func TestAccResource_deployment(t *testing.T) {
 		WorkPoolName:           cfgCreate.WorkPoolName,
 
 		// Configure new values to test the update.
-		ConcurrencyLimit:  2,
-		CollisionStrategy: "CANCEL_NEW",
-		Description:       "My deployment description v2",
-		Entrypoint:        "hello_world.py:hello_world2",
-		JobVariables:      `{"env":{"some-key":"some-value2"}}`,
-		ManifestPath:      "some-manifest-path2",
-		Parameters:        "some-value2",
-		Path:              "some-path2",
-		Paused:            true,
-		Version:           "v1.1.2",
-		WorkQueueName:     "default",
+		ConcurrencyLimit:       2,
+		CollisionStrategy:      "CANCEL_NEW",
+		Description:            "My deployment description v2",
+		Entrypoint:             "hello_world.py:hello_world2",
+		JobVariables:           `{"env":{"some-key":"some-value2"}}`,
+		ManifestPath:           "some-manifest-path2",
+		ParameterOpenAPISchema: parameterOpenAPISchemaUpdate,
+		Parameters:             "some-value2",
+		Path:                   "some-path2",
+		Paused:                 true,
+		Version:                "v1.1.2",
+		WorkQueueName:          "default",
 
 		// Enforcing parameter schema  returns the following error:
 		//
@@ -263,9 +267,6 @@ func TestAccResource_deployment(t *testing.T) {
 		//
 		// Tags: []string{"test1", "test3"}
 		Tags: cfgCreate.Tags,
-
-		// ParameterOpenAPISchema is not settable via the Update method.
-		ParameterOpenAPISchema: cfgCreate.ParameterOpenAPISchema,
 
 		// PullSteps require a replacement of the resource.
 		PullSteps: []api.PullStep{
@@ -355,7 +356,7 @@ func TestAccResource_deployment(t *testing.T) {
 					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "job_variables", cfgUpdate.JobVariables),
 					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "manifest_path", cfgUpdate.ManifestPath),
 					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "parameters", `{"some-parameter":"some-value2"}`),
-					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "parameter_openapi_schema", expectedParameterOpenAPISchema),
+					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "parameter_openapi_schema", expectedParameterOpenAPISchemaUpdate),
 					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "path", cfgUpdate.Path),
 					testutils.ExpectKnownValueBool(cfgUpdate.DeploymentResourceName, "paused", cfgUpdate.Paused),
 					testutils.ExpectKnownValueList(cfgUpdate.DeploymentResourceName, "tags", cfgUpdate.Tags),


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->

With https://github.com/PrefectHQ/prefect/pull/17016, the field 'parameter_openapi_schema' can be passed in the Update payload.

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/275

Closes https://linear.app/prefect/issue/PLA-372/deployments-support-updating-parameteropenapischema

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
