### PR TITLE
fix(deployments): deprecate `manifest_path`

### DIFF
--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -70,7 +70,7 @@ data "prefect_deployment" "existing_by_id_string" {
 - `entrypoint` (String) The path to the entrypoint for the workflow, relative to the path.
 - `flow_id` (String) Flow ID (UUID) to associate deployment to
 - `job_variables` (String) Overrides for the flow's infrastructure configuration.
-- `manifest_path` (String) The path to the flow's manifest file, relative to the chosen storage.
+- `manifest_path` (String, Deprecated) The path to the flow's manifest file, relative to the chosen storage.
 - `parameter_openapi_schema` (String) The parameter schema of the flow, including defaults.
 - `parameters` (String) Parameters for flow runs scheduled by the deployment.
 - `path` (String) The path to the working directory for the workflow, relative to remote storage or an absolute path.

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -52,7 +52,6 @@ resource "prefect_deployment" "deployment" {
   job_variables = jsonencode({
     "env" : { "some-key" : "some-value" }
   })
-  manifest_path = "./bar/foo"
   parameters = jsonencode({
     "some-parameter" : "some-value",
     "some-parameter2" : "some-value2"
@@ -117,7 +116,7 @@ resource "prefect_deployment" "deployment" {
 - `enforce_parameter_schema` (Boolean) Whether or not the deployment should enforce the parameter schema.
 - `entrypoint` (String) The path to the entrypoint for the workflow, relative to the path.
 - `job_variables` (String) Overrides for the flow's infrastructure configuration.
-- `manifest_path` (String) The path to the flow's manifest file, relative to the chosen storage.
+- `manifest_path` (String, Deprecated) The path to the flow's manifest file, relative to the chosen storage.
 - `parameter_openapi_schema` (String) The parameter schema of the flow, including defaults.
 - `parameters` (String) Parameters for flow runs scheduled by the deployment.
 - `path` (String) The path to the working directory for the workflow, relative to remote storage or an absolute path.

--- a/examples/resources/prefect_deployment/resource.tf
+++ b/examples/resources/prefect_deployment/resource.tf
@@ -32,7 +32,6 @@ resource "prefect_deployment" "deployment" {
   job_variables = jsonencode({
     "env" : { "some-key" : "some-value" }
   })
-  manifest_path = "./bar/foo"
   parameters = jsonencode({
     "some-parameter" : "some-value",
     "some-parameter2" : "some-value2"

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -29,7 +29,6 @@ type Deployment struct {
 	FlowID                 uuid.UUID                      `json:"flow_id"`
 	GlobalConcurrencyLimit *CurrentGlobalConcurrencyLimit `json:"global_concurrency_limit"`
 	JobVariables           map[string]interface{}         `json:"job_variables"`
-	ManifestPath           string                         `json:"manifest_path"`
 	Name                   string                         `json:"name"`
 	ParameterOpenAPISchema map[string]interface{}         `json:"parameter_openapi_schema"`
 	Parameters             map[string]interface{}         `json:"parameters"`
@@ -52,7 +51,6 @@ type DeploymentCreate struct {
 	Entrypoint             string                 `json:"entrypoint,omitempty"`
 	FlowID                 uuid.UUID              `json:"flow_id"` // required
 	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
-	ManifestPath           string                 `json:"manifest_path,omitempty"`
 	Name                   string                 `json:"name"` // required
 	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
 	Parameters             map[string]interface{} `json:"parameters,omitempty"`
@@ -74,7 +72,6 @@ type DeploymentUpdate struct {
 	EnforceParameterSchema bool                   `json:"enforce_parameter_schema,omitempty"`
 	Entrypoint             string                 `json:"entrypoint,omitempty"`
 	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
-	ManifestPath           string                 `json:"manifest_path,omitempty"`
 	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
 	Parameters             map[string]interface{} `json:"parameters,omitempty"`
 	Path                   string                 `json:"path,omitempty"`

--- a/internal/provider/datasources/deployment.go
+++ b/internal/provider/datasources/deployment.go
@@ -123,8 +123,9 @@ For more information, see [deploy overview](https://docs.prefect.io/v3/deploy/in
 				Description: "ID of the associated storage document (UUID)",
 			},
 			"manifest_path": schema.StringAttribute{
-				Computed:    true,
-				Description: "The path to the flow's manifest file, relative to the chosen storage.",
+				Computed:           true,
+				DeprecationMessage: "Remove this attribute's configuration as it no longer is used and the attribute will be removed in the next major version of the provider.",
+				Description:        "The path to the flow's manifest file, relative to the chosen storage.",
 			},
 			"job_variables": schema.StringAttribute{
 				Computed:    true,
@@ -362,7 +363,6 @@ func copyDeploymentToModel(ctx context.Context, deployment *api.Deployment, mode
 		Entrypoint:             model.Entrypoint,
 		FlowID:                 model.FlowID,
 		JobVariables:           model.JobVariables,
-		ManifestPath:           model.ManifestPath,
 		Name:                   model.Name,
 		ParameterOpenAPISchema: model.ParameterOpenAPISchema,
 		Parameters:             model.Parameters,

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -54,7 +54,6 @@ type DeploymentResourceModel struct {
 	Entrypoint             types.String          `tfsdk:"entrypoint"`
 	FlowID                 customtypes.UUIDValue `tfsdk:"flow_id"`
 	JobVariables           jsontypes.Normalized  `tfsdk:"job_variables"`
-	ManifestPath           types.String          `tfsdk:"manifest_path"`
 	Name                   types.String          `tfsdk:"name"`
 	ParameterOpenAPISchema jsontypes.Normalized  `tfsdk:"parameter_openapi_schema"`
 	Parameters             jsontypes.Normalized  `tfsdk:"parameters"`
@@ -228,9 +227,10 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Description: "ID of the associated storage document (UUID)",
 			},
 			"manifest_path": schema.StringAttribute{
-				Description: "The path to the flow's manifest file, relative to the chosen storage.",
-				Optional:    true,
-				Computed:    true,
+				Description:        "The path to the flow's manifest file, relative to the chosen storage.",
+				DeprecationMessage: "Remove this attribute's configuration as it no longer is used and the attribute will be removed in the next major version of the provider.",
+				Optional:           true,
+				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -561,7 +561,6 @@ func CopyDeploymentToModel(ctx context.Context, deployment *api.Deployment, mode
 	model.EnforceParameterSchema = types.BoolValue(deployment.EnforceParameterSchema)
 	model.Entrypoint = types.StringValue(deployment.Entrypoint)
 	model.FlowID = customtypes.NewUUIDValue(deployment.FlowID)
-	model.ManifestPath = types.StringValue(deployment.ManifestPath)
 	model.Name = types.StringValue(deployment.Name)
 	model.Path = types.StringValue(deployment.Path)
 	model.Paused = types.BoolValue(deployment.Paused)
@@ -678,7 +677,6 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 		Entrypoint:             plan.Entrypoint.ValueString(),
 		FlowID:                 plan.FlowID.ValueUUID(),
 		JobVariables:           jobVariables,
-		ManifestPath:           plan.ManifestPath.ValueString(),
 		Name:                   plan.Name.ValueString(),
 		Parameters:             parameters,
 		Path:                   plan.Path.ValueString(),
@@ -836,7 +834,6 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		EnforceParameterSchema: model.EnforceParameterSchema.ValueBool(),
 		Entrypoint:             model.Entrypoint.ValueString(),
 		JobVariables:           jobVariables,
-		ManifestPath:           model.ManifestPath.ValueString(),
 		ParameterOpenAPISchema: parameterOpenAPISchema,
 		Parameters:             parameters,
 		Path:                   model.Path.ValueString(),

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -54,6 +54,7 @@ type DeploymentResourceModel struct {
 	Entrypoint             types.String          `tfsdk:"entrypoint"`
 	FlowID                 customtypes.UUIDValue `tfsdk:"flow_id"`
 	JobVariables           jsontypes.Normalized  `tfsdk:"job_variables"`
+	ManifestPath           types.String          `tfsdk:"manifest_path"`
 	Name                   types.String          `tfsdk:"name"`
 	ParameterOpenAPISchema jsontypes.Normalized  `tfsdk:"parameter_openapi_schema"`
 	Parameters             jsontypes.Normalized  `tfsdk:"parameters"`
@@ -230,7 +231,6 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Description:        "The path to the flow's manifest file, relative to the chosen storage.",
 				DeprecationMessage: "Remove this attribute's configuration as it no longer is used and the attribute will be removed in the next major version of the provider.",
 				Optional:           true,
-				Computed:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -27,7 +27,6 @@ type deploymentConfig struct {
 	EnforceParameterSchema bool
 	Entrypoint             string
 	JobVariables           string
-	ManifestPath           string
 	Parameters             string
 	Path                   string
 	Paused                 bool
@@ -86,7 +85,6 @@ resource "prefect_deployment" "{{.DeploymentName}}" {
 	job_variables = jsonencode(
 		{{.JobVariables}}
 	)
-	manifest_path = "{{.ManifestPath}}"
 	parameters = jsonencode({
 		"some-parameter": "{{.Parameters}}"
 	})
@@ -209,7 +207,6 @@ func TestAccResource_deployment(t *testing.T) {
 		EnforceParameterSchema: false,
 		Entrypoint:             "hello_world.py:hello_world",
 		JobVariables:           `{"env":{"some-key":"some-value"}}`,
-		ManifestPath:           "some-manifest-path",
 		Parameters:             "some-value1",
 		Path:                   "some-path",
 		Paused:                 false,
@@ -242,7 +239,6 @@ func TestAccResource_deployment(t *testing.T) {
 		Description:            "My deployment description v2",
 		Entrypoint:             "hello_world.py:hello_world2",
 		JobVariables:           `{"env":{"some-key":"some-value2"}}`,
-		ManifestPath:           "some-manifest-path2",
 		ParameterOpenAPISchema: parameterOpenAPISchemaUpdate,
 		Parameters:             "some-value2",
 		Path:                   "some-path2",
@@ -323,7 +319,6 @@ func TestAccResource_deployment(t *testing.T) {
 					testutils.ExpectKnownValueBool(cfgCreate.DeploymentResourceName, "enforce_parameter_schema", cfgCreate.EnforceParameterSchema),
 					testutils.ExpectKnownValue(cfgCreate.DeploymentResourceName, "entrypoint", cfgCreate.Entrypoint),
 					testutils.ExpectKnownValue(cfgCreate.DeploymentResourceName, "job_variables", cfgCreate.JobVariables),
-					testutils.ExpectKnownValue(cfgCreate.DeploymentResourceName, "manifest_path", cfgCreate.ManifestPath),
 					testutils.ExpectKnownValue(cfgCreate.DeploymentResourceName, "parameters", `{"some-parameter":"some-value1"}`),
 					testutils.ExpectKnownValue(cfgCreate.DeploymentResourceName, "parameter_openapi_schema", expectedParameterOpenAPISchema),
 					testutils.ExpectKnownValue(cfgCreate.DeploymentResourceName, "path", cfgCreate.Path),
@@ -354,7 +349,6 @@ func TestAccResource_deployment(t *testing.T) {
 					testutils.ExpectKnownValueBool(cfgUpdate.DeploymentResourceName, "enforce_parameter_schema", cfgUpdate.EnforceParameterSchema),
 					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "entrypoint", cfgUpdate.Entrypoint),
 					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "job_variables", cfgUpdate.JobVariables),
-					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "manifest_path", cfgUpdate.ManifestPath),
 					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "parameters", `{"some-parameter":"some-value2"}`),
 					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "parameter_openapi_schema", expectedParameterOpenAPISchemaUpdate),
 					testutils.ExpectKnownValue(cfgUpdate.DeploymentResourceName, "path", cfgUpdate.Path),


### PR DESCRIPTION
### Summary

Deprecates `manifest_path`. This is an old, unused field that Cloud only has for backward compatibility for older clients but isn't required for newer clients. Validated this with Chris W.

Related to https://linear.app/prefect/issue/PLA-1352/cycle-17-catch-all

Found while working on https://github.com/PrefectHQ/terraform-provider-prefect/pull/488.

Will remove in https://github.com/PrefectHQ/terraform-provider-prefect/issues/493.

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
