### PR TITLE
chore(tests): test automation resources and datasources against OSS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ testacc-dev-user:
 testacc-oss:
 	docker compose up -d
 	./scripts/testacc-oss $(TESTS)
+	docker compose down
 .PHONY: testacc-oss
 
 docs:

--- a/internal/provider/datasources/automation_test.go
+++ b/internal/provider/datasources/automation_test.go
@@ -10,21 +10,21 @@ import (
 )
 
 type automationFixtureConfig struct {
-	EphemeralWorkspace             string
-	EphemeralWorkspaceResourceName string
-	AutomationResourceName         string
+	Workspace              string
+	WorkspaceIDArg         string
+	AutomationResourceName string
 }
 
 func fixtureAccAutomationResourceEventTrigger(cfg automationFixtureConfig) string {
 	tmpl := `
-{{ .EphemeralWorkspace }}
+{{ .Workspace }}
 
 resource "prefect_automation" "{{ .AutomationResourceName }}" {
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+  {{ .WorkspaceIDArg }}
 
-	name         = "test-event-automation"
-	description  = "description for test-event-automation"
-	enabled      = true
+  name         = "test-event-automation"
+  description  = "description for test-event-automation"
+  enabled      = true
 
   trigger = {
     event = {
@@ -55,16 +55,16 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
       })
       job_variables = jsonencode({
         string_var = "value1"
-				int_var = 2
-				bool_var = true
+        int_var = 2
+        bool_var = true
       })
     }
   ]
 }
 
 data "prefect_automation" "{{ .AutomationResourceName }}" {
-	id = prefect_automation.{{ .AutomationResourceName }}.id
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+  id = prefect_automation.{{ .AutomationResourceName }}.id
+  {{ .WorkspaceIDArg }}
 }
 `
 
@@ -73,10 +73,10 @@ data "prefect_automation" "{{ .AutomationResourceName }}" {
 
 func fixtureAccAutomationResourceMetricTrigger(cfg automationFixtureConfig) string {
 	tmpl := `
-{{ .EphemeralWorkspace }}
+{{ .Workspace }}
 
 resource "prefect_automation" "{{ .AutomationResourceName }}" {
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+  {{ .WorkspaceIDArg }}
 
 	name         = "test-metric-automation"
 	description  = "description for test-metric-automation"
@@ -113,7 +113,7 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 
 data "prefect_automation" "{{ .AutomationResourceName }}" {
 	id = prefect_automation.{{ .AutomationResourceName }}.id
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+	{{ .WorkspaceIDArg }}
 }
 `
 
@@ -122,10 +122,10 @@ data "prefect_automation" "{{ .AutomationResourceName }}" {
 
 func fixtureAccAutomationResourceCompoundTrigger(cfg automationFixtureConfig) string {
 	tmpl := `
-{{ .EphemeralWorkspace }}
+{{ .Workspace }}
 
 resource "prefect_automation" "{{ .AutomationResourceName }}" {
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+	{{ .WorkspaceIDArg }}
 
 	name         = "test-compound-automation"
 	description  = "description for test-compound-automation"
@@ -185,7 +185,7 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 
 data "prefect_automation" "{{ .AutomationResourceName }}" {
 	id = prefect_automation.{{ .AutomationResourceName }}.id
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+	{{ .WorkspaceIDArg }}
 }
 `
 
@@ -194,10 +194,10 @@ data "prefect_automation" "{{ .AutomationResourceName }}" {
 
 func fixtureAccAutomationResourceSequenceTrigger(cfg automationFixtureConfig) string {
 	tmpl := `
-{{ .EphemeralWorkspace }}
+{{ .Workspace }}
 
 resource "prefect_automation" "{{ .AutomationResourceName }}" {
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+	{{ .WorkspaceIDArg }}
 
 	name         = "test-sequence-automation"
 	description  = "description for test-sequence-automation"
@@ -264,7 +264,7 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 
 data "prefect_automation" "{{ .AutomationResourceName }}" {
 	id = prefect_automation.{{ .AutomationResourceName }}.id
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+	{{ .WorkspaceIDArg }}
 }
 `
 
@@ -297,9 +297,9 @@ func TestAccDatasource_automation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fixtureAccAutomationResourceEventTrigger(automationFixtureConfig{
-					EphemeralWorkspace:             ephemeralWorkspace.Resource,
-					EphemeralWorkspaceResourceName: testutils.WorkspaceResourceName,
-					AutomationResourceName:         eventTriggerAutomationResourceName,
+					Workspace:              ephemeralWorkspace.Resource,
+					WorkspaceIDArg:         ephemeralWorkspace.IDArg,
+					AutomationResourceName: eventTriggerAutomationResourceName,
 				}),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNotNull(eventTriggerAutomationDataSourceNameAndPath, "id"),
@@ -316,9 +316,9 @@ func TestAccDatasource_automation(t *testing.T) {
 			},
 			{
 				Config: fixtureAccAutomationResourceMetricTrigger(automationFixtureConfig{
-					EphemeralWorkspace:             ephemeralWorkspace.Resource,
-					EphemeralWorkspaceResourceName: testutils.WorkspaceResourceName,
-					AutomationResourceName:         metricTriggerAutomationResourceName,
+					Workspace:              ephemeralWorkspace.Resource,
+					WorkspaceIDArg:         ephemeralWorkspace.IDArg,
+					AutomationResourceName: metricTriggerAutomationResourceName,
 				}),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNotNull(metricTriggerAutomationDataSourceNameAndPath, "id"),
@@ -335,9 +335,9 @@ func TestAccDatasource_automation(t *testing.T) {
 			},
 			{
 				Config: fixtureAccAutomationResourceCompoundTrigger(automationFixtureConfig{
-					EphemeralWorkspace:             ephemeralWorkspace.Resource,
-					EphemeralWorkspaceResourceName: testutils.WorkspaceResourceName,
-					AutomationResourceName:         compoundTriggerAutomationResourceName,
+					Workspace:              ephemeralWorkspace.Resource,
+					WorkspaceIDArg:         ephemeralWorkspace.IDArg,
+					AutomationResourceName: compoundTriggerAutomationResourceName,
 				}),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNotNull(compoundTriggerAutomationDataSourceNameAndPath, "id"),
@@ -354,9 +354,9 @@ func TestAccDatasource_automation(t *testing.T) {
 			},
 			{
 				Config: fixtureAccAutomationResourceSequenceTrigger(automationFixtureConfig{
-					EphemeralWorkspace:             ephemeralWorkspace.Resource,
-					EphemeralWorkspaceResourceName: testutils.WorkspaceResourceName,
-					AutomationResourceName:         sequenceTriggerAutomationResourceName,
+					Workspace:              ephemeralWorkspace.Resource,
+					WorkspaceIDArg:         ephemeralWorkspace.IDArg,
+					AutomationResourceName: sequenceTriggerAutomationResourceName,
 				}),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNotNull(sequenceTriggerAutomationDataSourceNameAndPath, "id"),

--- a/internal/provider/resources/automation_test.go
+++ b/internal/provider/resources/automation_test.go
@@ -16,17 +16,17 @@ import (
 )
 
 type automationFixtureConfig struct {
-	EphemeralWorkspace             string
-	EphemeralWorkspaceResourceName string
-	AutomationResourceName         string
+	Workspace              string
+	WorkspaceIDArg         string
+	AutomationResourceName string
 }
 
 func fixtureAccAutomationResourceEventTrigger(cfg automationFixtureConfig) string {
 	tmpl := `
-{{ .EphemeralWorkspace }}
+{{ .Workspace }}
 
 resource "prefect_automation" "{{ .AutomationResourceName }}" {
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+	{{ .WorkspaceIDArg }}
 
 	name         = "test-event-automation"
 	description  = "description for test-event-automation"
@@ -84,10 +84,10 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 
 func fixtureAccAutomationResourceMetricTrigger(cfg automationFixtureConfig) string {
 	tmpl := `
-{{ .EphemeralWorkspace }}
+{{ .Workspace }}
 
 resource "prefect_automation" "{{ .AutomationResourceName }}" {
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+	{{ .WorkspaceIDArg }}
 
 	name         = "test-metric-automation"
 	description  = "description for test-metric-automation"
@@ -128,10 +128,10 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 
 func fixtureAccAutomationResourceCompoundTrigger(cfg automationFixtureConfig) string {
 	tmpl := `
-{{ .EphemeralWorkspace }}
+{{ .Workspace }}
 
 resource "prefect_automation" "{{ .AutomationResourceName }}" {
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+	{{ .WorkspaceIDArg }}
 
 	name         = "test-compound-automation"
 	description  = "description for test-compound-automation"
@@ -208,10 +208,10 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 
 func fixtureAccAutomationResourceSequenceTrigger(cfg automationFixtureConfig) string {
 	tmpl := `
-{{ .EphemeralWorkspace }}
+{{ .Workspace }}
 
 resource "prefect_automation" "{{ .AutomationResourceName }}" {
-	workspace_id = {{ .EphemeralWorkspaceResourceName }}.id
+	{{ .WorkspaceIDArg }}
 
 	name         = "test-sequence-automation"
 	description  = "description for test-sequence-automation"
@@ -282,9 +282,6 @@ resource "prefect_automation" "{{ .AutomationResourceName }}" {
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_automation(t *testing.T) {
-	// Automations are not supported in OSS.
-	testutils.SkipTestsIfOSS(t)
-
 	eventTriggerAutomationResourceName := testutils.NewRandomPrefixedString()
 	eventTriggerAutomationResourceNameAndPath := fmt.Sprintf("prefect_automation.%s", eventTriggerAutomationResourceName)
 
@@ -304,9 +301,9 @@ func TestAccResource_automation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fixtureAccAutomationResourceEventTrigger(automationFixtureConfig{
-					EphemeralWorkspace:             ephemeralWorkspace.Resource,
-					EphemeralWorkspaceResourceName: testutils.WorkspaceResourceName,
-					AutomationResourceName:         eventTriggerAutomationResourceName,
+					Workspace:              ephemeralWorkspace.Resource,
+					WorkspaceIDArg:         ephemeralWorkspace.IDArg,
+					AutomationResourceName: eventTriggerAutomationResourceName,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAutomationResourceExists(eventTriggerAutomationResourceNameAndPath, &api.Automation{}),
@@ -339,9 +336,9 @@ func TestAccResource_automation(t *testing.T) {
 			},
 			{
 				Config: fixtureAccAutomationResourceMetricTrigger(automationFixtureConfig{
-					EphemeralWorkspace:             ephemeralWorkspace.Resource,
-					EphemeralWorkspaceResourceName: testutils.WorkspaceResourceName,
-					AutomationResourceName:         metricTriggerAutomationResourceName,
+					Workspace:              ephemeralWorkspace.Resource,
+					WorkspaceIDArg:         ephemeralWorkspace.IDArg,
+					AutomationResourceName: metricTriggerAutomationResourceName,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAutomationResourceExists(metricTriggerAutomationResourceNameAndPath, &api.Automation{}),
@@ -372,9 +369,9 @@ func TestAccResource_automation(t *testing.T) {
 			},
 			{
 				Config: fixtureAccAutomationResourceCompoundTrigger(automationFixtureConfig{
-					EphemeralWorkspace:             ephemeralWorkspace.Resource,
-					EphemeralWorkspaceResourceName: testutils.WorkspaceResourceName,
-					AutomationResourceName:         compoundTriggerAutomationResourceName,
+					Workspace:              ephemeralWorkspace.Resource,
+					WorkspaceIDArg:         ephemeralWorkspace.IDArg,
+					AutomationResourceName: compoundTriggerAutomationResourceName,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAutomationResourceExists(compoundTriggerAutomationResourceNameAndPath, &api.Automation{}),
@@ -414,9 +411,9 @@ func TestAccResource_automation(t *testing.T) {
 			},
 			{
 				Config: fixtureAccAutomationResourceSequenceTrigger(automationFixtureConfig{
-					EphemeralWorkspace:             ephemeralWorkspace.Resource,
-					EphemeralWorkspaceResourceName: testutils.WorkspaceResourceName,
-					AutomationResourceName:         sequenceTriggerAutomationResourceName,
+					Workspace:              ephemeralWorkspace.Resource,
+					WorkspaceIDArg:         ephemeralWorkspace.IDArg,
+					AutomationResourceName: sequenceTriggerAutomationResourceName,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAutomationResourceExists(sequenceTriggerAutomationResourceNameAndPath, &api.Automation{}),

--- a/internal/provider/resources/automation_test.go
+++ b/internal/provider/resources/automation_test.go
@@ -306,7 +306,7 @@ func TestAccResource_automation(t *testing.T) {
 				Config: fixtureAccAutomationResourceEventTrigger(automationFixtureConfig{
 					Workspace:              ephemeralWorkspace.Resource,
 					WorkspaceIDArg:         ephemeralWorkspace.IDArg,
-					Deployment:             fixtureAccAutomationDeployment(ephemeralWorkspace.IDArg),
+					Deployment:             testutils.FixtureAccAutomationDeployment(ephemeralWorkspace.IDArg),
 					AutomationResourceName: eventTriggerAutomationResourceName,
 				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -520,37 +520,4 @@ func testAccCheckAutomationResourceExists(automationResourceName string, automat
 
 		return nil
 	}
-}
-
-func fixtureAccAutomationDeployment(workspaceIDArg string) string {
-	return fmt.Sprintf(`
-resource "prefect_block" "test_block" {
-	name = "test-block"
-	type_slug = "github-repository"
-
-	data = jsonencode({
-		"repository_url": "https://github.com/foo/bar",
-		"reference": "main"
-	})
-
-	%s
-}
-
-resource "prefect_flow" "test_flow" {
-	name = "test-flow"
-
-	%s
-}
-
-resource "prefect_deployment" "test_deployment" {
-	name = "test-deployment"
-	description = "Test description"
-	flow_id = prefect_flow.test_flow.id
-	storage_document_id = prefect_block.test_block.id
-
-	depends_on = [prefect_flow.test_flow]
-
-	%s
-}
-`, workspaceIDArg, workspaceIDArg, workspaceIDArg)
 }

--- a/internal/testutils/fixture.go
+++ b/internal/testutils/fixture.go
@@ -1,0 +1,40 @@
+package testutils
+
+import "fmt"
+
+// FixtureAccAutomationWorkspace creates a minimal block, flow, and deployment
+// resource.
+//
+// It is used in acceptance tests that depend on these resources, like automations.
+func FixtureAccAutomationDeployment(workspaceIDArg string) string {
+	return fmt.Sprintf(`
+resource "prefect_block" "test_block" {
+	name = "test-block"
+	type_slug = "github-repository"
+
+	data = jsonencode({
+		"repository_url": "https://github.com/foo/bar",
+		"reference": "main"
+	})
+
+	%s
+}
+
+resource "prefect_flow" "test_flow" {
+	name = "test-flow"
+
+	%s
+}
+
+resource "prefect_deployment" "test_deployment" {
+	name = "test-deployment"
+	description = "Test description"
+	flow_id = prefect_flow.test_flow.id
+	storage_document_id = prefect_block.test_block.id
+
+	depends_on = [prefect_flow.test_flow]
+
+	%s
+}
+`, workspaceIDArg, workspaceIDArg, workspaceIDArg)
+}

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -9,22 +9,6 @@ set -e
 # Then, run the OSS tests:
 #   ./scripts/testacc-oss [tests]
 
-# This is the list of tests that will run if a specific test is not provided.
-# This list is required because only certain tests have adjusted their logic to
-# work as expected on OSS.
-#
-# When all tests have been updated, this default list can be removed.
-# At that point, tests that are known not to be compatible with OSS will include
-# logic to be skipped if the target instance is OSS.
-#
-# Note: for automations, the resource test is incorrectly skipped in OSS and the
-# datasource testing in OSS needs to be properly implemented. This will happen
-# in a separate change.
-testsDefault="
-TestAccResource_*
-TestAccDatasource_*
-"
-
 tests=${1:-""}
 
 function run() {
@@ -36,10 +20,7 @@ function run() {
 
 if [ "${tests}" == "" ]; then
   echo "Running all tests..."
-  for test in ${testsDefault}; do
-    echo "Running test: ${test}"
-    run ${test}
-  done
+  run
 else
   echo "Running specified tests: ${tests}"
   run "^${tests}$"


### PR DESCRIPTION
### Summary

Tests automation resources and datasources against Prefect OSS.

Related to https://linear.app/prefect/issue/PLA-191/run-acceptance-tests-against-prefect-server-in-docker-compose

### Testing

```
$ make testacc-oss
docker compose up -d
[+] Running 2/2
 ✔ Network automation-oss-tests_default      Created                                                                                                                                                0.2s
 ✔ Container automation-oss-tests-prefect-1  Started                                                                                                                                                0.3s
./scripts/testacc-oss ""
Running all tests...
∅  .
∅  internal/client
∅  internal/provider/customtypes
✓  internal/api (292ms)
∅  internal/provider/helpers
∅  internal/testutils
∅  internal/utils
∅  scripts
✓  internal/provider (445ms)
∅  internal/sweep (885ms)
✓  internal/provider/datasources (12.899s)
✓  internal/provider/resources (22.154s)

=== Skipped
=== SKIP: internal/provider/datasources TestAccDatasource_account_member (0.00s)
    account_member_test.go:23: skipping test in OSS mode

=== SKIP: internal/provider/datasources TestAccDatasource_account_role_defaults (0.00s)
    account_role_test.go:23: skipping test in OSS mode

=== SKIP: internal/provider/datasources TestAccDatasource_account (0.00s)
    account_test.go:24: skipping test in OSS mode

=== SKIP: internal/provider/datasources TestAccDatasource_service_account (0.00s)
    service_account_test.go:18: skipping test in OSS mode

=== SKIP: internal/provider/datasources TestAccDatasource_team (0.00s)
    team_test.go:24: skipping test in OSS mode

=== SKIP: internal/provider/datasources TestAccDatasource_workspace_role_defaults (0.00s)
    workspace_role_test.go:23: skipping test in OSS mode

=== SKIP: internal/provider/datasources TestAccDatasource_workspace (0.00s)
    workspace_test.go:36: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_account_member (0.00s)
    account_member_test.go:42: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_account (0.00s)
    account_test.go:14: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_deployment_access (0.00s)
    deployment_access_test.go:82: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_service_account (0.00s)
    service_account_test.go:80: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_resource_sla (0.00s)
    sla_test.go:111: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_team_access_service_account (0.00s)
    team_access_test.go:37: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_team_access_user (0.00s)
    team_access_test.go:85: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_team (0.00s)
    team_test.go:24: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_user_api_key (0.00s)
    user_api_key_test.go:36: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_webhook (0.00s)
    webhooks_test.go:73: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_work_pool_access (0.00s)
    work_pool_access_test.go:81: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_bot_workspace_access (0.00s)
    workspace_access_test.go:54: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_team_workspace_access (0.00s)
    workspace_access_test.go:137: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_workspace_role (0.00s)
    workspace_role_test.go:39: skipping test in OSS mode

=== SKIP: internal/provider/resources TestAccResource_workspace (0.00s)
    workspace_test.go:19: skipping test in OSS mode

DONE 68 tests, 22 skipped in 24.399s
docker compose down
[+] Running 2/2
 ✔ Container automation-oss-tests-prefect-1  Removed                                                                                                                                                1.4s
 ✔ Network automation-oss-tests_default      Removed
```

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
