### PR TITLE
fix(work-pools): omit base job template if not defined

### DIFF
--- a/docs/resources/work_pool.md
+++ b/docs/resources/work_pool.md
@@ -22,10 +22,10 @@ This feature is available in the following [product plan(s)](https://www.prefect
 ## Example Usage
 
 ```terraform
+# Use the default base job template by omitting the `base_job_template` argument.
 resource "prefect_work_pool" "example" {
   name         = "my-work-pool"
-  type         = "kubernetes"
-  paused       = false
+  type         = "prefect:managed"
   workspace_id = "my-workspace-id"
 }
 

--- a/examples/resources/prefect_work_pool/resource.tf
+++ b/examples/resources/prefect_work_pool/resource.tf
@@ -1,7 +1,7 @@
+# Use the default base job template by omitting the `base_job_template` argument.
 resource "prefect_work_pool" "example" {
   name         = "my-work-pool"
-  type         = "kubernetes"
-  paused       = false
+  type         = "prefect:managed"
   workspace_id = "my-workspace-id"
 }
 

--- a/internal/api/work_pools.go
+++ b/internal/api/work_pools.go
@@ -29,20 +29,20 @@ type WorkPool struct {
 
 // WorkPoolCreate is a subset of WorkPool used when creating pools.
 type WorkPoolCreate struct {
-	Name             string                 `json:"name"`
-	Description      *string                `json:"description"`
-	Type             string                 `json:"type"`
-	BaseJobTemplate  map[string]interface{} `json:"base_job_template"`
-	IsPaused         bool                   `json:"is_paused"`
-	ConcurrencyLimit *int64                 `json:"concurrency_limit"`
+	Name             string                  `json:"name"`
+	Description      *string                 `json:"description"`
+	Type             string                  `json:"type"`
+	BaseJobTemplate  *map[string]interface{} `json:"base_job_template,omitempty"`
+	IsPaused         bool                    `json:"is_paused"`
+	ConcurrencyLimit *int64                  `json:"concurrency_limit"`
 }
 
 // WorkPoolUpdate is a subset of WorkPool used when updating pools.
 type WorkPoolUpdate struct {
-	Description      *string                `json:"description"`
-	IsPaused         *bool                  `json:"is_paused"`
-	BaseJobTemplate  map[string]interface{} `json:"base_job_template"`
-	ConcurrencyLimit *int64                 `json:"concurrency_limit"`
+	Description      *string                 `json:"description"`
+	IsPaused         *bool                   `json:"is_paused"`
+	BaseJobTemplate  *map[string]interface{} `json:"base_job_template,omitempty"`
+	ConcurrencyLimit *int64                  `json:"concurrency_limit"`
 }
 
 // WorkPoolFilter defines filters when searching for work pools.

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -243,8 +243,7 @@ func (r *WorkPoolResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	copyWorkPoolToModel(pool, &plan)
-	resp.Diagnostics.Append()
+	resp.Diagnostics.Append(copyWorkPoolToModel(pool, &plan))
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->
fully resolves #429 
resolves https://linear.app/prefect/issue/PLA-1267/query-and-use-default-base-job-template-in-work-pool-that-omits

In this PR:
- if the `base_job_template` is not defined in the user's HCL, we omit appending it to the API request and do not map it to state, to avoid state conflicts

### Requirements
In cases where the practicioner doesn't want to have to think about the base_job_template, they can omit it and have the API configure the default value for us. 

Where we used to have to do something like this:
```hcl
data "prefect_worker_metadata" "d" {}

resource "prefect_work_pool" "pool" {
  name              = "my-cool-pool"
  type              = "prefect:managed"
  base_job_template = data.prefect_worker_metadata.d.base_job_configs.prefect_managed
}
```

we can allow something like this:
```hcl
resource "prefect_work_pool" "pool" {
  name              = "my-cool-pool"
  type              = "prefect:managed"
}
```

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [x] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
