### PR TITLE
fix(deployments): allow removing parameters, parameter_openapi_schema

### DIFF
--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -52,8 +52,8 @@ type DeploymentCreate struct {
 	FlowID                 uuid.UUID              `json:"flow_id"` // required
 	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
 	Name                   string                 `json:"name"` // required
-	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
-	Parameters             map[string]interface{} `json:"parameters,omitempty"`
+	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema"`
+	Parameters             map[string]interface{} `json:"parameters"`
 	Path                   string                 `json:"path,omitempty"`
 	Paused                 bool                   `json:"paused,omitempty"`
 	PullSteps              []PullStep             `json:"pull_steps,omitempty"`
@@ -72,8 +72,8 @@ type DeploymentUpdate struct {
 	EnforceParameterSchema *bool                  `json:"enforce_parameter_schema,omitempty"`
 	Entrypoint             string                 `json:"entrypoint,omitempty"`
 	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
-	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
-	Parameters             map[string]interface{} `json:"parameters,omitempty"`
+	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema"`
+	Parameters             map[string]interface{} `json:"parameters"`
 	Path                   string                 `json:"path,omitempty"`
 	Paused                 bool                   `json:"paused,omitempty"`
 	PullSteps              []PullStep             `json:"pull_steps,omitempty"`


### PR DESCRIPTION
### Summary


Allows removing parameters and parameter_openapi_schema by removing the `omitempty` on the API definitions.

Previously, with `omitempty`, the field would not be passed in the API requests at all, leaving the values as they previously were configured and then resulting in an "inconsistent result" error.

Closes https://github.com/PrefectHQ/terraform-provider-prefect/issues/581

Closes https://linear.app/prefect/issue/PLA-2070/prefect-deployment-parameter-change-error

### Testing

```terraform
terraform {
  required_providers {
    prefect = {
      source = "prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint = "http://localhost:4200"
}

resource "prefect_flow" "flow" {
  name = "my-flow"
  tags = ["tf-test"]
}

resource "prefect_deployment" "deployment" {
  name            = "my-deployment"
  description     = "string"
  flow_id         = prefect_flow.flow.id
  entrypoint      = "hello_world.py:hello_world"
  work_pool_name  = "some-testing-pool"
  work_queue_name = "default"

  # Comment out below to test removal

  enforce_parameter_schema = true

  parameters = jsonencode({
    "some-parameter" : "some-value",
    "some-parameter2" : "some-value2"
  })

  parameter_openapi_schema = jsonencode({
    "type" : "object",
    "properties" : {
      "some-parameter" : { "type" : "string" }
      "some-parameter2" : { "type" : "string" }
    }
  })
}
```

1. Apply the above configuration
2. Comment out the parameter-related fields
3. Apply the configuration again
4. Confirm that the parameters are removed and there are no errors in the plan/apply

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
