### PR TITLE
chore(tests): test all resources against OSS

### DIFF
--- a/docs/resources/team_access.md
+++ b/docs/resources/team_access.md
@@ -4,14 +4,14 @@ page_title: "prefect_team_access Resource - prefect"
 subcategory: ""
 description: |-
   The resource team_access grants access to a team for a user or service account. For more information, see manage teams https://docs.prefect.io/v3/manage/cloud/manage-users/manage-teams.
-  This feature is available in the following product plan(s) https://www.prefect.io/pricing: Prefect OSS, Prefect Cloud (Free), Prefect Cloud (Pro), Prefect Cloud (Enterprise).
+  This feature is available in the following product plan(s) https://www.prefect.io/pricing: Prefect Cloud (Enterprise).
 ---
 
 # prefect_team_access (Resource)
 
 The resource `team_access` grants access to a team for a user or service account. For more information, see [manage teams](https://docs.prefect.io/v3/manage/cloud/manage-users/manage-teams).
 
-This feature is available in the following [product plan(s)](https://www.prefect.io/pricing): Prefect OSS, Prefect Cloud (Free), Prefect Cloud (Pro), Prefect Cloud (Enterprise).
+This feature is available in the following [product plan(s)](https://www.prefect.io/pricing): Prefect Cloud (Enterprise).
 
 ## Example Usage
 

--- a/internal/provider/resources/account_member_test.go
+++ b/internal/provider/resources/account_member_test.go
@@ -38,6 +38,9 @@ removed {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_account_member(t *testing.T) {
+	// Account member is not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	resourceName := "prefect_account_member.test"
 	resourceEmail := "marvin@prefect.io"
 	accountID := os.Getenv("PREFECT_CLOUD_ACCOUNT_ID")

--- a/internal/provider/resources/account_test.go
+++ b/internal/provider/resources/account_test.go
@@ -10,6 +10,9 @@ import (
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_account(t *testing.T) {
+	// Accounts are not compatible OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	resourceName := "prefect_account.test"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/provider/resources/deployment_access_test.go
+++ b/internal/provider/resources/deployment_access_test.go
@@ -78,6 +78,9 @@ resource "prefect_deployment_access" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_deployment_access(t *testing.T) {
+	// Deployment access is not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	workspace := testutils.NewEphemeralWorkspace()
 	serviceAccountName := "my-service-account"
 	teamName := "my-team"

--- a/internal/provider/resources/global_concurrency_limit_test.go
+++ b/internal/provider/resources/global_concurrency_limit_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccGlobalConcurrencyLimitCreate(workspace, name string, limit int64, active bool, activeSlots int64, slotDecayPerSecond float64) string {
+func fixtureAccGlobalConcurrencyLimitCreate(workspace, workspaceIDArg, name string, limit int64, active bool, activeSlots int64, slotDecayPerSecond float64) string {
 	return fmt.Sprintf(`
 %s
 resource "prefect_global_concurrency_limit" "global_concurrency_limit" {
-	workspace_id = prefect_workspace.test.id
+	%s
 	name = "%s"
 	limit = %d
 	active = %t
 	active_slots = %d
 	slot_decay_per_second = %f
 }
-`, workspace, name, limit, active, activeSlots, slotDecayPerSecond)
+`, workspace, workspaceIDArg, name, limit, active, activeSlots, slotDecayPerSecond)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -34,7 +34,7 @@ func TestAccResource_global_concurrency_limit(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Check creation + existence of the resource
-				Config: fixtureAccGlobalConcurrencyLimitCreate(workspace.Resource, "test1", 10, true, 0, 1.5),
+				Config: fixtureAccGlobalConcurrencyLimitCreate(workspace.Resource, workspace.IDArg, "test1", 10, true, 0, 1.5),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValue(resourceName, "name", "test1"),
 					testutils.ExpectKnownValueNumber(resourceName, "limit", 10),
@@ -45,7 +45,7 @@ func TestAccResource_global_concurrency_limit(t *testing.T) {
 			},
 			{
 				// Check updating the resource
-				Config: fixtureAccGlobalConcurrencyLimitCreate(workspace.Resource, "test2", 20, false, 1, 2),
+				Config: fixtureAccGlobalConcurrencyLimitCreate(workspace.Resource, workspace.IDArg, "test2", 20, false, 1, 2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValue(resourceName, "name", "test2"),
 					testutils.ExpectKnownValueNumber(resourceName, "limit", 20),

--- a/internal/provider/resources/service_account_test.go
+++ b/internal/provider/resources/service_account_test.go
@@ -76,6 +76,9 @@ resource "prefect_service_account" "bot" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_service_account(t *testing.T) {
+	// Service accounts are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	botResourceName := "prefect_service_account.bot"
 
 	botRandomName := testutils.NewRandomPrefixedString()

--- a/internal/provider/resources/sla_test.go
+++ b/internal/provider/resources/sla_test.go
@@ -107,6 +107,9 @@ resource "prefect_resource_sla" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_resource_sla(t *testing.T) {
+	// SLAs are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	resourceName := "prefect_resource_sla.test"
 	workspace := testutils.NewEphemeralWorkspace()
 

--- a/internal/provider/resources/task_run_concurrency_limit_test.go
+++ b/internal/provider/resources/task_run_concurrency_limit_test.go
@@ -9,16 +9,16 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccTaskRunConcurrencyLimitCreate(workspace, tag string, concurrencyLimit int64) string {
+func fixtureAccTaskRunConcurrencyLimitCreate(workspace, workspaceIDArg, tag string, concurrencyLimit int64) string {
 	return fmt.Sprintf(`
 %s
 
 resource "prefect_task_run_concurrency_limit" "task_run_concurrency_limit" {
-	workspace_id = prefect_workspace.test.id
+	%s
 	tag = "%s"
 	concurrency_limit = %d
 }
-`, workspace, tag, concurrencyLimit)
+`, workspace, workspaceIDArg, tag, concurrencyLimit)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -32,7 +32,7 @@ func TestAccResource_task_run_concurrency_limit(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Check creation + existence of the resource
-				Config: fixtureAccTaskRunConcurrencyLimitCreate(workspace.Resource, "test1", 10),
+				Config: fixtureAccTaskRunConcurrencyLimitCreate(workspace.Resource, workspace.IDArg, "test1", 10),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValue(resourceName, "tag", "test1"),
 					testutils.ExpectKnownValueNumber(resourceName, "concurrency_limit", 10),
@@ -40,7 +40,7 @@ func TestAccResource_task_run_concurrency_limit(t *testing.T) {
 			},
 			{
 				// Check updating the resource
-				Config: fixtureAccTaskRunConcurrencyLimitCreate(workspace.Resource, "test2", 20),
+				Config: fixtureAccTaskRunConcurrencyLimitCreate(workspace.Resource, workspace.IDArg, "test2", 20),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValue(resourceName, "tag", "test2"),
 					testutils.ExpectKnownValueNumber(resourceName, "concurrency_limit", 20),

--- a/internal/provider/resources/team_access.go
+++ b/internal/provider/resources/team_access.go
@@ -66,7 +66,7 @@ func (r *TeamAccessResource) Schema(_ context.Context, _ resource.SchemaRequest,
 		Description: helpers.DescriptionWithPlans(
 			"The resource `team_access` grants access to a team for a user or service account. "+
 				"For more information, see [manage teams](https://docs.prefect.io/v3/manage/cloud/manage-users/manage-teams).",
-			helpers.AllPlans...,
+			helpers.PlanPrefectCloudEnterprise,
 		),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{

--- a/internal/provider/resources/team_access_test.go
+++ b/internal/provider/resources/team_access_test.go
@@ -33,6 +33,9 @@ resource "prefect_team_access" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_team_access_service_account(t *testing.T) {
+	// Team access is not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	accessResourceName := "prefect_team_access.test"
 	randomName := testutils.NewRandomPrefixedString()
 

--- a/internal/provider/resources/team_access_test.go
+++ b/internal/provider/resources/team_access_test.go
@@ -81,6 +81,9 @@ resource "prefect_team_access" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_team_access_user(t *testing.T) {
+	// Team access is not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	accessResourceName := "prefect_team_access.test"
 	randomName := testutils.NewRandomPrefixedString()
 

--- a/internal/provider/resources/team_test.go
+++ b/internal/provider/resources/team_test.go
@@ -20,6 +20,9 @@ resource "prefect_team" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_team(t *testing.T) {
+	// Teams are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	randomName := testutils.NewRandomPrefixedString()
 	randomName2 := testutils.NewRandomPrefixedString()
 

--- a/internal/provider/resources/user_api_key_test.go
+++ b/internal/provider/resources/user_api_key_test.go
@@ -32,6 +32,9 @@ resource "prefect_user_api_key" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_user_api_key(t *testing.T) {
+	// API keys are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	resourceName := "prefect_user_api_key.test"
 	userID := os.Getenv("ACC_TEST_USER_RESOURCE_ID")
 	name := testutils.NewRandomPrefixedString()

--- a/internal/provider/resources/variable_test.go
+++ b/internal/provider/resources/variable_test.go
@@ -14,20 +14,19 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccVariableResource(workspace, name string, value interface{}) string {
+func fixtureAccVariableResource(workspace, workspaceIDArg, name string, value interface{}) string {
 	return fmt.Sprintf(`
 %s
 
 resource "prefect_variable" "test" {
 	name = "%s"
 	value = %v
-	workspace_id = prefect_workspace.test.id
-	depends_on = [prefect_workspace.test]
+	%s
 }
-	`, workspace, name, value)
+	`, workspace, name, value, workspaceIDArg)
 }
 
-func fixtureAccVariableResourceWithTags(workspace, name string, value interface{}) string {
+func fixtureAccVariableResourceWithTags(workspace, workspaceIDARg, name string, value interface{}) string {
 	return fmt.Sprintf(`
 %s
 
@@ -35,10 +34,9 @@ resource "prefect_variable" "test" {
 	name = "%s"
 	value = %v
 	tags = ["foo", "bar"]
-	workspace_id = prefect_workspace.test.id
-	depends_on = [prefect_workspace.test]
+	%s
 }
-	`, workspace, name, value)
+	`, workspace, name, value, workspaceIDARg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -69,7 +67,7 @@ func TestAccResource_variable(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Check creation + existence of the variable resource
-				Config: fixtureAccVariableResource(workspace.Resource, randomName, valueStringForResource),
+				Config: fixtureAccVariableResource(workspace.Resource, workspace.IDArg, randomName, valueStringForResource),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName, Value: valueString}),
@@ -80,7 +78,7 @@ func TestAccResource_variable(t *testing.T) {
 			},
 			{
 				// Check updating name of the variable resource
-				Config: fixtureAccVariableResource(workspace.Resource, randomName2, valueStringForResource),
+				Config: fixtureAccVariableResource(workspace.Resource, workspace.IDArg, randomName2, valueStringForResource),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: valueString}),
@@ -88,7 +86,7 @@ func TestAccResource_variable(t *testing.T) {
 			},
 			{
 				// Check updating value of the variable resource to a number
-				Config: fixtureAccVariableResource(workspace.Resource, randomName2, valueNumber),
+				Config: fixtureAccVariableResource(workspace.Resource, workspace.IDArg, randomName2, valueNumber),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: valueNumber}),
@@ -96,7 +94,7 @@ func TestAccResource_variable(t *testing.T) {
 			},
 			{
 				// Check updating value of the variable resource to a boolean
-				Config: fixtureAccVariableResource(workspace.Resource, randomName2, valueBool),
+				Config: fixtureAccVariableResource(workspace.Resource, workspace.IDArg, randomName2, valueBool),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: valueBool}),
@@ -104,7 +102,7 @@ func TestAccResource_variable(t *testing.T) {
 			},
 			{
 				// Check updating value of the variable resource to a object
-				Config: fixtureAccVariableResource(workspace.Resource, randomName2, valueObject),
+				Config: fixtureAccVariableResource(workspace.Resource, workspace.IDArg, randomName2, valueObject),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: valueObjectExpected}),
@@ -112,7 +110,7 @@ func TestAccResource_variable(t *testing.T) {
 			},
 			{
 				// Check updating value of the variable resource to a tuple
-				Config: fixtureAccVariableResource(workspace.Resource, randomName2, valueTuple),
+				Config: fixtureAccVariableResource(workspace.Resource, workspace.IDArg, randomName2, valueTuple),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: valueTupleExpected}),
@@ -120,7 +118,7 @@ func TestAccResource_variable(t *testing.T) {
 			},
 			{
 				// Check adding tags
-				Config: fixtureAccVariableResourceWithTags(workspace.Resource, randomName2, valueBool),
+				Config: fixtureAccVariableResourceWithTags(workspace.Resource, workspace.IDArg, randomName2, valueBool),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVariableExists(resourceName, &variable),
 					testAccCheckVariableValues(&variable, &api.Variable{Name: randomName2, Value: valueBool}),
@@ -148,9 +146,14 @@ func testAccCheckVariableExists(variableResourceName string, variable *api.Varia
 			return fmt.Errorf("error fetching variable ID: %w", err)
 		}
 
-		workspaceID, err := testutils.GetResourceWorkspaceIDFromState(state)
-		if err != nil {
-			return fmt.Errorf("error fetching workspace ID: %w", err)
+		var workspaceID uuid.UUID
+
+		if !testutils.TestContextOSS() {
+			// Get the workspace resource we just created from the state
+			workspaceID, err = testutils.GetResourceWorkspaceIDFromState(state)
+			if err != nil {
+				return fmt.Errorf("error fetching workspace ID: %w", err)
+			}
 		}
 
 		// Create a new client, and use the default configurations from the environment

--- a/internal/provider/resources/webhooks_test.go
+++ b/internal/provider/resources/webhooks_test.go
@@ -69,6 +69,9 @@ const webhookTemplateStatic = `
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_webhook(t *testing.T) {
+	// Webhooks are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	workspace := testutils.NewEphemeralWorkspace()
 
 	randomName := testutils.NewRandomPrefixedString()

--- a/internal/provider/resources/work_pool_access_test.go
+++ b/internal/provider/resources/work_pool_access_test.go
@@ -77,6 +77,9 @@ resource "prefect_work_pool_access" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_work_pool_access(t *testing.T) {
+	// Work pool access is not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	workspace := testutils.NewEphemeralWorkspace()
 	serviceAccountName := "my-service-account"
 	teamName := "my-team"

--- a/internal/provider/resources/work_queue.go
+++ b/internal/provider/resources/work_queue.go
@@ -339,20 +339,26 @@ func (r *WorkQueueResource) Delete(ctx context.Context, req resource.DeleteReque
 // ImportState imports the resource into Terraform state.
 func (r *WorkQueueResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Allow input values in the form of:
+	// - "work_pool_name,work_queue_name"
 	// - "work_pool_name,work_queue_name,workspace_id"
-	reqInputCount := 3
+	minInputCount := 2
+	maxInputCount := 3
 	inputParts := strings.Split(req.ID, ",")
 
-	if len(inputParts) != reqInputCount {
+	switch inputCount := len(inputParts); inputCount {
+	case minInputCount:
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("work_pool_name"), inputParts[0])...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), inputParts[1])...)
+	case maxInputCount:
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("work_pool_name"), inputParts[0])...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), inputParts[1])...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), inputParts[2])...)
+	default:
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected 3 import identifiers, in the form of `work_pool_name,work_queue_name,workspace_id`. Got %q", req.ID),
+			fmt.Sprintf("Expected import identifiers, in the form of `work_pool_name,work_queue_name,workspace_id` or `work_pool_name,work_queue_name`. Got %q", req.ID),
 		)
 
 		return
 	}
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("work_pool_name"), inputParts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), inputParts[1])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), inputParts[2])...)
 }

--- a/internal/provider/resources/workspace_access_test.go
+++ b/internal/provider/resources/workspace_access_test.go
@@ -50,6 +50,9 @@ resource "prefect_workspace_access" "bot_access" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_bot_workspace_access(t *testing.T) {
+	// Workspace access is not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	accessResourceName := "prefect_workspace_access.bot_access"
 	botResourceName := "prefect_service_account.bot"
 	developerRoleDatsourceName := "data.prefect_workspace_role.developer"
@@ -130,6 +133,9 @@ resource "prefect_workspace_access" "team_access" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_team_workspace_access(t *testing.T) {
+	// Workspace access is not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	accessResourceName := "prefect_workspace_access.team_access"
 	teamResourceName := "data.prefect_team.my_team"
 	viewerRoleDatsourceName := "data.prefect_workspace_role.viewer"

--- a/internal/provider/resources/workspace_role_test.go
+++ b/internal/provider/resources/workspace_role_test.go
@@ -35,6 +35,9 @@ resource "prefect_workspace_role" "role" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_workspace_role(t *testing.T) {
+	// Workspace role is not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	resourceName := "prefect_workspace_role.role"
 	randomName := testutils.NewRandomPrefixedString()
 

--- a/internal/provider/resources/workspace_test.go
+++ b/internal/provider/resources/workspace_test.go
@@ -15,6 +15,9 @@ import (
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_workspace(t *testing.T) {
+	// Workspace is not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	ephemeralWorkspaceCreate := testutils.NewEphemeralWorkspace()
 	ephemeralWorkspaceUpdate := testutils.NewEphemeralWorkspace()
 

--- a/internal/testutils/import.go
+++ b/internal/testutils/import.go
@@ -101,16 +101,20 @@ func GetResourceWorkspaceImportStateID(resourceName string) resource.ImportState
 // "name" attribute for use in import tests.
 func GetResourceWorkspaceImportStateIDByName(resourceName string) resource.ImportStateIdFunc {
 	return func(state *terraform.State) (string, error) {
+		fetchedResourceName, err := GetResourceAttributeFromStateByAttribute(state, resourceName, "name")
+		if err != nil {
+			return "", fmt.Errorf("unable to get resource from state: %w", err)
+		}
+
+		if TestContextOSS() {
+			return fetchedResourceName, nil
+		}
+
 		workspaceID, err := GetResourceWorkspaceIDFromState(state)
 		if err != nil {
 			return "", fmt.Errorf("unable to get workspaceID from state: %w", err)
 		}
 
-		fetchedResourceID, err := GetResourceAttributeFromStateByAttribute(state, resourceName, "name")
-		if err != nil {
-			return "", fmt.Errorf("unable to get resource from state: %w", err)
-		}
-
-		return fmt.Sprintf("%s,%s", fetchedResourceID, workspaceID), nil
+		return fmt.Sprintf("%s,%s", fetchedResourceName, workspaceID), nil
 	}
 }

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -61,6 +61,12 @@ func SkipTestsIfOSS(t *testing.T) {
 	}
 }
 
+// SkipFuncOSS implements a Terraform acceptance test SkipFunc that will
+// skip the test if it is running against Prefect OSS.
+func SkipFuncOSS() (bool, error) {
+	return TestContextOSS(), nil
+}
+
 // AccTestPreCheck is a utility hook, which every test suite will call
 // in order to verify if the necessary provider configurations are passed
 // through the environment variables.

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -17,6 +17,7 @@ set -e
 # At that point, tests that are known not to be compatible with OSS will include
 # logic to be skipped if the target instance is OSS.
 testsDefault="
+TestAccResource_account
 TestAccResource_automation
 TestAccResource_block
 TestAccResource_deployment

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -22,6 +22,7 @@ TestAccResource_automation
 TestAccResource_block
 TestAccResource_deployment
 TestAccResource_flow
+TestAccResource_global_concurrency_limit
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -17,9 +17,9 @@ set -e
 # At that point, tests that are known not to be compatible with OSS will include
 # logic to be skipped if the target instance is OSS.
 testsDefault="
-TestAccResource_deployment
-TestAccResource_block
 TestAccResource_automation
+TestAccResource_block
+TestAccResource_deployment
 TestAccResource_flow
 "
 

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -30,6 +30,7 @@ TestAccResource_team
 TestAccResource_team_access
 TestAccResource_user_api_key
 TestAccResource_user
+TestAccResource_variable
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -35,6 +35,9 @@ TestAccResource_webhook
 TestAccResource_work_pool
 TestAccResource_work_pool_access
 TestAccResource_work_queue
+TestAccResource_workspace_access
+TestAccResource_workspace_role
+TestAccResource_workspace
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -32,6 +32,7 @@ TestAccResource_user_api_key
 TestAccResource_user
 TestAccResource_variable
 TestAccResource_webhook
+TestAccResource_work_pool
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -25,6 +25,7 @@ TestAccResource_flow
 TestAccResource_global_concurrency_limit
 TestAccResource_service_account
 TestAccResource_resource_sla
+TestAccResource_task_run_concurrency_limit
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -23,6 +23,7 @@ TestAccResource_block
 TestAccResource_deployment
 TestAccResource_flow
 TestAccResource_global_concurrency_limit
+TestAccResource_service_account
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -33,6 +33,7 @@ TestAccResource_user
 TestAccResource_variable
 TestAccResource_webhook
 TestAccResource_work_pool
+TestAccResource_work_pool_access
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -24,6 +24,7 @@ TestAccResource_deployment
 TestAccResource_flow
 TestAccResource_global_concurrency_limit
 TestAccResource_service_account
+TestAccResource_resource_sla
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -34,6 +34,7 @@ TestAccResource_variable
 TestAccResource_webhook
 TestAccResource_work_pool
 TestAccResource_work_pool_access
+TestAccResource_work_queue
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -17,27 +17,7 @@ set -e
 # At that point, tests that are known not to be compatible with OSS will include
 # logic to be skipped if the target instance is OSS.
 testsDefault="
-TestAccResource_account
-TestAccResource_automation
-TestAccResource_block
-TestAccResource_deployment
-TestAccResource_flow
-TestAccResource_global_concurrency_limit
-TestAccResource_service_account
-TestAccResource_resource_sla
-TestAccResource_task_run_concurrency_limit
-TestAccResource_team
-TestAccResource_team_access
-TestAccResource_user_api_key
-TestAccResource_user
-TestAccResource_variable
-TestAccResource_webhook
-TestAccResource_work_pool
-TestAccResource_work_pool_access
-TestAccResource_work_queue
-TestAccResource_workspace_access
-TestAccResource_workspace_role
-TestAccResource_workspace
+TestAccResource_*
 "
 
 tests=${1:-""}
@@ -46,7 +26,7 @@ function run() {
   TF_ACC=1 \
     TEST_CONTEXT="OSS" \
     PREFECT_API_URL="http://localhost:4200/api" \
-    gotestsum --max-fails=50 ./... -count=1 -v -run "^${1}$"
+    gotestsum --max-fails=50 ./... -count=1 -v -run "${1}"
 }
 
 if [ "${tests}" == "" ]; then
@@ -57,5 +37,5 @@ if [ "${tests}" == "" ]; then
   done
 else
   echo "Running specified tests: ${tests}"
-  run ${tests}
+  run "^${tests}$"
 fi

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -31,6 +31,7 @@ TestAccResource_team_access
 TestAccResource_user_api_key
 TestAccResource_user
 TestAccResource_variable
+TestAccResource_webhook
 "
 
 tests=${1:-""}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -26,6 +26,10 @@ TestAccResource_global_concurrency_limit
 TestAccResource_service_account
 TestAccResource_resource_sla
 TestAccResource_task_run_concurrency_limit
+TestAccResource_team
+TestAccResource_team_access
+TestAccResource_user_api_key
+TestAccResource_user
 "
 
 tests=${1:-""}


### PR DESCRIPTION
### Summary

Tests all resources against OSS. Next we'll do datasources.

Related to https://linear.app/prefect/issue/PLA-191/run-acceptance-tests-against-prefect-server-in-docker-compose

### Testing

```
$ make testacc-oss
docker compose up -d
[+] Running 1/1
 ✔ Container more-oss-tests-prefect-1  Running                                                                                                                                                                                0.0s
./scripts/testacc-oss ""
Running all tests...
Running test: TestAccResource_*
∅  .
∅  internal/client
∅  internal/provider/customtypes
∅  internal/api (171ms)
∅  internal/provider (262ms)
∅  internal/provider/helpers
∅  internal/testutils
∅  internal/utils
∅  scripts
∅  internal/provider/datasources (301ms)
∅  internal/sweep (685ms)
✓  internal/provider/resources (15.367s)

=== Skipped
=== SKIP: internal/provider/resources TestAccResource_account_member (0.00s)
    account_member_test.go:42: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_account (0.00s)
    account_test.go:14: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_automation (0.00s)
    automation_test.go:286: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_deployment_access (0.00s)
    deployment_access_test.go:82: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_service_account (0.00s)
    service_account_test.go:80: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_resource_sla (0.00s)
    sla_test.go:111: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_team_access_service_account (0.00s)
    team_access_test.go:37: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_team_access_user (0.00s)
    team_access_test.go:85: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_team (0.00s)
    team_test.go:24: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_user_api_key (0.00s)
    user_api_key_test.go:36: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_webhook (0.00s)
    webhooks_test.go:73: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_work_pool_access (0.00s)
    work_pool_access_test.go:81: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_bot_workspace_access (0.00s)
    workspace_access_test.go:54: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_team_workspace_access (0.00s)
    workspace_access_test.go:137: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_workspace_role (0.00s)
    workspace_role_test.go:39: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_workspace (0.00s)
    workspace_test.go:19: skipping test in OSS mode

DONE 26 tests, 16 skipped in 16.501s
```

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
