### PR TITLE
chore(docs): mention API parity document

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@
 
 ## Supported objects
 
-We're continuously adding more Prefect Cloud object support, striving for near-parity around spring of 2025.
+The supported objects are listed in the [provider documentation](https://registry.terraform.io/providers/PrefectHQ/prefect/latest/docs).
 
-See our [Milestone for API parity](https://github.com/PrefectHQ/terraform-provider-prefect/milestone/1) for more information.
+We maintain an [API parity document](https://github.com/PrefectHQ/terraform-provider-prefect/wiki/API-Parity) to keep track of
+features available in the [Prefect API](https://app.prefect.cloud/api/docs) along with their current level of support in the Terraform provider.
+
+If you notice any missing features, see the [contributing section](#contributing) to file an issue in our bug tracker.
 
 ## Contributing
 


### PR DESCRIPTION
### Summary

We've closed all of the issues in the API parity milestone: https://github.com/PrefectHQ/terraform-provider-prefect/milestone/1

Let's remove that reference and instead point to the API parity doc.

Related to https://linear.app/prefect/issue/PLA-1265/cycle-16-catch-all

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
