### PR TITLE
chore(tests): add some datasource OSS tests

### DIFF
--- a/internal/provider/datasources/account_member_test.go
+++ b/internal/provider/datasources/account_member_test.go
@@ -19,6 +19,9 @@ data "prefect_account_member" "member" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccDatasource_account_member(t *testing.T) {
+	// Account members are not available in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	dataSourceName := "data.prefect_account_member.member"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/provider/datasources/account_role_test.go
+++ b/internal/provider/datasources/account_role_test.go
@@ -19,6 +19,9 @@ data "prefect_account_role" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccDatasource_account_role_defaults(t *testing.T) {
+	// Account roles are not available in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	dataSourceName := "data.prefect_account_role.test"
 
 	type defaultAccountRole struct {

--- a/internal/provider/datasources/account_test.go
+++ b/internal/provider/datasources/account_test.go
@@ -20,6 +20,9 @@ data "prefect_account" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccDatasource_account(t *testing.T) {
+	// Accounts are not available in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	datasourceName := "data.prefect_account.test"
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,

--- a/internal/provider/datasources/block_test.go
+++ b/internal/provider/datasources/block_test.go
@@ -1,7 +1,6 @@
 package datasources_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -10,9 +9,9 @@ import (
 )
 
 type blockFixtureConfig struct {
-	AccountID string
-	Workspace string
-	BlockName string
+	Workspace      string
+	WorkspaceIDArg string
+	BlockName      string
 }
 
 func fixtureAccBlock(cfg blockFixtureConfig) string {
@@ -27,15 +26,13 @@ resource "prefect_block" "{{ .BlockName }}" {
     "someKey" = "someValue"
   })
 
-  account_id = "{{ .AccountID }}"
-  workspace_id = prefect_workspace.test.id
+	{{ .WorkspaceIDArg }}
 }
 
 data "prefect_block" "my_existing_secret_by_id" {
   id = prefect_block.{{ .BlockName }}.id
 
-  account_id = "{{ .AccountID }}"
-  workspace_id = prefect_workspace.test.id
+	{{ .WorkspaceIDArg }}
 
   depends_on = [prefect_block.{{ .BlockName }}]
 }
@@ -44,8 +41,7 @@ data "prefect_block" "my_existing_secret_by_name" {
   name      = "{{ .BlockName }}"
   type_slug = "secret"
 
-  account_id = "{{ .AccountID }}"
-  workspace_id = prefect_workspace.test.id
+	{{ .WorkspaceIDArg }}
 
   depends_on = [prefect_block.{{ .BlockName }}]
 }
@@ -65,9 +61,9 @@ func TestAccDatasource_block(t *testing.T) {
 	blockValue := "{\"someKey\":\"someValue\"}"
 
 	cfg := blockFixtureConfig{
-		Workspace: workspace.Resource,
-		BlockName: blockName,
-		AccountID: os.Getenv("PREFECT_CLOUD_ACCOUNT_ID"),
+		Workspace:      workspace.Resource,
+		WorkspaceIDArg: workspace.IDArg,
+		BlockName:      blockName,
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/provider/datasources/deployment_test.go
+++ b/internal/provider/datasources/deployment_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 type deploymentFixtureConfig struct {
-	Workspace string
-	AccountID string
+	Workspace      string
+	WorkspaceIDArg string
+	AccountID      string
 }
 
 func fixtureAccDeployment(cfg deploymentFixtureConfig) string {
@@ -22,7 +23,7 @@ resource "prefect_flow" "test" {
 	name = "test"
 	tags = ["test"]
 
-	workspace_id = prefect_workspace.test.id
+	{{.WorkspaceIDArg}}
 }
 
 resource "prefect_deployment" "test" {
@@ -32,15 +33,13 @@ resource "prefect_deployment" "test" {
   description = "test description"
   version = "1.2.3"
 
-  account_id = "{{ .AccountID }}"
-  workspace_id = prefect_workspace.test.id
+	{{.WorkspaceIDArg}}
 }
 
 data "prefect_deployment" "test_by_id" {
   id = prefect_deployment.test.id
 
-  account_id = "{{ .AccountID }}"
-  workspace_id = prefect_workspace.test.id
+	{{.WorkspaceIDArg}}
 
   depends_on = [prefect_deployment.test]
 }
@@ -49,8 +48,7 @@ data "prefect_deployment" "test_by_name" {
   name = prefect_deployment.test.name
   flow_name = prefect_flow.test.name
 
-  account_id = "{{ .AccountID }}"
-  workspace_id = prefect_workspace.test.id
+	{{.WorkspaceIDArg}}
 
   depends_on = [prefect_deployment.test]
 }
@@ -67,8 +65,9 @@ func TestAccDatasource_deployment(t *testing.T) {
 	datasourceNameByName := "data.prefect_deployment.test_by_name"
 
 	cfg := deploymentFixtureConfig{
-		Workspace: workspace.Resource,
-		AccountID: os.Getenv("PREFECT_CLOUD_ACCOUNT_ID"),
+		Workspace:      workspace.Resource,
+		WorkspaceIDArg: workspace.IDArg,
+		AccountID:      os.Getenv("PREFECT_CLOUD_ACCOUNT_ID"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/provider/datasources/global_concurrency_limit_test.go
+++ b/internal/provider/datasources/global_concurrency_limit_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccGlobalConcurrencyLimitDataSource(workspace, name string) string {
+func fixtureAccGlobalConcurrencyLimitDataSource(workspace, workspaceIDArg, name string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "prefect_global_concurrency_limit" "global_concurrency_limit" {
-	workspace_id = prefect_workspace.test.id
+	%s
 	name = "%s"
 	limit = 10
 	active = true
@@ -29,7 +29,7 @@ data "prefect_global_concurrency_limit" "limit_by_id" {
 	id = prefect_global_concurrency_limit.global_concurrency_limit.id
 	workspace_id = prefect_global_concurrency_limit.global_concurrency_limit.workspace_id
 }
-	`, workspace, name)
+	`, workspace, workspaceIDArg, name)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -44,7 +44,7 @@ func TestAccDatasource_global_concurrency_limit(t *testing.T) {
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: fixtureAccGlobalConcurrencyLimitDataSource(workspace.Resource, randomName),
+				Config: fixtureAccGlobalConcurrencyLimitDataSource(workspace.Resource, workspace.IDArg, randomName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					// Check the prefect_global_concurrency_limit datasource that queries by ID
 					testutils.ExpectKnownValueNotNull(dataSourceNameByID, "id"),

--- a/internal/provider/datasources/service_account_test.go
+++ b/internal/provider/datasources/service_account_test.go
@@ -14,6 +14,9 @@ import (
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccDatasource_service_account(t *testing.T) {
+	// Service accounts are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	dataSourceNameByID := "data.prefect_service_account.bot_by_id"
 	dataSourceNameByName := "data.prefect_service_account.bot_by_name"
 	randomName := testutils.NewRandomPrefixedString()

--- a/internal/provider/datasources/team_test.go
+++ b/internal/provider/datasources/team_test.go
@@ -20,6 +20,9 @@ data "prefect_team" "default" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccDatasource_team(t *testing.T) {
+	// Teams are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	dataSourceName := "data.prefect_team.default"
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/internal/provider/datasources/variable_test.go
+++ b/internal/provider/datasources/variable_test.go
@@ -9,22 +9,22 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccVariableByName(workspace, name string) string {
+func fixtureAccVariableByName(workspace, workspaceIDArg, name string) string {
 	return fmt.Sprintf(`
+%s
+
+resource "prefect_variable" "test" {
+	name = "%s"
+	value = "variable value goes here"
 	%s
+}
 
-	resource "prefect_variable" "test" {
-		name = "%s"
-		value = "variable value goes here"
-		workspace_id = prefect_workspace.test.id
-		depends_on = [prefect_workspace.test]
-	}
-
-	data "prefect_variable" "test" {
-		name = "%s"
-		workspace_id = prefect_workspace.test.id
-	}
-	`, workspace, name, name)
+data "prefect_variable" "test" {
+	name = "%s"
+	%s
+	depends_on = [prefect_variable.test]
+}
+	`, workspace, name, workspaceIDArg, name, workspaceIDArg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -39,7 +39,7 @@ func TestAccDatasource_variable(t *testing.T) {
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: fixtureAccVariableByName(workspace.Resource, variableName),
+				Config: fixtureAccVariableByName(workspace.Resource, workspace.IDArg, variableName),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNotNull(datasourceName, "id"),
 					testutils.ExpectKnownValue(datasourceName, "name", variableName),

--- a/internal/provider/datasources/work_pool_test.go
+++ b/internal/provider/datasources/work_pool_test.go
@@ -49,6 +49,7 @@ func TestAccDatasource_work_pool(t *testing.T) {
 	singleWorkPoolDatasourceName := "data.prefect_work_pool.test"
 	multipleWorkPoolDatasourceName := "data.prefect_work_pools.test"
 	workspace := testutils.NewEphemeralWorkspace()
+	workPoolName := testutils.NewRandomPrefixedString()
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
@@ -56,9 +57,9 @@ func TestAccDatasource_work_pool(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Check that we can query a single work pool
-				Config: fixtureAccSingleWorkPool(workspace.Resource, workspace.IDArg, "test-pool"),
+				Config: fixtureAccSingleWorkPool(workspace.Resource, workspace.IDArg, workPoolName),
 				ConfigStateChecks: []statecheck.StateCheck{
-					testutils.ExpectKnownValue(singleWorkPoolDatasourceName, "name", "test-pool"),
+					testutils.ExpectKnownValue(singleWorkPoolDatasourceName, "name", workPoolName),
 					testutils.ExpectKnownValueNotNull(singleWorkPoolDatasourceName, "id"),
 					testutils.ExpectKnownValueNotNull(singleWorkPoolDatasourceName, "created"),
 					testutils.ExpectKnownValueNotNull(singleWorkPoolDatasourceName, "updated"),
@@ -70,9 +71,9 @@ func TestAccDatasource_work_pool(t *testing.T) {
 			},
 			{
 				// Check that we can query multiple work pools
-				Config: fixtureAccMultipleWorkPools(workspace.Resource, workspace.IDArg, "test-pool"),
+				Config: fixtureAccMultipleWorkPools(workspace.Resource, workspace.IDArg, workPoolName),
 				ConfigStateChecks: []statecheck.StateCheck{
-					testutils.ExpectKnownValue(multipleWorkPoolDatasourceName, "work_pools.0.name", "test-pool"),
+					testutils.ExpectKnownValue(multipleWorkPoolDatasourceName, "work_pools.0.name", workPoolName),
 					testutils.ExpectKnownValueNotNull(multipleWorkPoolDatasourceName, "work_pools.0.id"),
 					testutils.ExpectKnownValueNotNull(multipleWorkPoolDatasourceName, "work_pools.0.created"),
 					testutils.ExpectKnownValueNotNull(multipleWorkPoolDatasourceName, "work_pools.0.updated"),

--- a/internal/provider/datasources/work_queue_test.go
+++ b/internal/provider/datasources/work_queue_test.go
@@ -96,13 +96,16 @@ func TestAccDatasource_work_queue(t *testing.T) {
 	workspace := testutils.NewEphemeralWorkspace()
 	workQueues := []*api.WorkQueue{}
 
+	workPoolName := testutils.NewRandomPrefixedString()
+	workPoolMultiName := testutils.NewRandomPrefixedString()
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				// Check that we can query a single work queue
-				Config: fixtureAccSingleWorkQueue(workspace.Resource, workspace.IDArg, "test-pool", "test-queue"),
+				Config: fixtureAccSingleWorkQueue(workspace.Resource, workspace.IDArg, workPoolName, "test-queue"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(singleWorkQueueDatasourceName, "name", "test-queue"),
 					resource.TestCheckResourceAttrSet(singleWorkQueueDatasourceName, "id"),
@@ -114,7 +117,7 @@ func TestAccDatasource_work_queue(t *testing.T) {
 			},
 			{
 				// Check that we can query multiple work queues
-				Config: fixtureAccMultipleWorkQueue(workspace.Resource, workspace.IDArg, "test-pool-multi", "test-queue", "test-queue-2"),
+				Config: fixtureAccMultipleWorkQueue(workspace.Resource, workspace.IDArg, workPoolMultiName, "test-queue", "test-queue-2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckworkQueueExists("prefect_work_pool.test_multi", &workQueues),
 					testAccCheckWorkQueueValues(&workQueues, expectedWorkQueues),

--- a/internal/provider/datasources/work_queue_test.go
+++ b/internal/provider/datasources/work_queue_test.go
@@ -15,6 +15,7 @@ import (
 
 func fixtureAccSingleWorkQueue(
 	workspace string,
+	workspaceIDArg string,
 	workPoolName string,
 	workQueueName string,
 ) string {
@@ -25,8 +26,7 @@ resource "prefect_work_pool" "test" {
   name = "%s"
   type = "kubernetes"
   paused = "false"
-  workspace_id = prefect_workspace.test.id
-  depends_on = [prefect_workspace.test]
+	%s
 }
 
 resource "prefect_work_queue" "test" {
@@ -34,20 +34,21 @@ resource "prefect_work_queue" "test" {
   work_pool_name = prefect_work_pool.test.name
   priority = 1
   description = "my work queue"
-  workspace_id = prefect_workspace.test.id
+	%s
 }
 
 data "prefect_work_queue" "test" {
   name = prefect_work_queue.test.name
   work_pool_name = prefect_work_pool.test.name
-  workspace_id = prefect_workspace.test.id
+	%s
 }
 
-`, workspace, workPoolName, workQueueName)
+`, workspace, workPoolName, workspaceIDArg, workQueueName, workspaceIDArg, workspaceIDArg)
 }
 
 func fixtureAccMultipleWorkQueue(
 	workspace string,
+	workspaceIDArg string,
 	workPoolName string,
 	workQueue1Name string,
 	workQueue2Name string,
@@ -59,8 +60,7 @@ resource "prefect_work_pool" "test_multi" {
   name = "%s"
   type = "kubernetes"
   paused = "false"
-  workspace_id = prefect_workspace.test.id
-  depends_on = [prefect_workspace.test]
+	%s
 }
 
 resource "prefect_work_queue" "test_queue1" {
@@ -68,18 +68,18 @@ resource "prefect_work_queue" "test_queue1" {
   work_pool_name = prefect_work_pool.test_multi.name
   priority = 1
   description = "my work queue"
-  workspace_id = prefect_workspace.test.id
+	%s
 }
 
 resource "prefect_work_queue" "test_queue2" {
   name = "%s"
   work_pool_name = prefect_work_pool.test_multi.name
-  workspace_id = prefect_workspace.test.id
+	%s
 }
 
 data "prefect_work_queues" "test" {
   work_pool_name = prefect_work_pool.test_multi.name
-  workspace_id = prefect_workspace.test.id
+	%s
   depends_on = [
     prefect_work_pool.test_multi,
     prefect_work_queue.test_queue1,
@@ -87,7 +87,7 @@ data "prefect_work_queues" "test" {
   ]
 }
 
-`, workspace, workPoolName, workQueue1Name, workQueue2Name)
+`, workspace, workPoolName, workspaceIDArg, workQueue1Name, workspaceIDArg, workQueue2Name, workspaceIDArg, workspaceIDArg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -102,7 +102,7 @@ func TestAccDatasource_work_queue(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Check that we can query a single work queue
-				Config: fixtureAccSingleWorkQueue(workspace.Resource, "test-pool", "test-queue"),
+				Config: fixtureAccSingleWorkQueue(workspace.Resource, workspace.IDArg, "test-pool", "test-queue"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(singleWorkQueueDatasourceName, "name", "test-queue"),
 					resource.TestCheckResourceAttrSet(singleWorkQueueDatasourceName, "id"),
@@ -114,7 +114,7 @@ func TestAccDatasource_work_queue(t *testing.T) {
 			},
 			{
 				// Check that we can query multiple work queues
-				Config: fixtureAccMultipleWorkQueue(workspace.Resource, "test-pool-multi", "test-queue", "test-queue-2"),
+				Config: fixtureAccMultipleWorkQueue(workspace.Resource, workspace.IDArg, "test-pool-multi", "test-queue", "test-queue-2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckworkQueueExists("prefect_work_pool.test_multi", &workQueues),
 					testAccCheckWorkQueueValues(&workQueues, expectedWorkQueues),
@@ -135,12 +135,15 @@ func testAccCheckworkQueueExists(workPoolResourceName string, workQueues *[]*api
 
 		workPoolName := workPoolResource.Primary.Attributes["name"]
 
-		workspaceResource, exists := s.RootModule().Resources[testutils.WorkspaceResourceName]
-		if !exists {
-			return fmt.Errorf("Resource not found in state: %s", testutils.WorkspaceResourceName)
-		}
+		var workspaceID uuid.UUID
+		if !testutils.TestContextOSS() {
+			workspaceResource, exists := s.RootModule().Resources[testutils.WorkspaceResourceName]
+			if !exists {
+				return fmt.Errorf("Resource not found in state: %s", testutils.WorkspaceResourceName)
+			}
 
-		workspaceID, _ := uuid.Parse(workspaceResource.Primary.ID)
+			workspaceID, _ = uuid.Parse(workspaceResource.Primary.ID)
+		}
 
 		// Initialize the client with the associated workspaceID
 		// NOTE: the accountID is inherited by the one set in the test environment

--- a/internal/provider/datasources/worker_metadata_test.go
+++ b/internal/provider/datasources/worker_metadata_test.go
@@ -2,7 +2,6 @@ package datasources_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -12,17 +11,14 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccWorkerMetadtata(workspace string) string {
-	aID := os.Getenv("PREFECT_CLOUD_ACCOUNT_ID")
-
+func fixtureAccWorkerMetadtata(workspace, workspaceIDArg string) string {
 	return fmt.Sprintf(`
 %s
 
 data "prefect_worker_metadata" "default" {
-  account_id = "%s"
-  workspace_id = prefect_workspace.test.id
+	%s
 }
-`, workspace, aID)
+`, workspace, workspaceIDArg)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
@@ -35,7 +31,7 @@ func TestAccDatasource_worker_metadata(t *testing.T) {
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: fixtureAccWorkerMetadtata(workspace.Resource),
+				Config: fixtureAccWorkerMetadtata(workspace.Resource, workspace.IDArg),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						datasourceName,

--- a/internal/provider/datasources/workspace_role_test.go
+++ b/internal/provider/datasources/workspace_role_test.go
@@ -19,6 +19,9 @@ data "prefect_workspace_role" "test" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccDatasource_workspace_role_defaults(t *testing.T) {
+	// Workspaces are not supportedin OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	dataSourceName := "data.prefect_workspace_role.test"
 
 	// Default workspace role names - these exist in every account

--- a/internal/provider/datasources/workspace_test.go
+++ b/internal/provider/datasources/workspace_test.go
@@ -32,6 +32,9 @@ data "prefect_workspace" "testdata" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccDatasource_workspace(t *testing.T) {
+	// Workspaces are not supportedin OSS.
+	testutils.SkipTestsIfOSS(t)
+
 	ephemeralWorkspace := testutils.NewEphemeralWorkspace()
 	dataSourceName := "data.prefect_workspace.testdata"
 

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -16,8 +16,13 @@ set -e
 # When all tests have been updated, this default list can be removed.
 # At that point, tests that are known not to be compatible with OSS will include
 # logic to be skipped if the target instance is OSS.
+#
+# Note: for automations, the resource test is incorrectly skipped in OSS and the
+# datasource testing in OSS needs to be properly implemented. This will happen
+# in a separate change.
 testsDefault="
 TestAccResource_*
+TestAccDatasource_*
 "
 
 tests=${1:-""}


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->

Adds OSS tests for datasources.

Related to https://linear.app/prefect/issue/PLA-191/run-acceptance-tests-against-prefect-server-in-docker-compose

### Testing

If you run `make testacc-oss`, only automations should fail:

```
$ make testacc-oss
... trimmed ...

=== FAIL: internal/provider/datasources TestAccDatasource_automation (15.52s)
    automation_test.go:294: Step 1/1 error: Error running apply: exit status 1

        Error: Error during create Automation

          with prefect_automation.terraformaccra21p0p6xg,
          on terraform_plugin_test.tf line 14, in resource "prefect_automation" "terraformaccra21p0p6xg":
          14: resource "prefect_automation" "terraformaccra21p0p6xg" {

        Could not create Automation, unexpected error: failed to create automation:
        http error: Post "http://localhost:4200/api/automations/": POST
        http://localhost:4200/api/automations/ giving up after 5 attempt(s):
        status_code=404, error=%!w(<nil>)

DONE 15 tests, 7 skipped, 1 failure in 16.825s
make: *** [testacc-oss] Error 1
```

This will be addressed in an upcoming PR.

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
