### PR TITLE
fix(flows): use correct success code

### DIFF
--- a/internal/client/flows.go
+++ b/internal/client/flows.go
@@ -52,7 +52,7 @@ func (c *FlowsClient) Create(ctx context.Context, data api.FlowCreate) (*api.Flo
 		body:         &data,
 		apiKey:       c.apiKey,
 		basicAuthKey: c.basicAuthKey,
-		successCodes: successCodesStatusOK,
+		successCodes: successCodesStatusOKOrCreated,
 	}
 
 	var flow api.Flow

--- a/internal/client/flows.go
+++ b/internal/client/flows.go
@@ -52,7 +52,7 @@ func (c *FlowsClient) Create(ctx context.Context, data api.FlowCreate) (*api.Flo
 		body:         &data,
 		apiKey:       c.apiKey,
 		basicAuthKey: c.basicAuthKey,
-		successCodes: successCodesStatusCreated,
+		successCodes: successCodesStatusOK,
 	}
 
 	var flow api.Flow

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -109,6 +109,10 @@ var (
 	// successCodesStatusOKOrNoContent is a convenience variable to use for a common
 	// success criteria of either StatusOK or StatusNoContent.
 	successCodesStatusOKOrNoContent = []int{http.StatusOK, http.StatusNoContent}
+
+	// successCodesStatusOKOrCreated is a convenience variable to use for a common
+	// success criteria of either Status OK or StatusCreated.
+	successCodesStatusOKOrCreated = []int{http.StatusOK, http.StatusCreated}
 )
 
 // request performs an HTTP request with the provided configuration.


### PR DESCRIPTION
### Summary

The success return code for flow creation is actually 200, not 201.

- https://app.prefect.cloud/api/docs#tag/Flows/operation/create_flow_api_accounts__account_id__workspaces__workspace_id__flows__post
- https://docs.prefect.io/v3/api-ref/rest-api/server/flows/create-flow

However, this is only what's generated in the API docs. You can actually get one of two return codes based on the [source code](https://github.com/PrefectHQ/prefect/blob/6393a17dca7e63e1ee2a9363aaa3fef3d0f64b53/src/prefect/server/api/flows.py#L42):
- 201: if the resource did not exist and is created now
- 200: if the resource already exists

Related to https://linear.app/prefect/issue/PLA-1236/200-error-on-deployment-recreate

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/422

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
