### PR TITLE
fix(service_account datasource): set actor_id

### DIFF
--- a/internal/provider/datasources/service_account.go
+++ b/internal/provider/datasources/service_account.go
@@ -214,6 +214,7 @@ func (d *ServiceAccountDataSource) Read(ctx context.Context, req datasource.Read
 	model.AccountID = customtypes.NewUUIDValue(serviceAccount.AccountID)
 
 	model.AccountRoleName = types.StringValue(serviceAccount.AccountRoleName)
+	model.ActorID = customtypes.NewUUIDValue(serviceAccount.ActorID)
 	model.APIKeyID = types.StringValue(serviceAccount.APIKey.ID)
 	model.APIKeyName = types.StringValue(serviceAccount.APIKey.Name)
 	model.APIKeyCreated = customtypes.NewTimestampPointerValue(serviceAccount.APIKey.Created)

--- a/internal/provider/datasources/service_account_test.go
+++ b/internal/provider/datasources/service_account_test.go
@@ -33,11 +33,13 @@ func TestAccDatasource_service_account(t *testing.T) {
 					statecheck.ExpectKnownValue(dataSourceNameByID, tfjsonpath.New("api_key_name"), knownvalue.StringRegexp(regexp.MustCompile(fmt.Sprintf(`^%s`, randomName)))),
 					testutils.ExpectKnownValueNotNull(dataSourceNameByID, "created"),
 					testutils.ExpectKnownValueNotNull(dataSourceNameByID, "updated"),
+					testutils.ExpectKnownValueNotNull(dataSourceNameByID, "actor_id"),
 					// Check the prefect_service_account datasource that queries by name
 					testutils.ExpectKnownValue(dataSourceNameByName, "name", randomName),
 					statecheck.ExpectKnownValue(dataSourceNameByName, tfjsonpath.New("api_key_name"), knownvalue.StringRegexp(regexp.MustCompile(fmt.Sprintf(`^%s`, randomName)))),
 					testutils.ExpectKnownValueNotNull(dataSourceNameByName, "created"),
 					testutils.ExpectKnownValueNotNull(dataSourceNameByName, "updated"),
+					testutils.ExpectKnownValueNotNull(dataSourceNameByName, "actor_id"),
 				},
 			},
 		},


### PR DESCRIPTION
### Summary


We had mistakenly missed setting the actor_id during `Read`.

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/532


<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
