### PR TITLE
chore(contributing): provide `dev_overrides` config

### DIFF
--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -122,9 +122,9 @@ For more information, see the [Terraform testing patterns documentation](https:/
 
 ### Manual testing
 
-We can also test provider functionality by running `terraform apply` with handcrafted manifests.
+You can also test provider functionality by running `terraform apply` with handcrafted manifests.
 
-To ensure that `terraform` commands use the locally-built binary, we can use [development overrides for Terraform provider configurations](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers). These overrides are provided automatically in [dev.tfrc](../dev.tfrc),
+To ensure that `terraform` commands use the locally-built binary, we use [development overrides for Terraform provider configurations](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers). These overrides are provided automatically in [dev.tfrc](../dev.tfrc),
 
 First, build the binary:
 

--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -48,29 +48,7 @@ Anytime you want to test a local change, run the build command, which creates th
 make build
 ```
 
-The binary will be stored at the root of the project - obtain the absolute path of the project's `./build` directory, as you will need it in the next step
-
-```shell
-echo $(pwd)/build
-/Users/johnsmith/code/terraform-provider-prefect/build
-```
-
-To aid local development, we can use [development overrides for Terraform provider configurations](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers) - place this into your `~/.terraformrc` file
-
-```terraform
-# ~/.terraformrc
-provider_installation {
-  dev_overrides {
-    "hashicorp/prefect" = "/Users/johnsmith/code/terraform-provider-prefect/build"
-  }
-
-  direct {}
-}
-```
-
-With development overrides, `terraform init` will still initialize the dependency lock, but `terraform apply` commands will disregard the lockfile + use the executable located in the path you specify here (which is keyed off by the provider name).
-
-Note that with `dev_overrides`, you do not need a `required_providers` block
+The binary will be stored at the root of the project under `./build/`.
 
 If you ever want to start fresh, go ahead and run:
 
@@ -99,6 +77,8 @@ The following command will run [Terraform acceptance tests](https://developer.ha
 ```shell
 make testacc
 ```
+
+Note that this _does not_ require building the provider binary with `make build`.
 
 Acceptance tests create real Prefect Cloud resources, and require a Prefect Cloud account.
 
@@ -142,26 +122,50 @@ For more information, see the [Terraform testing patterns documentation](https:/
 
 ### Manual testing
 
-You can also test against a local instance of Prefect. An example of this setup using Docker Compose is available in the [Terraform Provider tutorial](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider).
+We can also test provider functionality by running `terraform apply` with handcrafted manifests.
 
-First, you'll need to create or modify `~/.terraformrc` on your machine:
+To ensure that `terraform` commands use the locally-built binary, we can use [development overrides for Terraform provider configurations](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers). These overrides are provided automatically in [dev.tfrc](../dev.tfrc),
 
-```terraform
-provider_installation {
-  dev_overrides {
-    "registry.terraform.io/prefecthq/prefect" = "/Users/<username>/go/bin/"
-  }
+First, build the binary:
 
-  # For all other providers, install them directly from their origin provider
-  # registries as normal. If you omit this, Terraform will _only_ use
-  # the dev_overrides block, and so no other providers will be available.
-  direct {}
-}
+```bash
+make build
 ```
 
-You only need to do this once, but if you will need to comment this out any time you want to use the provider from the official Terraform registry instead.
+Note: you will need to build the binary each time you change the source code.
 
-Next, start the Prefect server:
+Set up the test directory by running:
+
+```bash
+make dev-new resource=<resource name>
+```
+
+This will:
+- Create a new directory: `./dev/<resource name>`
+- Create a file for environment variables: `./dev/.envrc`
+- Create a file for Terraform configuration: `./dev/<resource name>.tf`
+
+The command to change to this directory will automatically be added to your clipboard.
+Use this, or manually change directories, to enter the testing directory.
+
+When you run `terraform` commands, you'll notice a message that the locally-built binary is in use:
+
+```plaintext
+$ terraform plan
+╷
+│ Warning: Provider development overrides are in effect
+│
+│ The following provider development overrides are set in the CLI configuration:
+│  - prefecthq/prefect in ../../build
+```
+
+You can then edit the `<resource name>.tf` file with your desired configuration for testing purposes.
+
+### Local testing
+
+You can also test against a local instance of Prefect. An example of this setup using Docker Compose is available in the [Terraform Provider tutorial](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider).
+
+Start the Prefect server:
 
 ```shell
 docker-compose up -d
@@ -172,13 +176,17 @@ You can confirm the server is running by either:
 1. Checking the logs with `docker-compose logs -f`, or
 2. Navigating to the UI in your browser at [localhost:4200](http://localhost:4200).
 
-When you're ready to test your changes, compile the provider and install it to your path:
+Set up the test directory by following the [manual testing instructions](#manual-testing).
+Open `<resource name>.tf` and modify the `provider` block with the following:
 
-```shell
-go install .
-```
+```terraform
+provider "prefect" {
+ endpoint = "http://localhost:4200"
+}
+ ```
 
-You can now run `terraform plan` and `terraform apply` to test features in the provider.
+You can now run `terraform plan` and `terraform apply` to test features in the
+provider against a local instance of Prefect.
 
 ## Build Documentation
 

--- a/create-dev-testfile.sh
+++ b/create-dev-testfile.sh
@@ -20,9 +20,10 @@ main() {
 
   dev_file_target="${PWD}/dev/${name}"
 
-  mkdir -p $dev_file_target
+  mkdir -p "$dev_file_target"
 
-  cat <<EOF > $dev_file_target/${resource}.tf
+  # Create the Terraform configuration file.
+  cat <<EOF > "$dev_file_target"/"${resource}".tf
 terraform {
   required_providers {
     prefect = {
@@ -32,12 +33,20 @@ terraform {
 }
 
 provider "prefect" {
-$([ -n "$PREFECT_API_URL" ] && echo '  endpoint = "'$PREFECT_API_URL'"')
-$([ -n "$PREFECT_API_KEY" ] && echo '  api_key = "'$PREFECT_API_KEY'"')
-$([ -n "$PREFECT_CLOUD_ACCOUNT_ID" ] && echo '  account_id = "'$PREFECT_CLOUD_ACCOUNT_ID'"')
+$([ -n "$PREFECT_API_URL" ] && echo '  endpoint = "'"$PREFECT_API_URL"'"')
+$([ -n "$PREFECT_API_KEY" ] && echo '  api_key = "'"$PREFECT_API_KEY"'"')
+$([ -n "$PREFECT_CLOUD_ACCOUNT_ID" ] && echo '  account_id = "'"$PREFECT_CLOUD_ACCOUNT_ID"'"')
 }
 
 resource "${resource}" "${name}" {}
+EOF
+
+
+  # Create the direnv file that will tell Terraform where to find the provider.
+  # configuration file.
+  cat <<EOF > "$dev_file_target"/.envrc
+#!/bin/bash
+export TF_CLI_CONFIG_FILE=../../dev.tfrc
 EOF
 
   cmd="cd ${dev_file_target} && terraform plan"

--- a/dev.tfrc
+++ b/dev.tfrc
@@ -1,0 +1,21 @@
+# https://developer.hashicorp.com/terraform/cli/config/config-file
+
+provider_installation {
+  # This disables the version and checksum verifications for this provider and
+  # forces Terraform to look for the provider plugin in the given directory.
+  dev_overrides {
+    # Retrieve the provider binary from the `build/` directory
+    # in the repository root. This binary is created by running
+    # `make build`.
+    #
+    # This file will be referenced from `./dev/<resource>`, which is
+    # created by running `make dev-new` and providing a resource name.
+    "prefecthq/prefect" = "../../build/"
+    "registry.terraform.io/prefecthq/prefect" = "../../build/"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}


### PR DESCRIPTION
### Summary

This change adds a configuration file specifying `dev_overrides` so
users don't need to create it themselves.

It also updates the `create-dev-testfile` script to add an `.envrc` file
that tells Terraform where to find this configuration file.

Related to https://linear.app/prefect/issue/PLA-1593/cycle-23-catch-all

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
