### PR TITLE
fix: add context-aware 404 retry logic for DELETE operations

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -191,17 +191,10 @@ func checkRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool
 
 	// Context-aware 404 handling: Skip retries for DELETE operations.
 	// This prevents timing issues in acceptance tests during post-destroy plans.
+	//
+	// For non-DELETE operations (GET, POST, PUT, PATCH), retry 404s.
+	// This is particularly relevant for block-related objects that are created asynchronously.
 	if resp.StatusCode == http.StatusNotFound {
-		retry := true
-		// Check if this is a DELETE operation - if so, don't retry 404s.
-		if httpMethod, ok := ctx.Value(httpMethodContextKey).(string); ok && httpMethod == http.MethodDelete {
-			retry = false
-		}
-
-		// For non-DELETE operations (GET, POST, PUT, PATCH), retry 404s.
-		//
-		// This is particularly relevant for block-related objects that are created asynchronously.
-		//
 		// NOTE: we encode the status code in the error object as a workaround
 		// in cases where we want access to the status code on a failed client.Do() call
 		// due to exhausted retries.
@@ -210,8 +203,13 @@ func checkRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool
 		//
 		// https://github.com/hashicorp/go-retryablehttp/blob/main/client.go#L811-L825
 		body, _ := io.ReadAll(resp.Body)
+		errResult := fmt.Errorf("status_code=%d, error=%w, body=%s", resp.StatusCode, err, body)
 
-		return retry, fmt.Errorf("status_code=%d, error=%w, body=%s", resp.StatusCode, err, body)
+		if httpMethod, ok := ctx.Value(httpMethodContextKey).(string); ok && httpMethod == http.MethodDelete {
+			return false, errResult
+		}
+
+		return true, errResult
 	}
 
 	// Fall back to the default retry policy for any other status codes.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -192,25 +192,26 @@ func checkRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool
 	// Context-aware 404 handling: Skip retries for DELETE operations.
 	// This prevents timing issues in acceptance tests during post-destroy plans.
 	if resp.StatusCode == http.StatusNotFound {
-		// Check if this is a DELETE operation - if so, don't retry 404s
+		retry := true
+		// Check if this is a DELETE operation - if so, don't retry 404s.
 		if httpMethod, ok := ctx.Value(httpMethodContextKey).(string); ok && httpMethod == http.MethodDelete {
-			// For DELETE operations, 404 means the resource is already deleted.
-			// This is the expected outcome, so don't retry.
-			body, _ := io.ReadAll(resp.Body)
-
-			return false, fmt.Errorf("status_code=%d, error=%w, body=%s", resp.StatusCode, err, body)
+			retry = false
 		}
 
 		// For non-DELETE operations (GET, POST, PUT, PATCH), retry 404s.
+		//
 		// This is particularly relevant for block-related objects that are created asynchronously.
+		//
 		// NOTE: we encode the status code in the error object as a workaround
 		// in cases where we want access to the status code on a failed client.Do() call
 		// due to exhausted retries.
+		//
 		// go-retryablehttp does not return the response object on exhausted retries.
+		//
 		// https://github.com/hashicorp/go-retryablehttp/blob/main/client.go#L811-L825
 		body, _ := io.ReadAll(resp.Body)
 
-		return true, fmt.Errorf("status_code=%d, error=%w, body=%s", resp.StatusCode, err, body)
+		return retry, fmt.Errorf("status_code=%d, error=%w, body=%s", resp.StatusCode, err, body)
 	}
 
 	// Fall back to the default retry policy for any other status codes.

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -15,6 +15,12 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
+// contextKey is a type for context keys to avoid collisions.
+type contextKey string
+
+// httpMethodContextKey is used to pass the HTTP method through context to the retry policy.
+const httpMethodContextKey contextKey = "http_method"
+
 // getAccountScopedURL constructs a URL for an account-scoped route.
 func getAccountScopedURL(endpoint string, accountID uuid.UUID, route string) string {
 	var builder strings.Builder
@@ -143,6 +149,9 @@ func request(ctx context.Context, client *http.Client, cfg requestConfig) (*http
 	} else {
 		body = http.NoBody
 	}
+
+	// Add HTTP method to context for retry policy to make context-aware decisions
+	ctx = context.WithValue(ctx, httpMethodContextKey, cfg.method)
 
 	req, err := http.NewRequestWithContext(ctx, cfg.method, cfg.url, body)
 	if err != nil {


### PR DESCRIPTION
### Context

👨🏼  My explanation:
- When Terraform runs the post-destroy plan, it calls `<resource>.Read`.
- That Read might happen when the resource is indeed gone, or it might read the resource when it's still waiting to be deleted.
- If it is indeed gone, then `Read` will return a 404. Our retry logic currently retries all `404` errors, and if they never succeed, we fail out.
- That's obviously not desirable on post-destroy plans because a `404` is the expected result.
- So this change only retries `404`s on methods that are not `DELETE`.
- We also considered adding `404` as an acceptable success code in the client calls, but that would affect many more lines of code. This feels like a cleaner way of handling it, plus it's mostly only relevant for acceptance testing due to the post-destroy plan checking to confirm everything is gone.

<details>
<summary>:robot: Claude's explanation</summary>

  ### The Post-Destroy Timing Conflict Explained

  The issue is a subtle but important race condition between resource deletion and post-destroy verification in Terraform acceptance tests.

  #### The Problem Sequence

  Here's what was happening:

  1. Test Step Completes: Terraform runs terraform destroy
  2. DELETE Requests Sent: Provider sends DELETE API calls to Prefect server
  3. Resources Deleted: Prefect successfully removes resources
  4. Post-Destroy Plan: Terraform immediately runs a plan to verify cleanup
  5. Read Operations: Terraform calls resource Read() methods to check if resources still exist
  6. 404 Responses: Server correctly returns 404 (resource not found)
  7. 🚨 PROBLEM: Client retry logic sees 404 and retries for up to 30 seconds
  8. Still 404: All retries fail (because resource is actually gone - which is correct!)
  9. Test Failure: Test fails due to "exhausted retries" error

  #### Why It Was Intermittent

  The failures were intermittent because of timing variations:

  - Sometimes: The retry delays happened to align with test timeouts → Test failed
  - Sometimes: The retries completed within acceptable time limits → Test passed
  - Race condition: Depended on server response times, network latency, and test execution timing

  #### The Reverted Commit Context

  The commit that was reverted (5a89d23) tried to solve this by removing resources from Terraform state when a 404 was encountered:

  ```go
  // This was REVERTED because it caused other issues
  if helpers.Is404Error(err) {
      resp.State.RemoveResource(ctx)  // Remove from state on 404
      return
  }
  ```

  But this created a different timing problem:
  - Resource might still exist briefly after DELETE due to async deletion
  - Immediate READ might get 200 (still exists), later READ gets 404 (now deleted)
  - Removing from state on 404 created inconsistent state during the transition period

  #### How Our Context-Aware Fix Solves This

  Our solution recognizes that 404 means different things for different HTTP methods:

  - For DELETE operations: 404 = "Success! Resource already deleted"
  - For GET operations: 404 = "Not found yet, might need to retry for async creation"

  ```go
  // Check HTTP method from context
  if httpMethod == http.MethodDelete {
      // DELETE + 404 = Success, don't retry
      return false, errResult
  } else {
      // GET/POST/PUT + 404 = Retry for async resources
      return true, errResult
  }
  ```

  #### The Key Insight

  The timing conflict happened because the client was treating all 404s the same way, when they actually have different meanings:

  - DELETE → 404: "Good! The resource was successfully deleted"
  - GET → 404: "Hmm, maybe the resource isn't created yet due to async processing"

  By making the retry policy context-aware of the HTTP method, we eliminate the false retries during DELETE operations while preserving the retry behavior needed for async resource creation during GET
  operations.

</details>

-----

### Summary

Fixes intermittent 404 errors during post-destroy acceptance test plans.

- Add httpMethodContextKey to pass HTTP method through request context
- Modify request() function in util.go to include HTTP method in context
- Update checkRetryPolicy() to skip 404 retries for DELETE operations
- Remove conflicting test.go file that was causing build failures
- DELETE operations now treat 404 as success (resource already deleted)
- Other operations (GET/POST/PUT/PATCH) continue to retry 404s for async creation

🤖 Generated with [Claude Code](https://claude.ai/code)

### Validation

Got 5 consecutive successes:

<img width="281" alt="image" src="https://github.com/user-attachments/assets/73f18a74-0f94-4b13-b817-222ef4118e47" />

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
