### PR TITLE
fix: properly refresh variable value in state during Read

### DIFF
--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -278,6 +278,16 @@ func convertAPIValueToDynamic(ctx context.Context, value interface{}) (types.Dyn
 		elements := make([]attr.Value, len(v))
 		elementTypes := make([]attr.Type, len(v))
 		for i, elem := range v {
+			// The API returns tuple elements as quoted strings (e.g., '"foo"' instead of 'foo')
+			// because getUnderlyingValue uses e.String() which adds quotes.
+			// We need to unquote them when converting back.
+			if strElem, ok := elem.(string); ok {
+				// Try to unquote if it's a quoted string
+				if unquoted, err := strconv.Unquote(strElem); err == nil {
+					elem = unquoted
+				}
+			}
+
 			// Recursively convert each element
 			elemDynamic, elemDiags := convertAPIValueToDynamic(ctx, elem)
 			if elemDiags.HasError() {

--- a/internal/provider/resources/variable_conversion_test.go
+++ b/internal/provider/resources/variable_conversion_test.go
@@ -56,6 +56,12 @@ func TestConvertAPIValueToDynamic(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			name:         "array value with quoted strings (from API)",
+			input:        []interface{}{`"foo"`, `"bar"`},
+			expectedType: "types.Tuple",
+			expectError:  false,
+		},
+		{
 			name:         "object value",
 			input:        map[string]interface{}{"key": "value", "number": float64(42)},
 			expectedType: "types.Object",

--- a/internal/provider/resources/variable_conversion_test.go
+++ b/internal/provider/resources/variable_conversion_test.go
@@ -1,0 +1,116 @@
+package resources // nolint:testpackage // need access to private convertAPIValueToDynamic function
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertAPIValueToDynamic(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		input         interface{}
+		expectedType  string
+		expectedValue interface{}
+		expectError   bool
+	}{
+		{
+			name:          "string value",
+			input:         "hello-world",
+			expectedType:  "types.String",
+			expectedValue: "hello-world",
+			expectError:   false,
+		},
+		{
+			name:          "number value",
+			input:         float64(123.45),
+			expectedType:  "types.Number",
+			expectedValue: float64(123.45),
+			expectError:   false,
+		},
+		{
+			name:          "boolean value",
+			input:         true,
+			expectedType:  "types.Bool",
+			expectedValue: true,
+			expectError:   false,
+		},
+		{
+			name:          "nil value",
+			input:         nil,
+			expectedType:  "types.Dynamic",
+			expectedValue: nil,
+			expectError:   false,
+		},
+		{
+			name:         "array value",
+			input:        []interface{}{"foo", "bar"},
+			expectedType: "types.Tuple",
+			expectError:  false,
+		},
+		{
+			name:         "object value",
+			input:        map[string]interface{}{"key": "value", "number": float64(42)},
+			expectedType: "types.Object",
+			expectError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, diags := convertAPIValueToDynamic(ctx, tt.input)
+
+			if tt.expectError {
+				assert.True(t, diags.HasError(), "expected error but got none")
+
+				return
+			}
+
+			require.False(t, diags.HasError(), "unexpected error: %v", diags)
+			assert.NotNil(t, result, "result should not be nil")
+
+			// Check specific values for simple types
+			switch tt.expectedType {
+			case "types.String":
+				strVal, ok := result.UnderlyingValue().(types.String)
+				require.True(t, ok, "expected types.String")
+				assert.Equal(t, tt.expectedValue, strVal.ValueString())
+
+			case "types.Number":
+				numVal, ok := result.UnderlyingValue().(types.Number)
+				require.True(t, ok, "expected types.Number")
+				numFloat, _ := numVal.ValueBigFloat().Float64()
+				assert.Equal(t, tt.expectedValue, numFloat)
+
+			case "types.Bool":
+				boolVal, ok := result.UnderlyingValue().(types.Bool)
+				require.True(t, ok, "expected types.Bool")
+				assert.Equal(t, tt.expectedValue, boolVal.ValueBool())
+
+			case "types.Dynamic":
+				if tt.expectedValue == nil {
+					assert.True(t, result.IsNull(), "expected null dynamic value")
+				}
+
+			case "types.Tuple":
+				tupleVal, ok := result.UnderlyingValue().(types.Tuple)
+				require.True(t, ok, "expected types.Tuple")
+				assert.NotNil(t, tupleVal)
+
+			case "types.Object":
+				objVal, ok := result.UnderlyingValue().(types.Object)
+				require.True(t, ok, "expected types.Object")
+				assert.NotNil(t, objVal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

The `prefect_variable` resource wasn't detecting when values changed outside Terraform (e.g., in the Prefect UI). The Read operation would fetch the latest variable from the API but never copied the value back into state.

Added `convertAPIValueToDynamic` to handle the reverse conversion from API response types (interface{}) to Terraform's types.Dynamic, supporting strings, numbers, booleans, arrays, and objects. Updated `copyVariableToModel` to use this conversion and properly set the Value field.

This fixes both the drift detection issue and makes `ignore_changes = [value]` work correctly since state now accurately reflects the API state.

Closes #579

Closes https://linear.app/prefect/issue/PLA-2063/prefect-variable-value-change

### Validation


```terraform
terraform {
  required_providers {
    prefect = {
      source = "prefecthq/prefect"
    }
  }
}

provider "prefect" {
  endpoint = "http://localhost:4200"
}

resource "prefect_variable" "variable" {
  name  = "my-variable"
  value = "my-value"
  tags  = ["tag1", "tag2"]
}
```

Applied this config and then updated the value in the UI.

Before this change:

```
$ tf plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in ../../.build
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
prefect_variable.variable: Refreshing state... [id=07509f96-64ba-4566-88f7-8890e266e88d]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

After this change:

```
$ tf plan
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - prefecthq/prefect in ../../.build
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
prefect_variable.variable: Refreshing state... [id=07509f96-64ba-4566-88f7-8890e266e88d]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # prefect_variable.variable will be updated in-place
  ~ resource "prefect_variable" "variable" {
        id      = "07509f96-64ba-4566-88f7-8890e266e88d"
        name    = "my-variable"
        tags    = [
            "tag1",
            "tag2",
        ]
      ~ updated = "2025-10-09T14:19:34Z" -> (known after apply)
      ~ value   = "my-value-from-ui" -> "my-value"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`