### PR TITLE
fix(work-pools/work-queues): queue create if remote object deleted

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -129,7 +129,12 @@ func checkRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool
 	// If the response is a 404 (NotFound), try again. This is particularly
 	// relevant for block-related objects that are created asynchronously.
 	if resp.StatusCode == http.StatusNotFound {
-		return true, err
+		// NOTE: we encode the status code in the error object as a workaround
+		// in cases where we want access to the status code on a failed client.Do() call
+		// due to exhausted retries.
+		// go-retryablehttp does not return the response object on exhausted retries.
+		// https://github.com/hashicorp/go-retryablehttp/blob/main/client.go#L811-L825
+		return true, fmt.Errorf("status_code=%d, error=%w", resp.StatusCode, err)
 	}
 
 	// Fall back to the default retry policy for any other status codes.

--- a/internal/provider/resources/work_queue.go
+++ b/internal/provider/resources/work_queue.go
@@ -224,6 +224,19 @@ func (r *WorkQueueResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	queue, err := client.Get(ctx, state.Name.ValueString())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		//
+		// NOTE: as a workaround, we encode + check this status code string on the error object.
+		// See `checkRetryPolicy` in `internal/client/client.go` for more details.
+		if strings.Contains(err.Error(), "status_code=404") {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
+		// Otherwise, we can log the error diagnostic and return
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Work Queue", "get", err))
 
 		return


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->

This PR adds a resilience mechanic for edge cases where the remote API object is deleted outside of Terraform.  Specifically, we add this mechanic for Work Pools and Work Queues

Generally, in these cases - it's on the developer to clean up their Terraform state so that the `terraform plan` can succeed; otherwise, a 404 will cause the plan to fail.

We've opted to try out a self-healing lever, where the plugin framework identifies a 404 specifically on Read() - in this case, we'll clean out resource from State so that the framework automatically queues up a Create() plan

This is likely not appropriate for all resources, though time will tell as we see how this behaves

resolves https://linear.app/prefect/issue/PLA-1229/self-healing-behavior-and-resource-fixing
resolves #417 
relates to #260 

### Requirements
Create a Work Pool via Terraform
```hcl
resource "prefect_work_pool" "example" {
  name         = "my-work-pool"
  type         = "kubernetes"
  paused       = false
}
```

Apply it
```
terraform apply --auto-approve
```

Go to the Prefect UI, delete the Work Pool
<img width="709" alt="image" src="https://github.com/user-attachments/assets/f1a913a3-de09-4444-a371-c833135679b5" />

Re-run the `terraform plan` on the existing HCL - this should automatically detect that a new `create` should be planned

```diff
➜ terraform plan
prefect_work_pool.example: Refreshing state... [id=fc426d27-95fd-45b8-8c85-6f15a37e1204]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # prefect_work_pool.example will be created
  + resource "prefect_work_pool" "example" {
      + base_job_template = jsonencode({})
      + created           = (known after apply)
      + default_queue_id  = (known after apply)
      + id                = (known after apply)
      + name              = "my-work-pool"
      + paused            = false
      + type              = "kubernetes"
      + updated           = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

To ensure that any non-404 error does NOT do this, force a 401 by mangling the API key.  This should not queue up a create plan
```
➜ terraform plan
prefect_work_pool.example: Refreshing state... [id=fc426d27-95fd-45b8-8c85-6f15a37e1204]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Error during get Work Pool
│
│   with prefect_work_pool.example,
│   on prefect_work_pool.tf line 16, in resource "prefect_work_pool" "example":
│   16: resource "prefect_work_pool" "example" {
│
│ Could not get Work Pool, unexpected error: failed to get work pool: msg=http error: Get
│ "https://api.stg.prefect.dev/api/accounts/bb19c492-73c2-4ecd-9cd7-d82c4aac08e6/workspaces/c63d708d-b4d7-49a7-92b1-e067e65c99d7/work_pools/my-work-pool": GET
│ https://api.stg.prefect.dev/api/accounts/bb19c492-73c2-4ecd-9cd7-d82c4aac08e6/workspaces/c63d708d-b4d7-49a7-92b1-e067e65c99d7/work_pools/my-work-pool giving up after 5 attempt(s)
```

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
