### PR TITLE
fix: send in correct error code after check for nil

### DIFF
--- a/internal/provider/datasources/deployment.go
+++ b/internal/provider/datasources/deployment.go
@@ -290,7 +290,7 @@ func (d *deploymentDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	}
 
 	if getErr != nil {
-		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Deployment", operation, err))
+		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Deployment", operation, getErr))
 
 		return
 	}


### PR DESCRIPTION
### Summary

We were getting a panic code with a stack trace. Following the stacktrace showed that after a check for nil, it was passing in the wrong error.

### Requirements

#### General

- [X] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [X] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [X] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
