### PR TITLE
fix(deployments): deprecate `max_active_runs` field

### DIFF
--- a/docs/resources/deployment_schedule.md
+++ b/docs/resources/deployment_schedule.md
@@ -43,10 +43,9 @@ resource "prefect_deployment_schedule" "test_interval" {
   workspace_id  = data.prefect_workspace.test.id
   deployment_id = prefect_deployment.test.id
 
-  active          = true
-  catchup         = false
-  max_active_runs = 10
-  timezone        = "America/New_York"
+  active   = true
+  catchup  = false
+  timezone = "America/New_York"
 
   # Interval-specific fields
   interval    = 30
@@ -57,10 +56,9 @@ resource "prefect_deployment_schedule" "test_cron" {
   workspace_id  = data.prefect_workspace.test.id
   deployment_id = prefect_deployment.test.id
 
-  active          = true
-  catchup         = false
-  max_active_runs = 10
-  timezone        = "America/New_York"
+  active   = true
+  catchup  = false
+  timezone = "America/New_York"
 
   # Cron-specific fields
   cron   = "0 0 * * *"
@@ -71,10 +69,9 @@ resource "prefect_deployment_schedule" "test_rrule" {
   workspace_id  = data.prefect_workspace.test.id
   deployment_id = prefect_deployment.test.id
 
-  active          = true
-  catchup         = false
-  max_active_runs = 10
-  timezone        = "America/New_York"
+  active   = true
+  catchup  = false
+  timezone = "America/New_York"
 
   # RRule-specific fields
   rrule = "FREQ=DAILY;INTERVAL=1"
@@ -98,7 +95,7 @@ resource "prefect_deployment_schedule" "test_rrule" {
 - `day_or` (Boolean) Control croniter behavior for handling day and day_of_week entries.
 - `id` (String) Deployment Schedule ID (UUID)
 - `interval` (Number) The interval of the schedule.
-- `max_active_runs` (Number) (Cloud only) The maximum number of active runs for the schedule.
+- `max_active_runs` (Number, Deprecated) (Cloud only) The maximum number of active runs for the schedule.
 - `max_scheduled_runs` (Number) The maximum number of scheduled runs for the schedule.
 - `rrule` (String) The rrule expression of the schedule.
 - `timezone` (String) The timezone of the schedule.

--- a/examples/resources/prefect_deployment_schedule/resource.tf
+++ b/examples/resources/prefect_deployment_schedule/resource.tf
@@ -20,10 +20,9 @@ resource "prefect_deployment_schedule" "test_interval" {
   workspace_id  = data.prefect_workspace.test.id
   deployment_id = prefect_deployment.test.id
 
-  active          = true
-  catchup         = false
-  max_active_runs = 10
-  timezone        = "America/New_York"
+  active   = true
+  catchup  = false
+  timezone = "America/New_York"
 
   # Interval-specific fields
   interval    = 30
@@ -34,10 +33,9 @@ resource "prefect_deployment_schedule" "test_cron" {
   workspace_id  = data.prefect_workspace.test.id
   deployment_id = prefect_deployment.test.id
 
-  active          = true
-  catchup         = false
-  max_active_runs = 10
-  timezone        = "America/New_York"
+  active   = true
+  catchup  = false
+  timezone = "America/New_York"
 
   # Cron-specific fields
   cron   = "0 0 * * *"
@@ -48,10 +46,9 @@ resource "prefect_deployment_schedule" "test_rrule" {
   workspace_id  = data.prefect_workspace.test.id
   deployment_id = prefect_deployment.test.id
 
-  active          = true
-  catchup         = false
-  max_active_runs = 10
-  timezone        = "America/New_York"
+  active   = true
+  catchup  = false
+  timezone = "America/New_York"
 
   # RRule-specific fields
   rrule = "FREQ=DAILY;INTERVAL=1"

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -139,9 +139,10 @@ For more information, see [schedule flow runs](https://docs.prefect.io/v3/automa
 				Computed:    true,
 			},
 			"max_active_runs": schema.Float32Attribute{
-				Description: "(Cloud only) The maximum number of active runs for the schedule.",
-				Optional:    true,
-				Computed:    true,
+				Description:        "(Cloud only) The maximum number of active runs for the schedule.",
+				Optional:           true,
+				Computed:           true,
+				DeprecationMessage: "Remove this attribute's configuration as it no longer is used and the attribute will be removed in the next major version of the provider.",
 			},
 			"catchup": schema.BoolAttribute{
 				Description: "(Cloud only) Whether or not a worker should catch up on Late runs for the schedule.",
@@ -207,7 +208,6 @@ func (r *DeploymentScheduleResource) Create(ctx context.Context, req resource.Cr
 		{
 			Active:           plan.Active.ValueBoolPointer(),
 			Catchup:          plan.Catchup.ValueBool(),
-			MaxActiveRuns:    plan.MaxActiveRuns.ValueFloat32(),
 			MaxScheduledRuns: plan.MaxScheduledRuns.ValueFloat32(),
 			Schedule: api.Schedule{
 				AnchorDate: plan.AnchorDate.ValueString(),
@@ -304,7 +304,6 @@ func (r *DeploymentScheduleResource) Update(ctx context.Context, req resource.Up
 	cfgUpdate := api.DeploymentSchedulePayload{
 		Active:           plan.Active.ValueBoolPointer(),
 		Catchup:          plan.Catchup.ValueBool(),
-		MaxActiveRuns:    plan.MaxActiveRuns.ValueFloat32(),
 		MaxScheduledRuns: plan.MaxScheduledRuns.ValueFloat32(),
 		Schedule: api.Schedule{
 			AnchorDate: plan.AnchorDate.ValueString(),
@@ -383,7 +382,6 @@ func copyScheduleModelToResourceModel(schedule *api.DeploymentSchedule, model *D
 	model.DeploymentID = customtypes.NewUUIDValue(schedule.DeploymentID)
 
 	model.Active = types.BoolPointerValue(schedule.Active)
-	model.MaxActiveRuns = types.Float32Value(schedule.MaxActiveRuns)
 
 	model.Catchup = types.BoolValue(schedule.Catchup)
 	model.MaxScheduledRuns = types.Float32Value(schedule.MaxScheduledRuns)

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -141,7 +141,6 @@ For more information, see [schedule flow runs](https://docs.prefect.io/v3/automa
 			"max_active_runs": schema.Float32Attribute{
 				Description:        "(Cloud only) The maximum number of active runs for the schedule.",
 				Optional:           true,
-				Computed:           true,
 				DeprecationMessage: "Remove this attribute's configuration as it no longer is used and the attribute will be removed in the next major version of the provider.",
 			},
 			"catchup": schema.BoolAttribute{

--- a/internal/provider/resources/deployment_schedule_test.go
+++ b/internal/provider/resources/deployment_schedule_test.go
@@ -36,7 +36,6 @@ resource "prefect_deployment_schedule" "test" {
 
 	active = true
 	catchup = false
-	max_active_runs = 10
 	timezone = "America/New_York"
 
 	interval = 30
@@ -70,7 +69,6 @@ resource "prefect_deployment_schedule" "test" {
 	# Update these values
 	active = false
 	catchup = true
-	max_active_runs = 20
 	timezone = "America/Chicago"
 
 	interval = 30
@@ -208,7 +206,6 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueBool(resourceName, "active", false),
 					testutils.ExpectKnownValueBool(resourceName, "catchup", true),
-					testutils.ExpectKnownValueNumber(resourceName, "max_active_runs", 20),
 					testutils.ExpectKnownValue(resourceName, "timezone", "America/Chicago"),
 				},
 			},


### PR DESCRIPTION
### Summary

This field is not actively used in the application code and can therefore be removed.

Related to https://linear.app/prefect/issue/ENG-2035/investigate-unused-deployment-schedule-field-max-active-runs

Field will be removed in https://linear.app/prefect/issue/PLA-1410/remove-deprecated-max-active-runs-field-from-deployments.

<!-- Add a brief description of your change here -->

### Testing

```
$ TESTS="TestAccResource_deployment_schedule" make testacc-dev
./scripts/testacc-dev TestAccResource_deployment_schedule "INFO" ""
specific test(s) configured: TestAccResource_deployment_schedule
∅  .
∅  internal/client
∅  internal/provider/customtypes
∅  internal/api (287ms)
∅  internal/provider/helpers
∅  internal/testutils
∅  internal/utils
∅  scripts
∅  internal/provider (439ms)
∅  internal/provider/datasources (493ms)
∅  internal/sweep (895ms)
✓  internal/provider/resources (15.308s)

DONE 1 tests in 17.589s
```

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
