### PR TITLE
feat(flows): support updating flows without replacement

### DIFF
--- a/internal/api/flows.go
+++ b/internal/api/flows.go
@@ -32,7 +32,6 @@ type FlowCreate struct {
 
 // FlowUpdate is a subset of Flow used when updating flows.
 type FlowUpdate struct {
-	Name *string  `json:"name"`
 	Tags []string `json:"tags"`
 }
 

--- a/internal/provider/resources/flow.go
+++ b/internal/provider/resources/flow.go
@@ -167,10 +167,9 @@ func (r *FlowResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	client, err := r.client.Flows(plan.AccountID.ValueUUID(), plan.WorkspaceID.ValueUUID())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating flows client",
-			fmt.Sprintf("Could not create flows client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
-		)
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Flow", err))
+
+		return
 	}
 
 	flow, err := client.Create(ctx, api.FlowCreate{
@@ -178,10 +177,7 @@ func (r *FlowResource) Create(ctx context.Context, req resource.CreateRequest, r
 		Tags: tags,
 	})
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating flow",
-			fmt.Sprintf("Could not create flow, unexpected error: %s", err),
-		)
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Flow", "create", err))
 
 		return
 	}
@@ -209,10 +205,9 @@ func (r *FlowResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	client, err := r.client.Flows(model.AccountID.ValueUUID(), model.WorkspaceID.ValueUUID())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating flow client",
-			fmt.Sprintf("Could not create flow client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
-		)
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Flow", err))
+
+		return
 	}
 
 	// A flow can be imported + read by specifying the workspace_id and the flow_id.
@@ -325,10 +320,9 @@ func (r *FlowResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	client, err := r.client.Flows(state.AccountID.ValueUUID(), state.WorkspaceID.ValueUUID())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating flows client",
-			fmt.Sprintf("Could not create flows client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
-		)
+		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Flow", err))
+
+		return
 	}
 
 	flowID, err := uuid.Parse(state.ID.ValueString())
@@ -344,10 +338,7 @@ func (r *FlowResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	err = client.Delete(ctx, flowID)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting Flow",
-			fmt.Sprintf("Could not delete Flow, unexpected error: %s", err),
-		)
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Flow", "delete", err))
 
 		return
 	}


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->

Supports updating the tags on a flow, no longer requiring the entire flow to be replaced.

Also makes use of the helpers we now have for adding diagnostics.

Closes https://linear.app/prefect/issue/PLA-1247/changing-tags-on-a-flow-requires-replacement

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
