### PR TITLE
chore: use customtypes.UUID for all IDs

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -133,7 +133,7 @@ resource "prefect_deployment" "deployment" {
 ### Read-Only
 
 - `created` (String) Timestamp of when the resource was created (RFC3339)
-- `id` (String) Workspace ID (UUID)
+- `id` (String) Deployment ID (UUID)
 - `updated` (String) Timestamp of when the resource was updated (RFC3339)
 
 <a id="nestedatt--concurrency_options"></a>

--- a/internal/api/account_memberships.go
+++ b/internal/api/account_memberships.go
@@ -14,7 +14,7 @@ type AccountMembershipsClient interface {
 }
 
 type AccountMembership struct {
-	ID              string     `json:"id"`
+	ID              uuid.UUID  `json:"id"`
 	ActorID         uuid.UUID  `json:"actor_id"`
 	UserID          uuid.UUID  `json:"user_id"`
 	FirstName       string     `json:"first_name"`

--- a/internal/provider/datasources/account_member.go
+++ b/internal/provider/datasources/account_member.go
@@ -21,7 +21,7 @@ type AccountMemberDataSource struct {
 }
 
 type AccountMemberDataSourceModel struct {
-	ID              types.String          `tfsdk:"id"`
+	ID              customtypes.UUIDValue `tfsdk:"id"`
 	ActorID         customtypes.UUIDValue `tfsdk:"actor_id"`
 	UserID          customtypes.UUIDValue `tfsdk:"user_id"`
 	FirstName       types.String          `tfsdk:"first_name"`
@@ -52,6 +52,7 @@ func (d *AccountMemberDataSource) Metadata(_ context.Context, req datasource.Met
 var accountMemberAttributesBase = map[string]schema.Attribute{
 	"id": schema.StringAttribute{
 		Computed:    true,
+		CustomType:  customtypes.UUIDType{},
 		Description: "Account Member ID (UUID)",
 	},
 	"actor_id": schema.StringAttribute{
@@ -174,7 +175,7 @@ func (d *AccountMemberDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	fetchedAccountMember := accountMembers[0]
 
-	config.ID = types.StringValue(fetchedAccountMember.ID)
+	config.ID = customtypes.NewUUIDValue(fetchedAccountMember.ID)
 	config.ActorID = customtypes.NewUUIDValue(fetchedAccountMember.ActorID)
 	config.UserID = customtypes.NewUUIDValue(fetchedAccountMember.UserID)
 	config.FirstName = types.StringValue(fetchedAccountMember.FirstName)

--- a/internal/provider/datasources/account_members.go
+++ b/internal/provider/datasources/account_members.go
@@ -126,7 +126,7 @@ func (d *AccountMembersDataSource) Read(ctx context.Context, req datasource.Read
 	for _, accountMember := range accountMembers {
 		attributeValues := map[string]attr.Value{
 
-			"id":                types.StringValue(accountMember.ID),
+			"id":                customtypes.NewUUIDValue(accountMember.ID),
 			"actor_id":          customtypes.NewUUIDValue(accountMember.ActorID),
 			"user_id":           customtypes.NewUUIDValue(accountMember.UserID),
 			"first_name":        types.StringValue(accountMember.FirstName),

--- a/internal/provider/datasources/deployment.go
+++ b/internal/provider/datasources/deployment.go
@@ -66,6 +66,7 @@ For more information, see [deploy overview](https://docs.prefect.io/v3/deploy/in
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Deployment ID (UUID)",
 				Optional:    true,
 			},

--- a/internal/provider/datasources/global_concurrency_limit.go
+++ b/internal/provider/datasources/global_concurrency_limit.go
@@ -67,6 +67,7 @@ For more information, see [apply global concurrency and rate limits](https://doc
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Global Concurrency Limit ID (UUID)",
 				Optional:    true,
 			},
@@ -175,7 +176,7 @@ func (d *globalConcurrencyLimitDataSource) Read(ctx context.Context, req datasou
 		return
 	}
 
-	model.ID = types.StringValue(limit.ID.String())
+	model.ID = customtypes.NewUUIDValue(limit.ID)
 	model.Created = customtypes.NewTimestampPointerValue(limit.Created)
 	model.Updated = customtypes.NewTimestampPointerValue(limit.Updated)
 	model.AccountID = customtypes.NewUUIDValue(limit.AccountID)

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -85,10 +85,8 @@ func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 		Version: 0,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
-				// We cannot use a CustomType due to a conflict with PlanModifiers; see
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/763
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/754
+				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Account ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -161,7 +159,7 @@ func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 // copyAccountToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
 func copyAccountToModel(_ context.Context, account *api.Account, tfModel *AccountResourceModel) diag.Diagnostics {
-	tfModel.ID = types.StringValue(account.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(account.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(account.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(account.Updated)
 

--- a/internal/provider/resources/account_member.go
+++ b/internal/provider/resources/account_member.go
@@ -30,7 +30,7 @@ type AccountMemberResource struct {
 // AccountMemberResourceModel defines the Terraform resource model.
 type AccountMemberResourceModel struct {
 	// This has the same fields as the AccountMemberDataSourceModel.
-	ID              types.String          `tfsdk:"id"`
+	ID              customtypes.UUIDValue `tfsdk:"id"`
 	ActorID         customtypes.UUIDValue `tfsdk:"actor_id"`
 	UserID          customtypes.UUIDValue `tfsdk:"user_id"`
 	FirstName       types.String          `tfsdk:"first_name"`
@@ -87,6 +87,7 @@ func (r *AccountMemberResource) Schema(_ context.Context, _ resource.SchemaReque
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Account Member ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -141,7 +142,7 @@ func (r *AccountMemberResource) Schema(_ context.Context, _ resource.SchemaReque
 }
 
 func copyAccountMemberToModel(member *api.AccountMembership, tfModel *AccountMemberResourceModel) diag.Diagnostics {
-	tfModel.ID = types.StringValue(member.ID)
+	tfModel.ID = customtypes.NewUUIDValue(member.ID)
 	tfModel.ActorID = customtypes.NewUUIDValue(member.ActorID)
 	tfModel.UserID = customtypes.NewUUIDValue(member.UserID)
 	tfModel.FirstName = types.StringValue(member.FirstName)

--- a/internal/provider/resources/automation_resource.go
+++ b/internal/provider/resources/automation_resource.go
@@ -280,7 +280,7 @@ func mapAutomationAPIToTerraform(ctx context.Context, apiAutomation *api.Automat
 	var diags diag.Diagnostics
 
 	// Map base attributes
-	tfModel.ID = types.StringValue(apiAutomation.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(apiAutomation.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(apiAutomation.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(apiAutomation.Updated)
 	tfModel.Name = types.StringValue(apiAutomation.Name)

--- a/internal/provider/resources/automation_schema.go
+++ b/internal/provider/resources/automation_schema.go
@@ -24,10 +24,8 @@ import (
 func AutomationSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"id": schema.StringAttribute{
-			Computed: true,
-			// We cannot use a CustomType due to a conflict with PlanModifiers; see
-			// https://github.com/hashicorp/terraform-plugin-framework/issues/763
-			// https://github.com/hashicorp/terraform-plugin-framework/issues/754
+			Computed:    true,
+			CustomType:  customtypes.UUIDType{},
 			Description: "Automation ID (UUID)",
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),

--- a/internal/provider/resources/base_model.go
+++ b/internal/provider/resources/base_model.go
@@ -1,14 +1,13 @@
 package resources
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
 )
 
 // BaseModel is embedded in all other types and defines fields
 // common to all Prefect data models.
 type BaseModel struct {
-	ID      types.String               `tfsdk:"id"`
+	ID      customtypes.UUIDValue      `tfsdk:"id"`
 	Created customtypes.TimestampValue `tfsdk:"created"`
 	Updated customtypes.TimestampValue `tfsdk:"updated"`
 }

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -83,6 +83,7 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Block ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -199,7 +200,7 @@ func (r *BlockResource) getLatestBlockSchema(ctx context.Context, plan BlockReso
 // copyBlockToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
 func copyBlockToModel(block *api.BlockDocument, tfModel *BlockResourceModel) diag.Diagnostics {
-	tfModel.ID = types.StringValue(block.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(block.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(block.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(block.Updated)
 	tfModel.Name = types.StringValue(block.Name)

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -170,11 +170,9 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 		Version: 0,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
-				// We cannot use a CustomType due to a conflict with PlanModifiers; see
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/763
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/754
-				Description: "Workspace ID (UUID)",
+				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "Deployment ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -555,7 +553,7 @@ func mapPullStepsAPIToTerraform(pullSteps []api.PullStep) ([]PullStepModel, diag
 // CopyDeploymentToModel copies an api.Deployment to a DeploymentResourceModel.
 // The function is exported for reuse in the Deployment datasource.
 func CopyDeploymentToModel(ctx context.Context, deployment *api.Deployment, model *DeploymentResourceModel) diag.Diagnostics {
-	model.ID = types.StringValue(deployment.ID.String())
+	model.ID = customtypes.NewUUIDValue(deployment.ID)
 	model.Created = customtypes.NewTimestampPointerValue(deployment.Created)
 	model.Updated = customtypes.NewTimestampPointerValue(deployment.Updated)
 

--- a/internal/provider/resources/flow.go
+++ b/internal/provider/resources/flow.go
@@ -88,10 +88,8 @@ func (r *FlowResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 		Version: 0,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
-				// We cannot use a CustomType due to a conflict with PlanModifiers; see
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/763
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/754
+				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Flow ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -135,7 +133,7 @@ func (r *FlowResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 
 // copyFlowToModel copies an api.Flow to a FlowResourceModel.
 func copyFlowToModel(ctx context.Context, flow *api.Flow, model *FlowResourceModel) diag.Diagnostics {
-	model.ID = types.StringValue(flow.ID.String())
+	model.ID = customtypes.NewUUIDValue(flow.ID)
 	model.Created = customtypes.NewTimestampPointerValue(flow.Created)
 	model.Updated = customtypes.NewTimestampPointerValue(flow.Updated)
 	model.Name = types.StringValue(flow.Name)

--- a/internal/provider/resources/global_concurrency_limit.go
+++ b/internal/provider/resources/global_concurrency_limit.go
@@ -84,6 +84,7 @@ func (r *GlobalConcurrencyLimitResource) Schema(_ context.Context, _ resource.Sc
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Global concurrency limit ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -189,7 +190,7 @@ func (r *GlobalConcurrencyLimitResource) Create(ctx context.Context, req resourc
 }
 
 func copyGlobalConcurrencyLimitToModel(globalConcurrencyLimit *api.GlobalConcurrencyLimit, model *GlobalConcurrencyLimitResourceModel) diag.Diagnostics {
-	model.ID = types.StringValue(globalConcurrencyLimit.ID.String())
+	model.ID = customtypes.NewUUIDValue(globalConcurrencyLimit.ID)
 	model.Created = customtypes.NewTimestampValue(*globalConcurrencyLimit.Created)
 	model.Updated = customtypes.NewTimestampValue(*globalConcurrencyLimit.Updated)
 	model.Name = types.StringValue(globalConcurrencyLimit.Name)

--- a/internal/provider/resources/service_account.go
+++ b/internal/provider/resources/service_account.go
@@ -105,6 +105,7 @@ func (r *ServiceAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Service account ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -194,7 +195,7 @@ func (r *ServiceAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 func copyServiceAccountToModel(serviceAccount *api.ServiceAccount, tfModel *ServiceAccountResourceModel) {
 	// NOTE: the API Key is attached to the resource model outside of this helper,
 	// as it is only returned on Create/Update operations.
-	tfModel.ID = types.StringValue(serviceAccount.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(serviceAccount.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(serviceAccount.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(serviceAccount.Updated)
 

--- a/internal/provider/resources/task_run_concurrency_limit.go
+++ b/internal/provider/resources/task_run_concurrency_limit.go
@@ -75,6 +75,7 @@ func (r *TaskRunConcurrencyLimitResource) Schema(_ context.Context, _ resource.S
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Task run concurrency limit ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -161,7 +162,7 @@ func (r *TaskRunConcurrencyLimitResource) Create(ctx context.Context, req resour
 }
 
 func copyTaskRunConcurrencyLimitToModel(concurrencyLimit *api.TaskRunConcurrencyLimit, model *TaskRunConcurrencyLimitResourceModel) diag.Diagnostics {
-	model.ID = types.StringValue(concurrencyLimit.ID.String())
+	model.ID = customtypes.NewUUIDValue(concurrencyLimit.ID)
 	model.Created = customtypes.NewTimestampValue(*concurrencyLimit.Created)
 	model.Updated = customtypes.NewTimestampValue(*concurrencyLimit.Updated)
 	model.Tag = types.StringValue(concurrencyLimit.Tag)

--- a/internal/provider/resources/team.go
+++ b/internal/provider/resources/team.go
@@ -78,6 +78,7 @@ func (r *TeamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Team ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -258,7 +259,7 @@ func (r *TeamResource) ImportState(ctx context.Context, req resource.ImportState
 // copyTeamToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
 func copyTeamToModel(team *api.Team, tfModel *TeamResourceModel) diag.Diagnostics {
-	tfModel.ID = types.StringValue(team.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(team.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(team.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(team.Updated)
 	tfModel.Name = types.StringValue(team.Name)

--- a/internal/provider/resources/team_access.go
+++ b/internal/provider/resources/team_access.go
@@ -71,8 +71,8 @@ func (r *TeamAccessResource) Schema(_ context.Context, _ resource.SchemaRequest,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
-				Description: "Team Access ID",
 				CustomType:  customtypes.UUIDType{},
+				Description: "Team Access ID",
 			},
 			"team_id": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resources/user.go
+++ b/internal/provider/resources/user.go
@@ -77,6 +77,7 @@ func (r *UserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "User ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),

--- a/internal/provider/resources/user_api_key.go
+++ b/internal/provider/resources/user_api_key.go
@@ -24,7 +24,7 @@ type UserAPIKeyResource struct {
 
 // UserAPIKeyResourceModel defines the Terraform resource model.
 type UserAPIKeyResourceModel struct {
-	ID      types.String               `tfsdk:"id"`
+	ID      customtypes.UUIDValue      `tfsdk:"id"`
 	Created customtypes.TimestampValue `tfsdk:"created"`
 
 	UserID     types.String               `tfsdk:"user_id"`
@@ -76,6 +76,7 @@ func (r *UserAPIKeyResource) Schema(_ context.Context, _ resource.SchemaRequest,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "User API Key ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -131,7 +132,7 @@ func (r *UserAPIKeyResource) Schema(_ context.Context, _ resource.SchemaRequest,
 // Note: we do not copy the Key field to the model, as it is only returned on Create.
 // For all other lifecycle methods, we will persist the existing State value.
 func copyUserAPIKeyToModel(apiKey *api.UserAPIKey, model *UserAPIKeyResourceModel) {
-	model.ID = types.StringValue(apiKey.ID.String())
+	model.ID = customtypes.NewUUIDValue(apiKey.ID)
 	model.Created = customtypes.NewTimestampValue(apiKey.Created)
 	model.Name = types.StringValue(apiKey.Name)
 	model.Expiration = customtypes.NewTimestampPointerValue(apiKey.Expiration)

--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -69,10 +69,8 @@ var defaultEmptyTagList, _ = basetypes.NewListValue(types.StringType, []attr.Val
 
 var VariableResourceSchemaAttributes = map[string]schema.Attribute{
 	"id": schema.StringAttribute{
-		Computed: true,
-		// We cannot use a CustomType due to a conflict with PlanModifiers; see
-		// https://github.com/hashicorp/terraform-plugin-framework/issues/763
-		// https://github.com/hashicorp/terraform-plugin-framework/issues/754
+		Computed:    true,
+		CustomType:  customtypes.UUIDType{},
 		Description: "Variable ID (UUID)",
 		PlanModifiers: []planmodifier.String{
 			stringplanmodifier.UseStateForUnknown(),
@@ -225,7 +223,7 @@ func (r *VariableResource) UpgradeState(_ context.Context) map[int64]resource.St
 // copyVariableToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
 func copyVariableToModel(ctx context.Context, variable *api.Variable, tfModel *VariableResourceModelV1) diag.Diagnostics {
-	tfModel.ID = types.StringValue(variable.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(variable.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(variable.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(variable.Updated)
 

--- a/internal/provider/resources/webhooks.go
+++ b/internal/provider/resources/webhooks.go
@@ -28,7 +28,7 @@ type WebhookResource struct {
 }
 
 type WebhookResourceModel struct {
-	ID               types.String               `tfsdk:"id"`
+	ID               customtypes.UUIDValue      `tfsdk:"id"`
 	Created          customtypes.TimestampValue `tfsdk:"created"`
 	Updated          customtypes.TimestampValue `tfsdk:"updated"`
 	Name             types.String               `tfsdk:"name"`
@@ -78,6 +78,7 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Webhook ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -150,7 +151,7 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 
 // copyWebhookResponseToModel maps an API response to a model that is saved in Terraform state.
 func copyWebhookResponseToModel(webhook *api.Webhook, tfModel *WebhookResourceModel, endpointHost string) {
-	tfModel.ID = types.StringValue(webhook.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(webhook.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(webhook.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(webhook.Updated)
 	tfModel.Name = types.StringValue(webhook.Name)

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -89,10 +89,8 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 		Version: 0,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
-				// We cannot use a CustomType due to a conflict with PlanModifiers; see
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/763
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/754
+				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Work pool ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -179,7 +177,7 @@ func (r *WorkPoolResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 //
 //nolint:ireturn // required to return Diagnostics
 func copyWorkPoolToModel(pool *api.WorkPool, tfModel *WorkPoolResourceModel) diag.Diagnostic {
-	tfModel.ID = types.StringValue(pool.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(pool.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(pool.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(pool.Updated)
 

--- a/internal/provider/resources/work_queue.go
+++ b/internal/provider/resources/work_queue.go
@@ -89,6 +89,7 @@ func (r *WorkQueueResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Work queue ID (UUID)",
 			},
 			"created": schema.StringAttribute{
@@ -149,7 +150,7 @@ func (r *WorkQueueResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 
 // copyWorkQueueToModel maps an API response to a model that is saved in Terraform state.
 func copyWorkQueueToModel(queue *api.WorkQueue, tfModel *WorkQueueResourceModel) {
-	tfModel.ID = types.StringValue(queue.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(queue.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(queue.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(queue.Updated)
 	tfModel.ConcurrencyLimit = types.Int64PointerValue(queue.ConcurrencyLimit)

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -80,10 +80,8 @@ func (r *WorkspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 		Version: 0,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Computed: true,
-				// We cannot use a CustomType due to a conflict with PlanModifiers; see
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/763
-				// https://github.com/hashicorp/terraform-plugin-framework/issues/754
+				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Workspace ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -127,7 +125,7 @@ func (r *WorkspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 // copyWorkspaceModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
 func copyWorkspaceToModel(_ context.Context, workspace *api.Workspace, tfModel *WorkspaceResourceModel) diag.Diagnostics {
-	tfModel.ID = types.StringValue(workspace.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(workspace.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(workspace.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(workspace.Updated)
 

--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -24,7 +24,7 @@ type WorkspaceAccessResource struct {
 }
 
 type WorkspaceAccessResourceModel struct {
-	ID              types.String          `tfsdk:"id"`
+	ID              customtypes.UUIDValue `tfsdk:"id"`
 	AccessorType    types.String          `tfsdk:"accessor_type"`
 	AccessorID      customtypes.UUIDValue `tfsdk:"accessor_id"`
 	WorkspaceRoleID customtypes.UUIDValue `tfsdk:"workspace_role_id"`
@@ -79,6 +79,7 @@ func (r *WorkspaceAccessResource) Schema(_ context.Context, _ resource.SchemaReq
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Workspace Access ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -121,7 +122,7 @@ func copyWorkspaceAccessToModel(access *api.WorkspaceAccess, tfModel *WorkspaceA
 	// NOTE: api.WorkspaceAccess represents a combined model for all accessor types,
 	// meaning accessor-specific attributes like BotID and UserID will be conditionally nil
 	// depending on the accessor type.
-	tfModel.ID = types.StringValue(access.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(access.ID)
 	tfModel.WorkspaceRoleID = customtypes.NewUUIDValue(access.WorkspaceRoleID)
 	tfModel.WorkspaceID = customtypes.NewUUIDValue(access.WorkspaceID)
 

--- a/internal/provider/resources/workspace_role.go
+++ b/internal/provider/resources/workspace_role.go
@@ -84,6 +84,7 @@ func (r *WorkspaceRoleResource) Schema(_ context.Context, _ resource.SchemaReque
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
 				Description: "Workspace Role ID (UUID)",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -134,7 +135,7 @@ func (r *WorkspaceRoleResource) Schema(_ context.Context, _ resource.SchemaReque
 // copyWorkspaceRoleToModel maps an API response to a model that is saved in Terraform state.
 // A model can be a Terraform Plan, State, or Config object.
 func copyWorkspaceRoleToModel(_ context.Context, role *api.WorkspaceRole, tfModel *WorkspaceRoleResourceModel) diag.Diagnostics {
-	tfModel.ID = types.StringValue(role.ID.String())
+	tfModel.ID = customtypes.NewUUIDValue(role.ID)
 	tfModel.Created = customtypes.NewTimestampPointerValue(role.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(role.Updated)
 


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->

Follow-up to https://github.com/PrefectHQ/terraform-provider-prefect/pull/320

Makes sure all IDs use customtypes.UUID instead of string. This was previously not doable because of a bug when using custom types with plan modifiers:
https://github.com/hashicorp/terraform-plugin-framework/issues/754

This has been fixed as of terraform-plugin-framework 1.3.1.

Closes https://linear.app/prefect/issue/PLA-825/terraform-provider-make-the-id-type-consistent

### To do

- [x] Test to confirm no conversion logic is required

### Testing

I tested going from the latest version of the provider (2.24.0) to the version from this branch to confirm we don't need any state upgrade logic:

1. Apply a configuration with the latest release of the provider using a flow and deployment resource (both are resources modified by this PR)
2. Modify `.terraformrc` to point to a locally-compiled version of the provider from this branch
3. Apply the configuration again
4. Confirm no change: `No changes. Your infrastructure matches the configuration.`

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
