### PR TITLE
fix: force replacement when flow name is updated

### DIFF
--- a/internal/provider/resources/flow.go
+++ b/internal/provider/resources/flow.go
@@ -118,6 +118,9 @@ func (r *FlowResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"name": schema.StringAttribute{
 				Description: "Name of the flow",
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 
 			"tags": schema.ListAttribute{


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->
resolves https://github.com/PrefectHQ/terraform-provider-prefect/issues/512

the Prefect API doesn't support updating a Flow's name on the `PATCH /flows/{id}` [endpoint](https://app.prefect.cloud/api/docs#tag/Flows/operation/update_flow_api_accounts__account_id__workspaces__workspace_id__flows__id__patch)

![image](https://github.com/user-attachments/assets/ab325dc7-489c-4517-bbba-9205c65768c6)

That means that the API will always return the same `name` value, which will cause a state conflict on the `Update()` operation

In this PR, we'll add the `RequiresReplace()` string plan modifier on the `Name` attribute for the `prefect_flow` resource

```hcl
resource "prefect_flow" "rename" {
  name = "name-1"
}
```
```
➜ terraform apply --auto-approve

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # prefect_flow.rename will be created
  + resource "prefect_flow" "rename" {
      + created = (known after apply)
      + id      = (known after apply)
      + name    = "name-1"
      + tags    = []
      + updated = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
prefect_flow.rename: Creating...
prefect_flow.rename: Creation complete after 1s [id=dbf1ec0f-cd41-429c-85cb-f3060153ce68]
```

then update the name

```hcl
resource "prefect_flow" "rename" {
  name = "name-2"
}
```
```
➜ terraform apply --auto-approve

prefect_flow.rename: Refreshing state... [id=dbf1ec0f-cd41-429c-85cb-f3060153ce68]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # prefect_flow.rename must be replaced
-/+ resource "prefect_flow" "rename" {
      ~ created = "2025-06-03T03:17:42Z" -> (known after apply)
      ~ id      = "dbf1ec0f-cd41-429c-85cb-f3060153ce68" -> (known after apply)
      ~ name    = "name-1" -> "name-2" # forces replacement
        tags    = []
      ~ updated = "2025-06-03T03:17:45Z" -> (known after apply)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
prefect_flow.rename: Destroying... [id=dbf1ec0f-cd41-429c-85cb-f3060153ce68]
prefect_flow.rename: Destruction complete after 1s
prefect_flow.rename: Creating...
prefect_flow.rename: Creation complete after 0s [id=69ad562d-e713-451e-8b24-f42208d1c87d]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
