### PR TITLE
fix(automations): support arrays in match_related

### DIFF
--- a/internal/api/automations.go
+++ b/internal/api/automations.go
@@ -43,7 +43,7 @@ type Trigger struct {
 
 	// For EventTrigger and MetricTrigger
 	Match        map[string]interface{} `json:"match,omitempty"`
-	MatchRelated map[string]interface{} `json:"match_related,omitempty"`
+	MatchRelated any                    `json:"match_related,omitempty"`
 	Posture      *string                `json:"posture,omitempty"`
 
 	// For EventTrigger

--- a/internal/provider/resources/automation_resource.go
+++ b/internal/provider/resources/automation_resource.go
@@ -557,8 +557,11 @@ func mapTriggerTerraformToAPI(ctx context.Context, apiTrigger *api.Trigger, tfTr
 
 		match, diagnostics := helpers.UnmarshalOptional(tfTriggerModel.Event.Match)
 		diags.Append(diagnostics...)
-		matchRelated, diagnostics := helpers.UnmarshalOptional(tfTriggerModel.Event.MatchRelated)
-		diags.Append(diagnostics...)
+
+		var matchRelated any
+		if !tfTriggerModel.Event.MatchRelated.IsNull() {
+			diags.Append(tfTriggerModel.Event.MatchRelated.Unmarshal(&matchRelated)...)
+		}
 
 		if diags.HasError() {
 			return diags
@@ -578,8 +581,11 @@ func mapTriggerTerraformToAPI(ctx context.Context, apiTrigger *api.Trigger, tfTr
 	case tfTriggerModel.Metric != nil:
 		match, diagnostics := helpers.UnmarshalOptional(tfTriggerModel.Metric.Match)
 		diags.Append(diagnostics...)
-		matchRelated, diagnostics := helpers.UnmarshalOptional(tfTriggerModel.Metric.MatchRelated)
-		diags.Append(diagnostics...)
+
+		var matchRelated any
+		if !tfTriggerModel.Metric.MatchRelated.IsNull() {
+			diags.Append(tfTriggerModel.Metric.MatchRelated.Unmarshal(&matchRelated)...)
+		}
 
 		if diags.HasError() {
 			return diags


### PR DESCRIPTION
The match_related field in the API is an object _or_ an array of objects. Using the `map[string]interface` type restricted the marshaling to only work with objects and not arrays. Using the `any` type should allow us to support both.

https://app.prefect.cloud/api/docs#tag/Automations/operation/create_automation_api_accounts__account_id__workspaces__workspace_id__automations__post

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/536

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
