### PR TITLE
fix(block resource): replace upon name change

### DIFF
--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -105,6 +105,9 @@ func (r *BlockResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Unique name of the Block",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"type_slug": schema.StringAttribute{
 				Required:    true,


### PR DESCRIPTION
### Summary


Replaces the block resource if the name changes.

The Update API doesn't take `name` as an argument: https://docs.prefect.io/v3/api-ref/rest-api/server/block-documents/update-block-document-data

So if the name changes, we need to recreate that object.

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/550


<!-- Add a brief description of your change here -->

### Testing

```terraform
terraform {
  required_providers {
    prefect = {
      source = "registry.terraform.io/prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint = "http://localhost:4200"
}

resource "prefect_block" "dummy_secret" {
  data      = jsonencode({ "key" : "value" })
  name      = "dummy-secret-name" # change this to `dummy-secret-new-name` after apply
  type_slug = "secret"
}
```

```
Terraform will perform the following actions:

  # prefect_block.dummy_secret must be replaced
-/+ resource "prefect_block" "dummy_secret" {
      ~ created   = "2025-07-15T15:12:48Z" -> (known after apply)
      ~ id        = "1949b7ed-5e1e-41b5-92b8-8b2eb16c21e6" -> (known after apply)
      ~ name      = "dummy-secret-name" -> "dummy-secret-new-name" # forces replacement
      ~ updated   = "2025-07-15T15:12:48Z" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

prefect_block.dummy_secret: Destroying... [id=1949b7ed-5e1e-41b5-92b8-8b2eb16c21e6]
prefect_block.dummy_secret: Destruction complete after 0s
prefect_block.dummy_secret: Creating...
prefect_block.dummy_secret: Creation complete after 0s [id=c11d7cf3-5cb3-461a-9dc1-e14a6685f35e]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
