### PR TITLE
chore(tests): update 1Password entry name

### DIFF
--- a/scripts/testacc-dev
+++ b/scripts/testacc-dev
@@ -15,7 +15,7 @@ set -e
 # Log levels are listed here:
 #   https://developer.hashicorp.com/terraform/internals/debugging
 
-vault_entry='op://Platform/Terraform provider acceptance test secrets'
+vault_entry='op://Platform/Terraform Provider - Acceptance Test Secrets'
 
 tests=${1:-""}
 log_level=${2:-"INFO"}

--- a/scripts/testacc-dev-user
+++ b/scripts/testacc-dev-user
@@ -9,7 +9,7 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 
-vault_entry='op://Platform/Terraform provider acceptance test secrets'
+vault_entry='op://Platform/Terraform Provider - Acceptance Test Secrets'
 
 # User tests
 TF_ACC=1 \


### PR DESCRIPTION
### Summary

The 1Password entry name for the acceptance tests secrets was changed.

Related to https://linear.app/prefect/issue/PLA-1624/cycle-24-catch-all


<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `make docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
