### PR TITLE
fix(ci): use head.sha in terraform docs job

### DIFF
--- a/.github/workflows/build-terraform-docs.yaml
+++ b/.github/workflows/build-terraform-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install tool dependencies
         uses: jdx/mise-action@v2
       - name: Build Terraform Docs

--- a/.github/workflows/build-terraform-docs.yaml
+++ b/.github/workflows/build-terraform-docs.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install tool dependencies
         uses: jdx/mise-action@v2


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->

### Requirements
The `head.ref` value was resolving to a branch name - i think we're running into "permission" issues in #434 when a forked user opens a PR, since that branch doesn't exist in the main repo

https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/14186251486/job/39742354436

```
Run actions/checkout@v4
  with:
    ref: docs-update-troubleshooting
    repository: PrefectHQ/terraform-provider-prefect
    token: ***
    ssh-strict: true
    ssh-user: git
    persist-credentials: true
    clean: true
    sparse-checkout-cone-mode: true
    fetch-depth: 1
    fetch-tags: false
    show-progress: true
    lfs: false
    submodules: false
    set-safe-directory: true
Syncing repository: PrefectHQ/terraform-provider-prefect
Getting Git version info
Temporarily overriding HOME='/home/runner/work/_temp/0ae75819-a0c6-448d-a04d-7a09c4af6421' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /home/runner/work/terraform-provider-prefect/terraform-provider-prefect
Deleting the contents of '/home/runner/work/terraform-provider-prefect/terraform-provider-prefect'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/docs-update-troubleshooting*:refs/remotes/origin/docs-update-troubleshooting* +refs/tags/docs-update-troubleshooting*:refs/tags/docs-update-troubleshooting*
  The process '/usr/bin/git' failed with exit code 1
  Waiting 15 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/docs-update-troubleshooting*:refs/remotes/origin/docs-update-troubleshooting* +refs/tags/docs-update-troubleshooting*:refs/tags/docs-update-troubleshooting*
  The process '/usr/bin/git' failed with exit code 1
  Waiting 16 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/docs-update-troubleshooting*:refs/remotes/origin/docs-update-troubleshooting* +refs/tags/docs-update-troubleshooting*:refs/tags/docs-update-troubleshooting*
  Error: The process '/usr/bin/git' failed with exit code 1
```

#### General

- [ ] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [ ] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [ ] Relevant labels have been added
- [ ] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
