### PR TITLE
fix: remove unknown checks, terraform deps graph covers providers as well

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -96,48 +96,6 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 		return
 	}
 
-	// Ensure that all configuration values passed in to provider are known
-	// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/terraform-concepts#unknown-values
-	if config.Endpoint.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("endpoint"),
-			"Unknown Prefect API Endpoint",
-			"The Prefect API Endpoint is not known at configuration time. "+
-				"Potential resolutions: target apply the source of the value first, set the value statically in the configuration, or set the PREFECT_API_URL environment variable.",
-		)
-	}
-
-	if config.APIKey.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("api_key"),
-			"Unknown Prefect API Key",
-			"The Prefect API Key is not known at configuration time. "+
-				"Potential resolutions: target apply the source of the value first, set the value statically in the configuration, set the PREFECT_API_KEY environment variable, or remove the value.",
-		)
-	}
-
-	if config.AccountID.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("account_id"),
-			"Unknown Prefect Account ID",
-			"The Prefect Account ID is not known at configuration time. "+
-				"Potential resolutions: target apply the source of the value first, set the value statically in the configuration, or remove the value.",
-		)
-	}
-
-	if config.WorkspaceID.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("workspace_id"),
-			"Unknown Prefect Workspace ID",
-			"The Prefect Workspace ID is not known at configuration time. "+
-				"Potential resolutions: target apply the source of the value first, set the value statically in the configuration, or remove the value.",
-		)
-	}
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	// Extract endpoint from configuration or environment variable.
 	var endpoint string
 	if !config.Endpoint.IsNull() {


### PR DESCRIPTION
### Summary

Remove unknown checks in the configure phase, this prevents the use of data/epehemeral source as configuration attributes.

```terraform
provider "prefect" {
  endpoint = "https://${var.domain}/api"
  api_key  = ephemeral.google_service_account_id_token.prefect_iap.id_token
}
```

### Requirements

#### General

- [ ] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`