### PR TITLE
fix(deployments): deprecate `catchup` field

### DIFF
--- a/docs/resources/deployment_schedule.md
+++ b/docs/resources/deployment_schedule.md
@@ -44,7 +44,6 @@ resource "prefect_deployment_schedule" "test_interval" {
   deployment_id = prefect_deployment.test.id
 
   active   = true
-  catchup  = false
   timezone = "America/New_York"
 
   # Interval-specific fields
@@ -57,7 +56,6 @@ resource "prefect_deployment_schedule" "test_cron" {
   deployment_id = prefect_deployment.test.id
 
   active   = true
-  catchup  = false
   timezone = "America/New_York"
 
   # Cron-specific fields
@@ -70,7 +68,6 @@ resource "prefect_deployment_schedule" "test_rrule" {
   deployment_id = prefect_deployment.test.id
 
   active   = true
-  catchup  = false
   timezone = "America/New_York"
 
   # RRule-specific fields
@@ -90,7 +87,7 @@ resource "prefect_deployment_schedule" "test_rrule" {
 - `account_id` (String) Account ID (UUID)
 - `active` (Boolean) Whether or not the schedule is active.
 - `anchor_date` (String) The anchor date of the schedule.
-- `catchup` (Boolean) (Cloud only) Whether or not a worker should catch up on Late runs for the schedule.
+- `catchup` (Boolean, Deprecated) (Cloud only) Whether or not a worker should catch up on Late runs for the schedule.
 - `cron` (String) The cron expression of the schedule.
 - `day_or` (Boolean) Control croniter behavior for handling day and day_of_week entries.
 - `id` (String) Deployment Schedule ID (UUID)

--- a/examples/resources/prefect_deployment_schedule/resource.tf
+++ b/examples/resources/prefect_deployment_schedule/resource.tf
@@ -21,7 +21,6 @@ resource "prefect_deployment_schedule" "test_interval" {
   deployment_id = prefect_deployment.test.id
 
   active   = true
-  catchup  = false
   timezone = "America/New_York"
 
   # Interval-specific fields
@@ -34,7 +33,6 @@ resource "prefect_deployment_schedule" "test_cron" {
   deployment_id = prefect_deployment.test.id
 
   active   = true
-  catchup  = false
   timezone = "America/New_York"
 
   # Cron-specific fields
@@ -47,7 +45,6 @@ resource "prefect_deployment_schedule" "test_rrule" {
   deployment_id = prefect_deployment.test.id
 
   active   = true
-  catchup  = false
   timezone = "America/New_York"
 
   # RRule-specific fields

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -146,7 +146,6 @@ For more information, see [schedule flow runs](https://docs.prefect.io/v3/automa
 			"catchup": schema.BoolAttribute{
 				Description:        "(Cloud only) Whether or not a worker should catch up on Late runs for the schedule.",
 				Optional:           true,
-				Computed:           true,
 				DeprecationMessage: "Remove this attribute's configuration as it no longer is used and the attribute will be removed in the next major version of the provider.",
 			},
 			// Timezone is a common field for all schedule kinds.

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -144,9 +144,10 @@ For more information, see [schedule flow runs](https://docs.prefect.io/v3/automa
 				DeprecationMessage: "Remove this attribute's configuration as it no longer is used and the attribute will be removed in the next major version of the provider.",
 			},
 			"catchup": schema.BoolAttribute{
-				Description: "(Cloud only) Whether or not a worker should catch up on Late runs for the schedule.",
-				Optional:    true,
-				Computed:    true,
+				Description:        "(Cloud only) Whether or not a worker should catch up on Late runs for the schedule.",
+				Optional:           true,
+				Computed:           true,
+				DeprecationMessage: "Remove this attribute's configuration as it no longer is used and the attribute will be removed in the next major version of the provider.",
 			},
 			// Timezone is a common field for all schedule kinds.
 			"timezone": schema.StringAttribute{
@@ -206,7 +207,6 @@ func (r *DeploymentScheduleResource) Create(ctx context.Context, req resource.Cr
 	cfgCreate := []api.DeploymentSchedulePayload{
 		{
 			Active:           plan.Active.ValueBoolPointer(),
-			Catchup:          plan.Catchup.ValueBool(),
 			MaxScheduledRuns: plan.MaxScheduledRuns.ValueFloat32(),
 			Schedule: api.Schedule{
 				AnchorDate: plan.AnchorDate.ValueString(),
@@ -302,7 +302,6 @@ func (r *DeploymentScheduleResource) Update(ctx context.Context, req resource.Up
 
 	cfgUpdate := api.DeploymentSchedulePayload{
 		Active:           plan.Active.ValueBoolPointer(),
-		Catchup:          plan.Catchup.ValueBool(),
 		MaxScheduledRuns: plan.MaxScheduledRuns.ValueFloat32(),
 		Schedule: api.Schedule{
 			AnchorDate: plan.AnchorDate.ValueString(),
@@ -382,7 +381,6 @@ func copyScheduleModelToResourceModel(schedule *api.DeploymentSchedule, model *D
 
 	model.Active = types.BoolPointerValue(schedule.Active)
 
-	model.Catchup = types.BoolValue(schedule.Catchup)
 	model.MaxScheduledRuns = types.Float32Value(schedule.MaxScheduledRuns)
 
 	model.Timezone = types.StringValue(schedule.Schedule.Timezone)

--- a/internal/provider/resources/deployment_schedule_test.go
+++ b/internal/provider/resources/deployment_schedule_test.go
@@ -17,7 +17,6 @@ type fixtureConfig struct {
 	WorkspaceResource     string
 	WorkspaceResourceName string
 	WorkspaceIDArg        string
-	CatchupArg            string
 }
 
 func fixtureAccDeploymentScheduleInterval(cfg fixtureConfig) string {
@@ -41,7 +40,6 @@ resource "prefect_deployment_schedule" "test" {
 	deployment_id = prefect_deployment.test.id
 
 	active = true
-	{{.CatchupArg}}
 	timezone = "America/New_York"
 
 	interval = 30
@@ -74,7 +72,6 @@ resource "prefect_deployment_schedule" "test" {
 
 	# Update these values
 	active = false
-	{{.CatchupArg}}
 	timezone = "America/Chicago"
 
 	interval = 30
@@ -196,21 +193,6 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 	stateChecksForIntervalUpdate := []statecheck.StateCheck{
 		testutils.ExpectKnownValueBool(resourceName, "active", false),
 		testutils.ExpectKnownValue(resourceName, "timezone", "America/Chicago"),
-	}
-
-	if !testutils.TestContextOSS() {
-		fixtureCfg.CatchupArg = "catchup = false"
-		fixtureCfgUpdate.CatchupArg = "catchup = true"
-
-		stateChecksForInterval = append(
-			stateChecksForInterval,
-			testutils.ExpectKnownValueBool(resourceName, "catchup", false),
-		)
-
-		stateChecksForIntervalUpdate = append(
-			stateChecksForIntervalUpdate,
-			testutils.ExpectKnownValueBool(resourceName, "catchup", true),
-		)
 	}
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
### Summary

The `catchup` field has been superseded by concurrency strategy: https://docs.prefect.io/v3/deploy/index#concurrency-limiting

Related to https://linear.app/prefect/issue/PLA-1428/cycle-18-catch-all

Will be removed in https://linear.app/prefect/issue/PLA-1372/remove-deprecated-fields-in-next-major-upgrade

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
