### PR TITLE
fix(accounts): deprecate `billing_email` field

### DIFF
--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -20,9 +20,8 @@ This feature is available in the following [product plan(s)](https://www.prefect
 
 ```terraform
 resource "prefect_account" "example" {
-  name          = "My Imported Account"
-  description   = "A cool account"
-  billing_email = "marvin@prefect.io"
+  name        = "My Imported Account"
+  description = "A cool account"
   settings = {
     allow_public_workspaces = true
     ai_log_summaries        = false

--- a/docs/resources/account.md
+++ b/docs/resources/account.md
@@ -41,7 +41,7 @@ resource "prefect_account" "example" {
 
 ### Optional
 
-- `billing_email` (String) Billing email to apply to the account's Stripe customer
+- `billing_email` (String, Deprecated) Billing email to apply to the account's Stripe customer
 - `domain_names` (List of String) The list of domain names for enabling SSO in Prefect Cloud.
 - `link` (String) An optional for an external url associated with the account, e.g. https://prefect.io/
 - `location` (String) An optional physical location for the account, e.g. Washington, D.C.

--- a/examples/resources/prefect_account/resource.tf
+++ b/examples/resources/prefect_account/resource.tf
@@ -1,7 +1,6 @@
 resource "prefect_account" "example" {
-  name          = "My Imported Account"
-  description   = "A cool account"
-  billing_email = "marvin@prefect.io"
+  name        = "My Imported Account"
+  description = "A cool account"
   settings = {
     allow_public_workspaces = true
     ai_log_summaries        = false

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -37,6 +37,7 @@ type Account struct {
 	RunRetentionDays      int64    `json:"run_retention_days"`
 	AuditLogRetentionDays int64    `json:"audit_log_retention_days"`
 	AutomationsLimit      int64    `json:"automations_limit"`
+	BillingEmail          *string  `json:"billing_email"`
 }
 
 // AccountUpdate is the data sent when updating an account.
@@ -46,7 +47,6 @@ type AccountUpdate struct {
 	Location              *string `json:"location"`
 	Link                  *string `json:"link"`
 	AuthExpirationSeconds *int64  `json:"auth_expiration_seconds"`
-	BillingEmail          *string `json:"billing_email"`
 }
 
 // AccountSettingsUpdate is the data sent when updating an account's settings.

--- a/internal/provider/resources/account.go
+++ b/internal/provider/resources/account.go
@@ -144,8 +144,10 @@ func (r *AccountResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				},
 			},
 			"billing_email": schema.StringAttribute{
-				Description: "Billing email to apply to the account's Stripe customer",
-				Optional:    true,
+				Description:        "Billing email to apply to the account's Stripe customer",
+				DeprecationMessage: "Remove this attribute's configuration as it no longer is used and the attribute will be removed in the next major version of the provider.",
+				Optional:           true,
+				Computed:           true,
 			},
 			"domain_names": schema.ListAttribute{
 				Description: "The list of domain names for enabling SSO in Prefect Cloud.",
@@ -283,11 +285,10 @@ func (r *AccountResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	err = client.Update(ctx, api.AccountUpdate{
-		Name:         plan.Name.ValueString(),
-		Handle:       plan.Handle.ValueString(),
-		Location:     plan.Location.ValueStringPointer(),
-		Link:         plan.Link.ValueStringPointer(),
-		BillingEmail: plan.BillingEmail.ValueStringPointer(),
+		Name:     plan.Name.ValueString(),
+		Handle:   plan.Handle.ValueString(),
+		Location: plan.Location.ValueStringPointer(),
+		Link:     plan.Link.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Account", "update", err))

--- a/internal/provider/resources/account_test.go
+++ b/internal/provider/resources/account_test.go
@@ -1,10 +1,12 @@
 package resources_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
@@ -14,6 +16,47 @@ func TestAccResource_account(t *testing.T) {
 	testutils.SkipTestsIfOSS(t)
 
 	resourceName := "prefect_account.test"
+
+	checkFunc := func(s []*terraform.InstanceState) error {
+		if len(s) != 1 {
+			return fmt.Errorf("expected 1 instance state, got %d", len(s))
+		}
+
+		account := s[0]
+
+		tests := []struct {
+			attribute string
+			expected  string
+		}{
+			{
+				attribute: "name",
+				expected:  "github-ci-tests",
+			},
+			{
+				attribute: "handle",
+				expected:  "github-ci-tests",
+			},
+			{
+				// This value was provided manually in the UI to support this test.
+				attribute: "link",
+				expected:  "https://github.com/PrefectHQ/terraform-provider-prefect",
+			},
+			{
+				// Billing email is not available in the staging account because Stripe
+				// is not configured.
+				attribute: "billing_email",
+				expected:  "",
+			},
+		}
+
+		for _, test := range tests {
+			if account.Attributes[test.attribute] != test.expected {
+				return fmt.Errorf("expected name to be %s, got %s", test.expected, account.Attributes[test.attribute])
+			}
+		}
+
+		return nil
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
@@ -25,13 +68,16 @@ func TestAccResource_account(t *testing.T) {
 			// will be challenging to test. Instead, we'll ensure that the
 			// resource can be found and properly imported. Note that
 			// ImportStateVerify is set to false, as the resource can't be
-			// saved to state after a Create.
+			// saved to state after a Create. We make up for this by providing
+			// a custom ImportStateCheck function to confirm that the retrieved
+			// attributes match expectations.
 			{
 				Config:            `resource "prefect_account" "test" {}`,
 				ImportStateId:     os.Getenv("PREFECT_CLOUD_ACCOUNT_ID"),
 				ImportState:       true,
 				ResourceName:      resourceName,
 				ImportStateVerify: false,
+				ImportStateCheck:  checkFunc,
 			},
 		},
 	})


### PR DESCRIPTION
### Summary


The `billing_email` field comes from Stripe, and is therefore not something that a user will update themselves.

This marks the field as deprecated, and no longer sends that field in the Update payload.

This also adds a custom check function to the account so we can validate that the fields are as we expect them to be after import.

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/559


<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
