### PR TITLE
fix(webhooks resource): use string type for Template

### DIFF
--- a/internal/provider/resources/webhooks.go
+++ b/internal/provider/resources/webhooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -34,7 +33,7 @@ type WebhookResourceModel struct {
 	Name             types.String               `tfsdk:"name"`
 	Description      types.String               `tfsdk:"description"`
 	Enabled          types.Bool                 `tfsdk:"enabled"`
-	Template         jsontypes.Normalized       `tfsdk:"template"`
+	Template         types.String               `tfsdk:"template"`
 	AccountID        customtypes.UUIDValue      `tfsdk:"account_id"`
 	WorkspaceID      customtypes.UUIDValue      `tfsdk:"workspace_id"`
 	Endpoint         types.String               `tfsdk:"endpoint"`
@@ -102,7 +101,6 @@ func (r *WebhookResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"template": schema.StringAttribute{
 				Required:    true,
-				CustomType:  jsontypes.NormalizedType{},
 				Description: "Template used by the webhook",
 			},
 			"created": schema.StringAttribute{
@@ -157,7 +155,7 @@ func copyWebhookResponseToModel(webhook *api.Webhook, tfModel *WebhookResourceMo
 	tfModel.Name = types.StringValue(webhook.Name)
 	tfModel.Description = types.StringValue(webhook.Description)
 	tfModel.Enabled = types.BoolValue(webhook.Enabled)
-	tfModel.Template = jsontypes.NewNormalizedValue(webhook.Template)
+	tfModel.Template = types.StringValue(webhook.Template)
 	tfModel.AccountID = customtypes.NewUUIDValue(webhook.AccountID)
 	tfModel.WorkspaceID = customtypes.NewUUIDValue(webhook.WorkspaceID)
 	tfModel.Endpoint = types.StringValue(fmt.Sprintf("%s/hooks/%s", endpointHost, webhook.Slug))


### PR DESCRIPTION
The Template attribute was using jsontypes.Normalized, which was modifying the data format provided by users and leading to unexpected results.

The string type matches what's defined in the API: https://app.prefect.cloud/api/docs#tag/Webhooks/operation/create_webhook_api_accounts__account_id__workspaces__workspace_id__webhooks__post

Related to https://github.com/PrefectHQ/terraform-provider-prefect/issues/533

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [ ] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [ ] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [ ] Relevant labels have been added
- [ ] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
