### PR TITLE
chore(go): update to 1.24.1, remove separate toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/prefecthq/terraform-provider-prefect
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	github.com/avast/retry-go/v4 v4.6.1


### PR DESCRIPTION
### Summary

We didn't intentionally set a different toolchain version, and instead that change was brought about by updatecli/dependabot PRs. Update: this isn't quite true - it was added in when running `go mod tidy`. More notes below.

This difference appears to cause cache issues in the `setup-go` GitHub Action. Rather than implement more involved workarounds, let's just align those versions.

Related to https://linear.app/prefect/issue/PLA-1223/ci-cache-restore-failures-for-go-toolchain
<!-- Add a brief description of your change here -->

## Testing

- [Before this change: `cannot open: File exists` errors](https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/14207714657/job/39808952126#step:4:81)
- [With this change: cache restored successfully](https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/14367767107/job/40284649421?pr=480#step:4:29)

## Notes

The toolchain directive was initially added here in https://github.com/PrefectHQ/terraform-provider-prefect/pull/161. From some research, it looks like this directive will be added if you're running `go mod tidy` with a different version of `go` than what is specified in `go.mod`.

I found this in a [Reddit thread](https://old.reddit.com/r/golang/comments/1dpiw0p/struggling_to_understand_the_new_toolchain/lahjenc/):

> The go directive specifies the language version, the toolchain directive specifies the toolchain version. If no toolchain version is given, the toolchain version is set to the language version by default. The toolchain directive is optional, the go directive is not (technically it is, but then it will default to 1.16). The toolchain version, if set, must be >= the language version. Setting the toolchain version to a different version than the language version is useful in rare cases. For example, if you want to compile the project with at least toolchain 1.22.0, but want the language to act as if it was still 1.21 (before the loop variable change). In most cases you do not want to set the toolchain version, because it's already implicitly set by the go directive. Go also downloads a newer toolchain if necessary when no toolchain directive is set.

In [another thread](https://old.reddit.com/r/golang/comments/1g42zc7/how_to_stop_go_from_adding_a_toolchain_line_to/lsfo3tz/):

> I fixed this by adding the env var `GOTOOLCHAIN=local` - this effectively instructs your go compiler to ignore the toolchain stanza and use the toolchain it has available to it - e.g. tied to the already installed version. 

We can use that in the future if we find that `go mod tidy` is wanting to inject the toolchain directive back in again.

## References

- https://go.dev/blog/go1.24
- https://go.dev/doc/toolchain

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
