### PR TITLE
fix: warn on provider config, not error

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -99,7 +99,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	// Ensure that all configuration values passed in to provider are known
 	// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/terraform-concepts#unknown-values
 	if config.Endpoint.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
+		resp.Diagnostics.AddAttributeWarning(
 			path.Root("endpoint"),
 			"Unknown Prefect API Endpoint",
 			"The Prefect API Endpoint is not known at configuration time. "+
@@ -108,7 +108,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	}
 
 	if config.APIKey.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
+		resp.Diagnostics.AddAttributeWarning(
 			path.Root("api_key"),
 			"Unknown Prefect API Key",
 			"The Prefect API Key is not known at configuration time. "+
@@ -117,7 +117,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	}
 
 	if config.AccountID.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
+		resp.Diagnostics.AddAttributeWarning(
 			path.Root("account_id"),
 			"Unknown Prefect Account ID",
 			"The Prefect Account ID is not known at configuration time. "+
@@ -126,7 +126,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	}
 
 	if config.WorkspaceID.IsUnknown() {
-		resp.Diagnostics.AddAttributeError(
+		resp.Diagnostics.AddAttributeWarning(
 			path.Root("workspace_id"),
 			"Unknown Prefect Workspace ID",
 			"The Prefect Workspace ID is not known at configuration time. "+


### PR DESCRIPTION
### Summary


Emits a warning when provider configuration is not known at configuration time. This previously returned an error, which would block the plan from continuing. This was a problem when getting provider configuration from another resource.

Related to https://github.com/PrefectHQ/terraform-provider-prefect/pull/484

<!-- Add a brief description of your change here -->

### Testing

```terraform
terraform {
  required_version = ">= 1.11.0"
  required_providers {
    prefect = {
      source  = "registry.terraform.io/prefecthq/prefect"
      version = "~> 2.25.0"
    }

    random = {
      source  = "hashicorp/random"
      version = "~> 3.0"
    }
  }
}

resource "random_string" "example" {
  length = 16
}

# For a cloud instance
provider "prefect" {
  endpoint = "https://api.stg.prefect.dev"

  account_id   = "<account ID>"
  workspace_id = "<workspace ID>"

  api_key = random_string.example.result
}


resource "prefect_block" "test" {
  type_slug = "secret"
  name      = "test"
  data = jsonencode({
    "key" = "value"
  })
}
```

Apply the latest release of the Prefect Terraform provider and notice we hit an error:

```
╷
│ Error: Unknown Prefect API Key
│
│   with provider["registry.terraform.io/prefecthq/prefect"],
│   on main.tf line 27, in provider "prefect":
│   27:   api_key = random_string.example.result
│
│ The Prefect API Key is not known at configuration time. Potential
│ resolutions: target apply the source of the value first, set the value
│ statically in the configuration, set the PREFECT_API_KEY environment
│ variable, or remove the value.
```

Modify your `.terraformrc` to use the version from this PR branch and notice we only hit a warning:

```
│ Warning: Unknown Prefect API Key
│
│   with provider["registry.terraform.io/prefecthq/prefect"],
│   on main.tf line 27, in provider "prefect":
│   27:   api_key = random_string.example.result
│
│ The Prefect API Key is not known at configuration time. Potential
│ resolutions: target apply the source of the value first, set the value
│ statically in the configuration, set the PREFECT_API_KEY environment
│ variable, or remove the value.
```

(Note: with this specific example, we still end up hitting the error case because the value of the random password is still unknown at this time. The existing error text still applies: we could apply the random password first with `tf apply --target=random_string.example`, or hard-code the password).

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
