### PR TITLE
enhancement: remove resource from state on 404s

### DIFF
--- a/internal/provider/helpers/errors.go
+++ b/internal/provider/helpers/errors.go
@@ -1,0 +1,11 @@
+package helpers
+
+import "strings"
+
+const (
+	Err404 = "status_code=404"
+)
+
+func Is404Error(err error) bool {
+	return strings.Contains(err.Error(), Err404)
+}

--- a/internal/provider/resources/automation_resource.go
+++ b/internal/provider/resources/automation_resource.go
@@ -145,6 +145,14 @@ func (r *AutomationResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	automation, err := client.Get(ctx, automationID)
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Automation", "get", err))
 
 		return

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -311,6 +311,15 @@ func (r *BlockResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	block, err := client.Get(ctx, blockID)
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Block", "get", err))
 
 		return

--- a/internal/provider/resources/block_access.go
+++ b/internal/provider/resources/block_access.go
@@ -193,6 +193,15 @@ func (r *BlockAccessResource) Read(ctx context.Context, req resource.ReadRequest
 
 	_, err = client.GetAccess(ctx, state.BlockID.ValueUUID())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Block Document", "Get Access", err))
 
 		return

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -758,6 +758,15 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error refreshing deployment state",
 			fmt.Sprintf("Could not read Deployment, unexpected error: %s", err.Error()),

--- a/internal/provider/resources/deployment_access.go
+++ b/internal/provider/resources/deployment_access.go
@@ -229,6 +229,15 @@ func (r *DeploymentAccessResource) Read(ctx context.Context, req resource.ReadRe
 
 	_, err = client.Read(ctx, state.DeploymentID.ValueUUID())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Deployment Access", "read", err))
 
 		return

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -261,6 +261,15 @@ func (r *DeploymentScheduleResource) Read(ctx context.Context, req resource.Read
 
 	schedules, err := client.Read(ctx, state.DeploymentID.ValueUUID())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Deployment Schedule", "read", err))
 
 		return

--- a/internal/provider/resources/flow.go
+++ b/internal/provider/resources/flow.go
@@ -231,6 +231,15 @@ func (r *FlowResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error refreshing flow state",
 			fmt.Sprintf("Could not read Flow, unexpected error: %s", err.Error()),

--- a/internal/provider/resources/global_concurrency_limit.go
+++ b/internal/provider/resources/global_concurrency_limit.go
@@ -248,6 +248,15 @@ func (r *GlobalConcurrencyLimitResource) Read(ctx context.Context, req resource.
 
 	globalConcurrencyLimit, err := client.Read(ctx, state.ID.ValueString())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Global Concurrency Limit", "read", err))
 
 		return

--- a/internal/provider/resources/service_account.go
+++ b/internal/provider/resources/service_account.go
@@ -345,6 +345,15 @@ func (r *ServiceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Service Account", operation, err))
 
 		return

--- a/internal/provider/resources/task_run_concurrency_limit.go
+++ b/internal/provider/resources/task_run_concurrency_limit.go
@@ -213,6 +213,15 @@ func (r *TaskRunConcurrencyLimitResource) Read(ctx context.Context, req resource
 
 	taskRunConcurrencyLimit, err := client.Read(ctx, state.ID.ValueString())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Task Run Concurrency Limit", "get", err))
 
 		return

--- a/internal/provider/resources/team.go
+++ b/internal/provider/resources/team.go
@@ -169,6 +169,15 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	team, err := teamClient.Read(ctx, plan.ID.ValueString())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Team", "read", err))
 
 		return

--- a/internal/provider/resources/team_access.go
+++ b/internal/provider/resources/team_access.go
@@ -160,6 +160,15 @@ func (r *TeamAccessResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	teamAccess, err := client.Read(ctx, plan.TeamID.ValueUUID(), plan.MemberID.ValueUUID(), plan.MemberActorID.ValueUUID())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Team Access", "read", err))
 
 		return

--- a/internal/provider/resources/user_api_key.go
+++ b/internal/provider/resources/user_api_key.go
@@ -204,6 +204,15 @@ func (r *UserAPIKeyResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	apiKey, err := userClient.ReadAPIKey(ctx, state.UserID.ValueString(), state.ID.ValueString())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("User API Key", "read", err))
 
 		return

--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -385,6 +385,15 @@ func (r *VariableResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Variable", "get", err))
 
 		return

--- a/internal/provider/resources/webhooks.go
+++ b/internal/provider/resources/webhooks.go
@@ -243,6 +243,15 @@ func (r *WebhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Webhook", "get", err))
 
 		return

--- a/internal/provider/resources/work_pool.go
+++ b/internal/provider/resources/work_pool.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"context"
 	"encoding/json"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -274,10 +273,7 @@ func (r *WorkPoolResource) Read(ctx context.Context, req resource.ReadRequest, r
 		// If the remote object does not exist, we can remove it from TF state
 		// so that the framework can queue up a new Create.
 		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
-		//
-		// NOTE: as a workaround, we encode + check this status code string on the error object.
-		// See `checkRetryPolicy` in `internal/client/client.go` for more details.
-		if strings.Contains(err.Error(), "status_code=404") {
+		if helpers.Is404Error(err) {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/resources/work_pool_access.go
+++ b/internal/provider/resources/work_pool_access.go
@@ -227,6 +227,15 @@ func (r *WorkPoolAccessResource) Read(ctx context.Context, req resource.ReadRequ
 
 	_, err = client.Read(ctx, state.WorkPoolName.ValueString())
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Work Pool Access", "read", err))
 
 		return

--- a/internal/provider/resources/work_queue.go
+++ b/internal/provider/resources/work_queue.go
@@ -231,10 +231,7 @@ func (r *WorkQueueResource) Read(ctx context.Context, req resource.ReadRequest, 
 		// If the remote object does not exist, we can remove it from TF state
 		// so that the framework can queue up a new Create.
 		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
-		//
-		// NOTE: as a workaround, we encode + check this status code string on the error object.
-		// See `checkRetryPolicy` in `internal/client/client.go` for more details.
-		if strings.Contains(err.Error(), "status_code=404") {
+		if helpers.Is404Error(err) {
 			resp.State.RemoveResource(ctx)
 
 			return

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -237,6 +237,15 @@ func (r *WorkspaceResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Error refreshing Workspace state",
 			fmt.Sprintf("Could not read Workspace, unexpected error: %s", err.Error()),

--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -199,6 +199,15 @@ func (r *WorkspaceAccessResource) Read(ctx context.Context, req resource.ReadReq
 
 	workspaceAccess, err := client.Get(ctx, accessorType, accessID)
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace Access", "read", err))
 
 		return

--- a/internal/provider/resources/workspace_role.go
+++ b/internal/provider/resources/workspace_role.go
@@ -233,6 +233,15 @@ func (r *WorkspaceRoleResource) Read(ctx context.Context, req resource.ReadReque
 
 	role, err := client.Get(ctx, roleID)
 	if err != nil {
+		// If the remote object does not exist, we can remove it from TF state
+		// so that the framework can queue up a new Create.
+		// https://discuss.hashicorp.com/t/recreate-a-resource-in-a-case-of-manual-deletion/66375/3
+		if helpers.Is404Error(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace Role", "get", err))
 
 		return


### PR DESCRIPTION
### Summary

<!-- Add a brief description of your change here -->
resolves https://linear.app/prefect/issue/PLA-1229/self-healing-behavior-and-resource-fixing

for _**most**_ resources, we add a helper to check if:
1. on the Read() operation
2. the call fails (and exhausts retries)
3. and the final status code is a 404
4. remove the resource from State

This will enqueue a new Create() operation

This PR addresses the philosophical concern raised in https://github.com/PrefectHQ/terraform-provider-prefect/issues/260#issuecomment-2900639384, which is that Terraform Providers should self-correct if the remote object is destroyed outside of the TF lifecycle

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
