### PR TITLE
chore(CI): do not run scheduled workflows in forks

### DIFF
--- a/.github/workflows/acceptance-tests-sweepers.yaml
+++ b/.github/workflows/acceptance-tests-sweepers.yaml
@@ -4,7 +4,7 @@ name: Acceptance Tests - Sweepers
 "on":
   # Run at 7 AM UTC every day (2 AM EST)
   schedule:
-    - cron: '0 7 * * *' 
+    - cron: '0 7 * * *'
   # Run manually
   workflow_dispatch: {}
 
@@ -12,6 +12,7 @@ permissions: {}
 
 jobs:
   sweepers:
+    if: github.repository == 'prefecthq/terraform-provider-prefect'
     permissions:
       contents: read
     name: Run Sweepers

--- a/.github/workflows/api-tracker.yaml
+++ b/.github/workflows/api-tracker.yaml
@@ -12,6 +12,7 @@ permissions: {}
 
 jobs:
   detect-api-drift:
+    if: github.repository == 'prefecthq/terraform-provider-prefect'
     permissions:
       # required to read from repo + write to wiki
       contents: write

--- a/.github/workflows/update-mise-tools.yaml
+++ b/.github/workflows/update-mise-tools.yaml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   update_mise_tools:
     runs-on: ubuntu-latest
+    if: github.repository == 'prefecthq/terraform-provider-prefect'
     permissions:
       # required to write to the repo
       contents: write


### PR DESCRIPTION
Ensures that forks of this repository do not inherit the schedules. For example, this happened in https://github.com/stigok/prefect-helm/pull/3

Related to https://linear.app/prefect/issue/PLA-1593/cycle-23-catch-all

References:
- https://github.com/orgs/community/discussions/26704#discussioncomment-3252979 (the approach taken here)
- https://beckysweger.com/2025/01/02/skip-a-job-in-a.html (an alternative we can consider later if needed)

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
