### PR TITLE
fix(block_type): add support for importing block types by ID

### DIFF
--- a/internal/api/block_types.go
+++ b/internal/api/block_types.go
@@ -8,6 +8,7 @@ import (
 
 // BlockTypeClient is a client for working with block types.
 type BlockTypeClient interface {
+	Get(ctx context.Context, id uuid.UUID) (*BlockType, error)
 	GetBySlug(ctx context.Context, slug string) (*BlockType, error)
 	Create(ctx context.Context, payload *BlockTypeCreate) (*BlockType, error)
 	Update(ctx context.Context, id uuid.UUID, payload *BlockTypeUpdate) error

--- a/internal/client/block_types.go
+++ b/internal/client/block_types.go
@@ -46,6 +46,27 @@ func (c *Client) BlockTypes(accountID uuid.UUID, workspaceID uuid.UUID) (api.Blo
 	}, nil
 }
 
+// Get returns details for a block type by ID.
+func (c *BlockTypeClient) Get(ctx context.Context, id uuid.UUID) (*api.BlockType, error) {
+	cfg := requestConfig{
+		method:          http.MethodGet,
+		url:             c.routePrefix + "/" + id.String(),
+		body:            http.NoBody,
+		apiKey:          c.apiKey,
+		basicAuthKey:    c.basicAuthKey,
+		csrfClientToken: c.csrfClientToken,
+		csrfToken:       c.csrfToken,
+		successCodes:    successCodesStatusOK,
+	}
+
+	var blockType api.BlockType
+	if err := requestWithDecodeResponse(ctx, c.hc, cfg, &blockType); err != nil {
+		return nil, fmt.Errorf("failed to get block type: %w", err)
+	}
+
+	return &blockType, nil
+}
+
 // GetBySlug returns details for a block type by slug.
 func (c *BlockTypeClient) GetBySlug(ctx context.Context, slug string) (*api.BlockType, error) {
 	cfg := requestConfig{

--- a/internal/provider/resources/block_type_test.go
+++ b/internal/provider/resources/block_type_test.go
@@ -102,6 +102,13 @@ func TestAccResource_block_type(t *testing.T) {
 					testutils.ExpectKnownValueBool(blockTypeResourceName, "is_protected", false),
 				},
 			},
+			{
+				// Import State checks - import by block_type_id,workspace_id
+				ImportState:       true,
+				ResourceName:      blockTypeResourceName,
+				ImportStateIdFunc: testutils.GetResourceWorkspaceImportStateID(blockTypeResourceName),
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
### Summary

The `terraform import` command was failing with a 404 error when trying to import `prefect_block_type` resources. The Read() method only supported fetching by slug, but during import only the ID is populated in state. This resulted in API calls to `/api/block_types/slug/` (empty slug) which returned 404.

Added a `Get(id)` method to `BlockTypeClient` and updated `Read()` to fetch by ID instead of slug, matching the pattern used in other resources like block documents. This allows users to import existing block types with their UUID.

Closes #580

Closes https://linear.app/prefect/issue/PLA-2064/error-during-terraform-import-of-block-type-ressource

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [x] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`