### PR TITLE
fix(deployments): default `enforce_parameter_schema` to `true`

### DIFF
--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -219,7 +219,10 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Description: "Whether or not the deployment should enforce the parameter schema.",
 				Optional:    true,
 				Computed:    true,
-				Default:     booldefault.StaticBool(false),
+				// The Prefect Cloud API defaults this value to `false`, but this is only for backward
+				// compatibility. We intentionally set this to `true` to align with the default value
+				// used in Prefect OSS.
+				Default: booldefault.StaticBool(true),
 			},
 			"storage_document_id": schema.StringAttribute{
 				Optional:    true,


### PR DESCRIPTION
### Summary

The Prefect Cloud API defaults this value to `false`, but this is only for backward compatibility. We intentionally set this to `true` to align with the default value used in Prefect OSS.

Validated with Chris W.

Found while testing
https://github.com/PrefectHQ/terraform-provider-prefect/pull/488.

Related to https://linear.app/prefect/issue/PLA-1352/cycle-17-catch-all

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
