### PR TITLE
fix(work pools datasource): implement ID filter

### DIFF
--- a/internal/api/work_pools.go
+++ b/internal/api/work_pools.go
@@ -9,7 +9,7 @@ import (
 // WorkPoolsClient is a client for working with work pools.
 type WorkPoolsClient interface {
 	Create(ctx context.Context, data WorkPoolCreate) (*WorkPool, error)
-	List(ctx context.Context, filter WorkPoolFilter) ([]*WorkPool, error)
+	List(ctx context.Context, ids []string) ([]*WorkPool, error)
 	Get(ctx context.Context, name string) (*WorkPool, error)
 	Update(ctx context.Context, name string, data WorkPoolUpdate) error
 	Delete(ctx context.Context, name string) error
@@ -47,5 +47,9 @@ type WorkPoolUpdate struct {
 
 // WorkPoolFilter defines filters when searching for work pools.
 type WorkPoolFilter struct {
-	Any []uuid.UUID `json:"any_"`
+	WorkPools struct {
+		ID struct {
+			Any []string `json:"any_"`
+		} `json:"id"`
+	} `json:"work_pools"`
 }

--- a/internal/client/work_pools.go
+++ b/internal/client/work_pools.go
@@ -63,7 +63,12 @@ func (c *WorkPoolsClient) Create(ctx context.Context, data api.WorkPoolCreate) (
 }
 
 // List returns a list of work pools matching filter criteria.
-func (c *WorkPoolsClient) List(ctx context.Context, filter api.WorkPoolFilter) ([]*api.WorkPool, error) {
+func (c *WorkPoolsClient) List(ctx context.Context, ids []string) ([]*api.WorkPool, error) {
+	filter := &api.WorkPoolFilter{}
+	if len(ids) > 0 {
+		filter.WorkPools.ID.Any = ids
+	}
+
 	cfg := requestConfig{
 		method:       http.MethodPost,
 		url:          c.routePrefix + "/filter",

--- a/internal/provider/datasources/work_pool_test.go
+++ b/internal/provider/datasources/work_pool_test.go
@@ -39,6 +39,11 @@ resource "prefect_work_pool" "test" {
 
 data "prefect_work_pools" "test" {
 	%s
+
+	filter_any = [
+	  prefect_work_pool.test.id,
+	]
+
 	depends_on = [prefect_work_pool.test]
 }
 `, workspace, name, workspaceIDArg, workspaceIDArg)

--- a/internal/provider/datasources/work_pools.go
+++ b/internal/provider/datasources/work_pools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -117,9 +118,20 @@ func (d *WorkPoolsDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	filter := api.WorkPoolFilter{}
+	filters := make([]string, 0, len(model.FilterAny.Elements()))
 
-	pools, err := client.List(ctx, filter)
+	for _, filter := range model.FilterAny.Elements() {
+		uuid, err := uuid.Parse(filter.String())
+		if err != nil {
+			resp.Diagnostics.AddAttributeError(path.Root("filter_any"), "Invalid UUID", fmt.Sprintf("Invalid UUID: %s", err))
+
+			return
+		}
+
+		filters = append(filters, uuid.String())
+	}
+
+	pools, err := client.List(ctx, filters)
 	if err != nil {
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Work Pools", "list", err))
 

--- a/internal/provider/datasources/work_pools.go
+++ b/internal/provider/datasources/work_pools.go
@@ -121,14 +121,18 @@ func (d *WorkPoolsDataSource) Read(ctx context.Context, req datasource.ReadReque
 	filters := make([]string, 0, len(model.FilterAny.Elements()))
 
 	for _, filter := range model.FilterAny.Elements() {
-		uuid, err := uuid.Parse(filter.String())
+		u, err := uuid.Parse(filter.String())
 		if err != nil {
-			resp.Diagnostics.AddAttributeError(path.Root("filter_any"), "Invalid UUID", fmt.Sprintf("Invalid UUID: %s", err))
+			resp.Diagnostics.AddAttributeError(
+				path.Root("filter_any"),
+				"Error parsing work pool %s ID",
+				fmt.Sprintf("Could not parse work pool ID %s to UUID, unexpected error: %s", u.String(), err.Error()),
+			)
 
 			return
 		}
 
-		filters = append(filters, uuid.String())
+		filters = append(filters, u.String())
 	}
 
 	pools, err := client.List(ctx, filters)


### PR DESCRIPTION
### Summary

The ID filter was present, but was not actually implemented in the resource or client logic. This was causing failures in the OSS tests because the nondeterministic order of work pools in the datasource could lead to race conditions.

This uses the filter feature to get the expected work pool by ID, and ensures the filter feature is properly implemented.

Related to https://linear.app/prefect/issue/PLA-191/run-acceptance-tests-against-prefect-server-in-docker-compose

Should unblock https://github.com/PrefectHQ/terraform-provider-prefect/pull/502

Note: the [API docs](https://app.prefect.cloud/api/docs#tag/Work-Pools/operation/read_work_pools_api_accounts__account_id__workspaces__workspace_id__work_pools_filter_post) support filtering by ID as well as name and work pool type. We can implement those in the future if there's interest.

<!-- Add a brief description of your change here -->

### Testing

```
$ make testacc-oss
docker compose up -d
[+] Running 2/2
 ✔ Network work-pool-filter_default      Created                                                                                                                                                                              0.1s
 ✔ Container work-pool-filter-prefect-1  Started                                                                                                                                                                              0.3s
./scripts/testacc-oss ""
Running all tests...
∅  .
∅  internal/client
∅  internal/provider/customtypes
✓  internal/api (171ms)
✓  internal/provider (255ms)
∅  internal/provider/helpers
∅  internal/testutils
∅  internal/utils
∅  scripts
∅  internal/sweep (701ms)
✓  internal/provider/datasources (17.364s)
✓  internal/provider/resources (22.915s)

=== Skipped
=== SKIP: internal/provider/datasources TestAccDatasource_account_member (0.00s)
    account_member_test.go:23: skipping test in OSS mode

... more skips ...

=== SKIP: internal/provider/resources TestAccResource_workspace (0.00s)
    workspace_test.go:19: skipping test in OSS mode

DONE 68 tests, 22 skipped in 24.224s
```

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
