### PR TITLE
feat(block resource): add write-only data attribute

### DIFF
--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -43,7 +43,7 @@ resource "prefect_block" "secret" {
 }
 # example:
 # you can also use a write-only attribute for the data field
-resource "prefect_block" "secret_write_onlyh" {
+resource "prefect_block" "secret_write_only" {
   name = "foo-write-only"
 
   # prefect block type ls

--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -41,6 +41,20 @@ resource "prefect_block" "secret" {
   # set the workpace_id attribute on the provider OR the resource
   workspace_id = "<workspace UUID>"
 }
+# example:
+# you can also use a write-only attribute for the data field
+resource "prefect_block" "secret_write_onlyh" {
+  name = "foo-write-only"
+
+  # prefect block type ls
+  type_slug = "aws-credentials"
+
+  # prefect block type inspect aws-credentials
+  data_wo = file("./aws-credentials.json")
+
+  # provide the version to control when to update the block data
+  data_wo_version = 1
+}
 
 # example:
 # you can also use file() to import a JSON file

--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -118,13 +118,17 @@ For more information on the `$ref` syntax definition, see the
 
 ### Required
 
-- `data` (String, Sensitive) The user-inputted Block payload, as a JSON string. Use `jsonencode` on the provided value to satisfy the underlying JSON type. The value's schema will depend on the selected `type` slug. Use `prefect block type inspect <slug>` to view the data schema for a given Block type.
 - `name` (String) Unique name of the Block
 - `type_slug` (String) Block Type slug, which determines the schema of the `data` JSON attribute. Use `prefect block type ls` to view all available Block type slugs.
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `account_id` (String) Account ID (UUID) where the Block is located
+- `data` (String, Sensitive) The user-inputted Block payload, as a JSON string. Use `jsonencode` on the provided value to satisfy the underlying JSON type. The value's schema will depend on the selected `type` slug. Use `prefect block type inspect <slug>` to view the data schema for a given Block type.
+- `data_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The user-inputted Block payload, as a JSON string. Use `jsonencode` on the provided value to satisfy the underlying JSON type. The value's schema will depend on the selected `type` slug. Use `prefect block type inspect <slug>` to view the data schema for a given Block type.
+- `data_wo_version` (Number) The version of the `data_wo` attribute. This is used to track changes to the `data_wo` attribute and trigger updates when the value changes.
 - `workspace_id` (String) Workspace ID (UUID) where the Block is located. In Prefect Cloud, either the `prefect_block` resource or the provider's `workspace_id` must be set.
 
 ### Read-Only

--- a/docs/resources/block.md
+++ b/docs/resources/block.md
@@ -50,7 +50,9 @@ resource "prefect_block" "secret_write_onlyh" {
   type_slug = "aws-credentials"
 
   # prefect block type inspect aws-credentials
-  data_wo = file("./aws-credentials.json")
+  data_wo = jsonencode({
+    "value" = "bar"
+  })
 
   # provide the version to control when to update the block data
   data_wo_version = 1

--- a/examples/resources/prefect_block/resource.tf
+++ b/examples/resources/prefect_block/resource.tf
@@ -13,7 +13,7 @@ resource "prefect_block" "secret" {
 }
 # example:
 # you can also use a write-only attribute for the data field
-resource "prefect_block" "secret_write_onlyh" {
+resource "prefect_block" "secret_write_only" {
   name = "foo-write-only"
 
   # prefect block type ls

--- a/examples/resources/prefect_block/resource.tf
+++ b/examples/resources/prefect_block/resource.tf
@@ -11,6 +11,20 @@ resource "prefect_block" "secret" {
   # set the workpace_id attribute on the provider OR the resource
   workspace_id = "<workspace UUID>"
 }
+# example:
+# you can also use a write-only attribute for the data field
+resource "prefect_block" "secret_write_onlyh" {
+  name = "foo-write-only"
+
+  # prefect block type ls
+  type_slug = "aws-credentials"
+
+  # prefect block type inspect aws-credentials
+  data_wo = file("./aws-credentials.json")
+
+  # provide the version to control when to update the block data
+  data_wo_version = 1
+}
 
 # example:
 # you can also use file() to import a JSON file

--- a/examples/resources/prefect_block/resource.tf
+++ b/examples/resources/prefect_block/resource.tf
@@ -20,7 +20,9 @@ resource "prefect_block" "secret_write_onlyh" {
   type_slug = "aws-credentials"
 
   # prefect block type inspect aws-credentials
-  data_wo = file("./aws-credentials.json")
+  data_wo = jsonencode({
+    "value" = "bar"
+  })
 
   # provide the version to control when to update the block data
   data_wo_version = 1

--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -299,7 +299,7 @@ func (r *BlockResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	if dataWO != nil {
+	if len(dataWO) != 0 {
 		data = dataWO
 	}
 


### PR DESCRIPTION
### Summary


Adds an attribute called `data_wo` to the block resource, providing a write-only attribute for security purposes.

References:
- https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments
- https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/549

See also https://linear.app/prefect/issue/PLA-1028/implement-ephemeral-resources


<!-- Add a brief description of your change here -->

### Testing

First, see the acceptance tests added. They confirm that:

- Write-only data attribute changes result in a `null` value in the state (as expected)
- Write-only data attribute changes trigger an update
- Write-only data attributes staying the same does _not_ trigger an update

Additionally, testing by hand:

```terraform
resource "prefect_block" "dummy_secret" {
  name      = "dummy-secret"
  type_slug = "secret"

  data_wo         = jsonencode({ "value" = "my-secret-value" })
  data_wo_version = 1
}
```

And confirming the result is null:

```
$ jq '.resources[0].instances[0].attributes.data_wo' terraform.tfstate
null

$ tf state show prefect_block.dummy_secret
# prefect_block.dummy_secret:
resource "prefect_block" "dummy_secret" {
    created         = "2025-07-15T21:46:40Z"
    data_wo         = (write-only attribute)
    data_wo_version = 1
    id              = "80bb8cd5-b1c4-4bc7-911d-94580073b8f8"
    name            = "dummy-secret"
    type_slug       = "secret"
    updated         = "2025-07-15T21:46:53Z"
}
```

Can confirm the value with Python:

```python
from prefect.blocks.system import Secret

secret_block = Secret.load("dummy-secret")
print(secret_block.get())
```

```
$ python test.py
my-secret-value
```

You can then:
- Update the value, apply, and see nothing changes
- Update the version too, apply, and see the value change

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [x] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
