### PR TITLE
chore(CI): add more acceptance test sweepers

### DIFF
--- a/internal/client/service_accounts.go
+++ b/internal/client/service_accounts.go
@@ -62,7 +62,10 @@ func (sa *ServiceAccountsClient) Create(ctx context.Context, request api.Service
 
 func (sa *ServiceAccountsClient) List(ctx context.Context, names []string) ([]*api.ServiceAccount, error) {
 	filter := api.ServiceAccountFilter{}
-	filter.ServiceAccounts.Name.Any = names
+
+	if len(names) != 0 {
+		filter.ServiceAccounts.Name.Any = names
+	}
 
 	cfg := requestConfig{
 		method:       http.MethodPost,

--- a/internal/client/workspace_roles.go
+++ b/internal/client/workspace_roles.go
@@ -97,7 +97,10 @@ func (c *WorkspaceRolesClient) Delete(ctx context.Context, id uuid.UUID) error {
 // List returns a list of workspace roles, based on the provided filter.
 func (c *WorkspaceRolesClient) List(ctx context.Context, roleNames []string) ([]*api.WorkspaceRole, error) {
 	filterQuery := api.WorkspaceRoleFilter{}
-	filterQuery.WorkspaceRoles.Name.Any = roleNames
+
+	if len(roleNames) != 0 {
+		filterQuery.WorkspaceRoles.Name.Any = roleNames
+	}
 
 	cfg := requestConfig{
 		method:       http.MethodPost,

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -10,6 +10,7 @@ import (
 // TestMain adds sweeper functionality to the "go test" command.
 func TestMain(m *testing.M) {
 	sweep.AddWorkspaceSweeper()
+	sweep.AddServiceAccountSweeper()
 
 	resource.TestMain(m)
 }

--- a/internal/sweep/sweep_test.go
+++ b/internal/sweep/sweep_test.go
@@ -11,6 +11,7 @@ import (
 func TestMain(m *testing.M) {
 	sweep.AddWorkspaceSweeper()
 	sweep.AddServiceAccountSweeper()
+	sweep.AddWorkspaceRoleSweeper()
 
 	resource.TestMain(m)
 }


### PR DESCRIPTION
### Summary

I noticed some lingering resources from acceptance tests, so I added a few more sweepers for those. It may be worth holding off on merging this until we see that more of these resources pile up - they could have been lingering from testing or prior to other fixes being merged.

Related to https://linear.app/prefect/issue/PLA-1352/cycle-17-catch-all

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
