### PR TITLE
docs(automations): list possible values for action type

### DIFF
--- a/docs/resources/automation.md
+++ b/docs/resources/automation.md
@@ -529,7 +529,7 @@ Required:
 
 Required:
 
-- `type` (String) The type of action to perform
+- `type` (String) The type of action to perform. Possible values: do-nothing, run-deployment, pause-deployment, resume-deployment, cancel-flow-run, change-flow-run-state, pause-work-queue, resume-work-queue, send-notification, call-webhook, pause-automation, resume-automation, suspend-flow-run, resume-flow-run, declare-incident, pause-work-pool, resume-work-pool)
 
 Optional:
 
@@ -554,7 +554,7 @@ Optional:
 
 Required:
 
-- `type` (String) The type of action to perform
+- `type` (String) The type of action to perform. Possible values: do-nothing, run-deployment, pause-deployment, resume-deployment, cancel-flow-run, change-flow-run-state, pause-work-queue, resume-work-queue, send-notification, call-webhook, pause-automation, resume-automation, suspend-flow-run, resume-flow-run, declare-incident, pause-work-pool, resume-work-pool)
 
 Optional:
 
@@ -579,7 +579,7 @@ Optional:
 
 Required:
 
-- `type` (String) The type of action to perform
+- `type` (String) The type of action to perform. Possible values: do-nothing, run-deployment, pause-deployment, resume-deployment, cancel-flow-run, change-flow-run-state, pause-work-queue, resume-work-queue, send-notification, call-webhook, pause-automation, resume-automation, suspend-flow-run, resume-flow-run, declare-incident, pause-work-pool, resume-work-pool)
 
 Optional:
 

--- a/docs/resources/automation.md
+++ b/docs/resources/automation.md
@@ -529,7 +529,7 @@ Required:
 
 Required:
 
-- `type` (String) The type of action to perform. Possible values: do-nothing, run-deployment, pause-deployment, resume-deployment, cancel-flow-run, change-flow-run-state, pause-work-queue, resume-work-queue, send-notification, call-webhook, pause-automation, resume-automation, suspend-flow-run, resume-flow-run, declare-incident, pause-work-pool, resume-work-pool)
+- `type` (String) The type of action to perform. Possible values: do-nothing, run-deployment, pause-deployment, resume-deployment, cancel-flow-run, change-flow-run-state, pause-work-queue, resume-work-queue, send-notification, call-webhook, pause-automation, resume-automation, suspend-flow-run, resume-flow-run, declare-incident, pause-work-pool, resume-work-pool
 
 Optional:
 
@@ -554,7 +554,7 @@ Optional:
 
 Required:
 
-- `type` (String) The type of action to perform. Possible values: do-nothing, run-deployment, pause-deployment, resume-deployment, cancel-flow-run, change-flow-run-state, pause-work-queue, resume-work-queue, send-notification, call-webhook, pause-automation, resume-automation, suspend-flow-run, resume-flow-run, declare-incident, pause-work-pool, resume-work-pool)
+- `type` (String) The type of action to perform. Possible values: do-nothing, run-deployment, pause-deployment, resume-deployment, cancel-flow-run, change-flow-run-state, pause-work-queue, resume-work-queue, send-notification, call-webhook, pause-automation, resume-automation, suspend-flow-run, resume-flow-run, declare-incident, pause-work-pool, resume-work-pool
 
 Optional:
 
@@ -579,7 +579,7 @@ Optional:
 
 Required:
 
-- `type` (String) The type of action to perform. Possible values: do-nothing, run-deployment, pause-deployment, resume-deployment, cancel-flow-run, change-flow-run-state, pause-work-queue, resume-work-queue, send-notification, call-webhook, pause-automation, resume-automation, suspend-flow-run, resume-flow-run, declare-incident, pause-work-pool, resume-work-pool)
+- `type` (String) The type of action to perform. Possible values: do-nothing, run-deployment, pause-deployment, resume-deployment, cancel-flow-run, change-flow-run-state, pause-work-queue, resume-work-queue, send-notification, call-webhook, pause-automation, resume-automation, suspend-flow-run, resume-flow-run, declare-incident, pause-work-pool, resume-work-pool
 
 Optional:
 

--- a/internal/provider/resources/automation_schema.go
+++ b/internal/provider/resources/automation_schema.go
@@ -284,7 +284,7 @@ func ActionsSchema() schema.ListNestedAttribute {
 				"type": schema.StringAttribute{
 					Required: true,
 					Description: fmt.Sprintf(
-						"The type of action to perform. Possible values: %s)",
+						"The type of action to perform. Possible values: %s",
 						strings.Join(utils.AllAutomationActionTypes, ", "),
 					),
 					Validators: []validator.String{

--- a/internal/provider/resources/automation_schema.go
+++ b/internal/provider/resources/automation_schema.go
@@ -1,6 +1,9 @@
 package resources
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -279,8 +282,11 @@ func ActionsSchema() schema.ListNestedAttribute {
 		NestedObject: schema.NestedAttributeObject{
 			Attributes: map[string]schema.Attribute{
 				"type": schema.StringAttribute{
-					Required:    true,
-					Description: "The type of action to perform",
+					Required: true,
+					Description: fmt.Sprintf(
+						"The type of action to perform. Possible values: %s)",
+						strings.Join(utils.AllAutomationActionTypes, ", "),
+					),
 					Validators: []validator.String{
 						stringvalidator.OneOf(utils.AllAutomationActionTypes...),
 					},

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -12,6 +12,7 @@ const TriggerTypeCompound string = "compound"
 const TriggerTypeSequence string = "sequence"
 
 // Automation Action Types.
+// Source: https://docs.prefect.io/v3/api-ref/rest-api/server/automations/create-automation#body-actions
 var AllAutomationActionTypes = []string{
 	"do-nothing",
 	"run-deployment",


### PR DESCRIPTION
Lists the possible values for action type.
These are already enumerated in a Go constant, so we reuse that in the Markdown description for the field.

There are a couple open issues in the `terraform-plugin-docs` repository to provide this functionality out of the box, given that the Validator already ensures one of these values is used:

- https://github.com/hashicorp/terraform-plugin-docs/issues/243
- https://github.com/hashicorp/terraform-plugin-docs/issues/65

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
