### PR TITLE
docs(deployment): provide 'credentials' example in pull_steps

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -77,11 +77,13 @@ resource "prefect_deployment" "deployment" {
       branch             = "main"
       include_submodules = true
 
-      # For private repositiroeis, choose from either:
+      # For private repositories, choose from one of the following options:
       #
-      # Option 1: using an access token
+      # Option 1: using an access token by passing it as plaintext
       access_token = "123abc"
-      # Or option 2: using a credentials block
+      # Option 2: using an access token by referencing a Secret block
+      access_token = "{{ prefect.blocks.secret.github-token }}"
+      # Option 3: using a Credentials block
       credentials = "{{ prefect.blocks.github-credentials.private-repo-creds }}"
     },
     {

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -75,8 +75,14 @@ resource "prefect_deployment" "deployment" {
       type               = "git_clone"
       repository         = "https://github.com/some/repo"
       branch             = "main"
-      access_token       = "123abc"
       include_submodules = true
+
+      # For private repositiroeis, choose from either:
+      #
+      # Option 1: using an access token
+      access_token = "123abc"
+      # Or option 2: using a credentials block
+      credentials = "{{ prefect.blocks.github-credentials.private-repo-creds }}"
     },
     {
       type     = "pull_from_s3",

--- a/examples/resources/prefect_deployment/resource.tf
+++ b/examples/resources/prefect_deployment/resource.tf
@@ -57,11 +57,13 @@ resource "prefect_deployment" "deployment" {
       branch             = "main"
       include_submodules = true
 
-      # For private repositiroeis, choose from either:
+      # For private repositories, choose from one of the following options:
       #
-      # Option 1: using an access token
+      # Option 1: using an access token by passing it as plaintext
       access_token = "123abc"
-      # Or option 2: using a credentials block
+      # Option 2: using an access token by referencing a Secret block
+      access_token = "{{ prefect.blocks.secret.github-token }}"
+      # Option 3: using a Credentials block
       credentials = "{{ prefect.blocks.github-credentials.private-repo-creds }}"
     },
     {

--- a/examples/resources/prefect_deployment/resource.tf
+++ b/examples/resources/prefect_deployment/resource.tf
@@ -55,8 +55,14 @@ resource "prefect_deployment" "deployment" {
       type               = "git_clone"
       repository         = "https://github.com/some/repo"
       branch             = "main"
-      access_token       = "123abc"
       include_submodules = true
+
+      # For private repositiroeis, choose from either:
+      #
+      # Option 1: using an access token
+      access_token = "123abc"
+      # Or option 2: using a credentials block
+      credentials = "{{ prefect.blocks.github-credentials.private-repo-creds }}"
     },
     {
       type     = "pull_from_s3",


### PR DESCRIPTION
### Summary

Provides an example for the 'credentials' attribute in the 'pull_steps' for a Deployment resource.

Related to https://linear.app/prefect/issue/PLA-1265/cycle-16-catch-all

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
