### PR TITLE
fix(tests): update base job template with PREFECT_CLOUD_API_URL

### DIFF
--- a/internal/provider/resources/work_pool_test.go
+++ b/internal/provider/resources/work_pool_test.go
@@ -239,6 +239,9 @@ var baseJobTemplateTpl = `
       },
       "env": {
         "title": "Environment Variables",
+        "default": {
+          "PREFECT_CLOUD_API_URL": "http://localhost:8000/"
+        },
         "description": "Environment variables to set when starting a flow run.",
         "type": "object",
         "additionalProperties": {

--- a/internal/provider/resources/work_queue_test.go
+++ b/internal/provider/resources/work_queue_test.go
@@ -326,6 +326,9 @@ var baseJobTemplateTplForQueues = `
       },
       "env": {
         "title": "Environment Variables",
+        "default": {
+          "PREFECT_CLOUD_API_URL": "http://localhost:8000/"
+        },
         "description": "Environment variables to set when starting a flow run.",
         "type": "object",
         "additionalProperties": {


### PR DESCRIPTION
### Summary

It appears that https://github.com/PrefectHQ/nebula/pull/9701 updated the default configuration for work pools created in dev and stg. Since our acceptance tests happen in stg, we need to update our expected template.

Related to https://linear.app/prefect/issue/PLA-1352/cycle-17-catch-all

First noticed in https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/14650542952/job/41115038048

<!-- Add a brief description of your change here -->

I got this value by checking the default template from making a new work pool:

<img width="724" alt="image" src="https://github.com/user-attachments/assets/e8e17619-ca42-48f6-8b96-86304a5cd744" />


### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
