### PR TITLE
feat(deployment schedules): support slug, parameters

### DIFF
--- a/docs/resources/deployment_schedule.md
+++ b/docs/resources/deployment_schedule.md
@@ -94,7 +94,9 @@ resource "prefect_deployment_schedule" "test_rrule" {
 - `interval` (Number) The interval of the schedule.
 - `max_active_runs` (Number, Deprecated) (Cloud only) The maximum number of active runs for the schedule.
 - `max_scheduled_runs` (Number) The maximum number of scheduled runs for the schedule.
+- `parameters` (String) Parameters for flow runs scheduled by the deployment schedule.
 - `rrule` (String) The rrule expression of the schedule.
+- `slug` (String) An optional unique identifier for the schedule.
 - `timezone` (String) The timezone of the schedule.
 - `workspace_id` (String) Workspace ID (UUID)
 

--- a/internal/api/deployments_schedule.go
+++ b/internal/api/deployments_schedule.go
@@ -31,7 +31,9 @@ type DeploymentSchedulePayload struct {
 	MaxActiveRuns float32 `json:"max_active_runs,omitempty"`
 	Catchup       bool    `json:"catchup,omitempty"`
 
-	Schedule Schedule `json:"schedule,omitempty"`
+	Schedule   Schedule               `json:"schedule,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	Slug       string                 `json:"slug,omitempty"`
 }
 
 type Schedule struct {

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -157,7 +157,6 @@ For more information, see [schedule flow runs](https://docs.prefect.io/v3/automa
 			"parameters": schema.StringAttribute{
 				Description: "Parameters for flow runs scheduled by the deployment schedule.",
 				Optional:    true,
-				Computed:    true,
 				CustomType:  jsontypes.NormalizedType{},
 			},
 			"slug": schema.StringAttribute{

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -430,7 +430,6 @@ func copyScheduleModelToResourceModel(schedule *api.DeploymentSchedule, model *D
 	model.DayOr = types.BoolValue(schedule.Schedule.DayOr)
 	model.RRule = types.StringValue(schedule.Schedule.RRule)
 
-	// Handle parameters
 	if len(schedule.Parameters) > 0 {
 		parametersByteSlice, err := json.Marshal(schedule.Parameters)
 		if err == nil {

--- a/internal/provider/resources/deployment_schedule_test.go
+++ b/internal/provider/resources/deployment_schedule_test.go
@@ -44,6 +44,12 @@ resource "prefect_deployment_schedule" "test" {
 
 	interval = 30
 	anchor_date = "2024-01-01T00:00:00Z"
+
+	parameters = jsonencode({
+	 	env = "test"
+	 	version = "1.0"
+	})
+	slug = "test-schedule"
 }
 `
 
@@ -76,6 +82,12 @@ resource "prefect_deployment_schedule" "test" {
 
 	interval = 30
 	anchor_date = "2024-01-01T00:00:00Z"
+
+	parameters = jsonencode({
+	 	env = "staging"
+	 	version = "2.0"
+	})
+	slug = "updated-test-schedule"
 }
 `
 
@@ -104,6 +116,11 @@ resource "prefect_deployment_schedule" "test" {
 
 	cron = "* * * * *"
 	day_or = true
+
+	parameters = jsonencode({
+	 	mode = "cron"
+	})
+	slug = "cron-schedule"
 }
 `
 
@@ -131,6 +148,12 @@ resource "prefect_deployment_schedule" "test" {
 	deployment_id = prefect_deployment.test.id
 
 	rrule = "FREQ=DAILY;BYHOUR=10;BYMINUTE=30"
+
+	parameters = jsonencode({
+	 	mode = "rrule"
+	 	repeat = "daily"
+	})
+	slug = "rrule-schedule"
 }
 `
 
@@ -159,6 +182,11 @@ resource "prefect_deployment_schedule" "test_cron" {
 
 	cron = "* * * * *"
 	day_or = true
+
+	parameters = jsonencode({
+	 	schedule_type = "cron"
+	})
+	slug = "multi-cron-schedule"
 }
 
 resource "prefect_deployment_schedule" "test_rrule" {
@@ -166,6 +194,48 @@ resource "prefect_deployment_schedule" "test_rrule" {
 	deployment_id = prefect_deployment.test.id
 
 	rrule = "FREQ=DAILY;BYHOUR=10;BYMINUTE=30"
+
+	parameters = jsonencode({
+	 	schedule_type = "rrule"
+	})
+	slug = "multi-rrule-schedule"
+}
+`
+
+	return testutils.RenderTemplate(tmpl, cfg)
+}
+
+func fixtureAccDeploymentScheduleWithParameters(cfg fixtureConfig) string {
+	tmpl := `
+{{.WorkspaceResource}}
+
+resource "prefect_flow" "test" {
+	name = "my-flow"
+	{{.WorkspaceIDArg}}
+	tags = ["test"]
+}
+
+resource "prefect_deployment" "test" {
+	name = "my-deployment"
+	{{.WorkspaceIDArg}}
+	flow_id = prefect_flow.test.id
+}
+
+resource "prefect_deployment_schedule" "test" {
+	{{.WorkspaceIDArg}}
+	deployment_id = prefect_deployment.test.id
+
+	active = true
+	timezone = "UTC"
+
+	interval = 60
+	anchor_date = "2024-01-01T00:00:00Z"
+
+	parameters = jsonencode({
+		env = "production"
+		version = "3.0"
+	})
+	slug = "parameters-test-schedule"
 }
 `
 
@@ -188,11 +258,13 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 		testutils.ExpectKnownValueBool(resourceName, "active", true),
 		testutils.ExpectKnownValueNumber(resourceName, "interval", 30),
 		testutils.ExpectKnownValue(resourceName, "timezone", "America/New_York"),
+		testutils.ExpectKnownValue(resourceName, "slug", "test-schedule"),
 	}
 
 	stateChecksForIntervalUpdate := []statecheck.StateCheck{
 		testutils.ExpectKnownValueBool(resourceName, "active", false),
 		testutils.ExpectKnownValue(resourceName, "timezone", "America/Chicago"),
+		testutils.ExpectKnownValue(resourceName, "slug", "updated-test-schedule"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -224,6 +296,7 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValue(resourceName, "cron", "* * * * *"),
 					testutils.ExpectKnownValueBool(resourceName, "day_or", true),
+					testutils.ExpectKnownValue(resourceName, "slug", "cron-schedule"),
 				},
 			},
 			{
@@ -234,6 +307,7 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValue(resourceName, "rrule", "FREQ=DAILY;BYHOUR=10;BYMINUTE=30"),
+					testutils.ExpectKnownValue(resourceName, "slug", "rrule-schedule"),
 				},
 			},
 			{
@@ -246,8 +320,22 @@ func TestAccResource_deployment_schedule(t *testing.T) {
 					// Cron schedule tests
 					testutils.ExpectKnownValue("prefect_deployment_schedule.test_cron", "cron", "* * * * *"),
 					testutils.ExpectKnownValueBool("prefect_deployment_schedule.test_cron", "day_or", true),
+					testutils.ExpectKnownValue("prefect_deployment_schedule.test_cron", "slug", "multi-cron-schedule"),
 					// RRule schedule tests
 					testutils.ExpectKnownValue("prefect_deployment_schedule.test_rrule", "rrule", "FREQ=DAILY;BYHOUR=10;BYMINUTE=30"),
+					testutils.ExpectKnownValue("prefect_deployment_schedule.test_rrule", "slug", "multi-rrule-schedule"),
+				},
+			},
+			{
+				// Test parameters and slug fields
+				Config: fixtureAccDeploymentScheduleWithParameters(fixtureCfg),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDeploymentExists("prefect_deployment.test", &api.Deployment{}),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValue(resourceName, "slug", "parameters-test-schedule"),
+					testutils.ExpectKnownValueNumber(resourceName, "interval", 60),
+					testutils.ExpectKnownValue(resourceName, "timezone", "UTC"),
 				},
 			},
 		},


### PR DESCRIPTION
Adds support for the `slug` and `parameters` fields on `deployment_schedule` resources.

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/499

Closes https://linear.app/prefect/issue/PLA-1430/support-parameters-slug-for-prefect-deployment-schedule

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [x] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
