### PR TITLE
feat: add global_concurrency_limit_id support to deployments

### DIFF
--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -69,6 +69,7 @@ data "prefect_deployment" "existing_by_id_string" {
 - `enforce_parameter_schema` (Boolean) Whether or not the deployment should enforce the parameter schema.
 - `entrypoint` (String) The path to the entrypoint for the workflow, relative to the path.
 - `flow_id` (String) Flow ID (UUID) to associate deployment to
+- `global_concurrency_limit_id` (String) The ID of a global concurrency limit applied to this deployment.
 - `job_variables` (String) Overrides for the flow's infrastructure configuration.
 - `manifest_path` (String, Deprecated) The path to the flow's manifest file, relative to the chosen storage.
 - `parameter_openapi_schema` (String) The parameter schema of the flow, including defaults.

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -121,6 +121,7 @@ resource "prefect_deployment" "deployment" {
 - `description` (String) A description for the deployment.
 - `enforce_parameter_schema` (Boolean) Whether or not the deployment should enforce the parameter schema.
 - `entrypoint` (String) The path to the entrypoint for the workflow, relative to the path.
+- `global_concurrency_limit_id` (String) The ID of a global concurrency limit to apply to this deployment. This is the recommended way to set concurrency limits. Mutually exclusive with concurrency_limit.
 - `job_variables` (String) Overrides for the flow's infrastructure configuration.
 - `manifest_path` (String, Deprecated) The path to the flow's manifest file, relative to the chosen storage.
 - `parameter_openapi_schema` (String) The parameter schema of the flow, including defaults.

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -44,44 +44,46 @@ type Deployment struct {
 
 // DeploymentCreate is a subset of Deployment used when creating deployments.
 type DeploymentCreate struct {
-	ConcurrencyLimit       *int64                 `json:"concurrency_limit,omitempty"`
-	ConcurrencyOptions     *ConcurrencyOptions    `json:"concurrency_options,omitempty"`
-	Description            string                 `json:"description,omitempty"`
-	EnforceParameterSchema *bool                  `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint             string                 `json:"entrypoint,omitempty"`
-	FlowID                 uuid.UUID              `json:"flow_id"` // required
-	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
-	Name                   string                 `json:"name"` // required
-	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema"`
-	Parameters             map[string]interface{} `json:"parameters"`
-	Path                   string                 `json:"path,omitempty"`
-	Paused                 bool                   `json:"paused,omitempty"`
-	PullSteps              []PullStep             `json:"pull_steps,omitempty"`
-	StorageDocumentID      *uuid.UUID             `json:"storage_document_id,omitempty"`
-	Tags                   []string               `json:"tags,omitempty"`
-	Version                string                 `json:"version,omitempty"`
-	WorkPoolName           string                 `json:"work_pool_name,omitempty"`
-	WorkQueueName          string                 `json:"work_queue_name,omitempty"`
+	ConcurrencyLimit         *int64                 `json:"concurrency_limit,omitempty"`
+	ConcurrencyOptions       *ConcurrencyOptions    `json:"concurrency_options,omitempty"`
+	Description              string                 `json:"description,omitempty"`
+	EnforceParameterSchema   *bool                  `json:"enforce_parameter_schema,omitempty"`
+	Entrypoint               string                 `json:"entrypoint,omitempty"`
+	FlowID                   uuid.UUID              `json:"flow_id"` // required
+	GlobalConcurrencyLimitID *uuid.UUID             `json:"global_concurrency_limit_id,omitempty"`
+	JobVariables             map[string]interface{} `json:"job_variables,omitempty"`
+	Name                     string                 `json:"name"` // required
+	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema"`
+	Parameters               map[string]interface{} `json:"parameters"`
+	Path                     string                 `json:"path,omitempty"`
+	Paused                   bool                   `json:"paused,omitempty"`
+	PullSteps                []PullStep             `json:"pull_steps,omitempty"`
+	StorageDocumentID        *uuid.UUID             `json:"storage_document_id,omitempty"`
+	Tags                     []string               `json:"tags,omitempty"`
+	Version                  string                 `json:"version,omitempty"`
+	WorkPoolName             string                 `json:"work_pool_name,omitempty"`
+	WorkQueueName            string                 `json:"work_queue_name,omitempty"`
 }
 
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
 type DeploymentUpdate struct {
-	ConcurrencyLimit       *int64                 `json:"concurrency_limit,omitempty"`
-	ConcurrencyOptions     *ConcurrencyOptions    `json:"concurrency_options"`
-	Description            string                 `json:"description,omitempty"`
-	EnforceParameterSchema *bool                  `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint             string                 `json:"entrypoint,omitempty"`
-	JobVariables           map[string]interface{} `json:"job_variables,omitempty"`
-	ParameterOpenAPISchema map[string]interface{} `json:"parameter_openapi_schema"`
-	Parameters             map[string]interface{} `json:"parameters"`
-	Path                   string                 `json:"path,omitempty"`
-	Paused                 bool                   `json:"paused,omitempty"`
-	PullSteps              []PullStep             `json:"pull_steps,omitempty"`
-	StorageDocumentID      *uuid.UUID             `json:"storage_document_id,omitempty"`
-	Tags                   []string               `json:"tags,omitempty"`
-	Version                string                 `json:"version,omitempty"`
-	WorkPoolName           string                 `json:"work_pool_name,omitempty"`
-	WorkQueueName          string                 `json:"work_queue_name,omitempty"`
+	ConcurrencyLimit         *int64                 `json:"concurrency_limit,omitempty"`
+	ConcurrencyOptions       *ConcurrencyOptions    `json:"concurrency_options"`
+	Description              string                 `json:"description,omitempty"`
+	EnforceParameterSchema   *bool                  `json:"enforce_parameter_schema,omitempty"`
+	Entrypoint               string                 `json:"entrypoint,omitempty"`
+	GlobalConcurrencyLimitID *uuid.UUID             `json:"global_concurrency_limit_id,omitempty"`
+	JobVariables             map[string]interface{} `json:"job_variables,omitempty"`
+	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema"`
+	Parameters               map[string]interface{} `json:"parameters"`
+	Path                     string                 `json:"path,omitempty"`
+	Paused                   bool                   `json:"paused,omitempty"`
+	PullSteps                []PullStep             `json:"pull_steps,omitempty"`
+	StorageDocumentID        *uuid.UUID             `json:"storage_document_id,omitempty"`
+	Tags                     []string               `json:"tags,omitempty"`
+	Version                  string                 `json:"version,omitempty"`
+	WorkPoolName             string                 `json:"work_pool_name,omitempty"`
+	WorkQueueName            string                 `json:"work_queue_name,omitempty"`
 }
 
 // ConcurrencyOptions is a representation of the deployment concurrency options.
@@ -91,12 +93,13 @@ type ConcurrencyOptions struct {
 
 // CurrentGlobalConcurrencyLimit is a representation of the deployment global concurrency limit.
 type CurrentGlobalConcurrencyLimit struct {
-	Limit int64 `json:"limit"`
+	ID    uuid.UUID `json:"id"`
+	Limit int64     `json:"limit"`
 
 	// These other fields exist in the response payload, but we don't make use of them at the
 	// moment, so we'll leave them disabled for now.
 	//
-	// BaseModel
+	// BaseModel (Created, Updated)
 	// Active             bool   `json:"active"`
 	// Name               string `json:"name"`
 	// ActiveSlots        int    `json:"active_slots"`

--- a/internal/provider/datasources/deployment.go
+++ b/internal/provider/datasources/deployment.go
@@ -185,6 +185,11 @@ For more information, see [deploy overview](https://docs.prefect.io/v3/deploy/in
 					},
 				},
 			},
+			"global_concurrency_limit_id": schema.StringAttribute{
+				Computed:    true,
+				CustomType:  customtypes.UUIDType{},
+				Description: "The ID of a global concurrency limit applied to this deployment.",
+			},
 			// Pull steps are polymorphic and can have different schemas based on the pull step type.
 			// In the resource schema, we only make `type` required. The other attributes are needed
 			// based on the pull step type, which we'll validate in the resource layer.

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -630,6 +630,9 @@ func CopyDeploymentToModel(ctx context.Context, deployment *api.Deployment, mode
 		if !model.ConcurrencyLimit.IsNull() {
 			model.ConcurrencyLimit = types.Int64Value(deployment.GlobalConcurrencyLimit.Limit)
 		}
+	} else {
+		// If no global concurrency limit is set, ensure the field is explicitly null (not unknown)
+		model.GlobalConcurrencyLimitID = customtypes.NewUUIDNull()
 	}
 
 	if deployment.ConcurrencyOptions != nil {

--- a/internal/provider/resources/global_concurrency_limit.go
+++ b/internal/provider/resources/global_concurrency_limit.go
@@ -226,6 +226,10 @@ func (r *GlobalConcurrencyLimitResource) Delete(ctx context.Context, req resourc
 
 	err = client.Delete(ctx, state.ID.ValueString())
 	if err != nil {
+		// If the resource is already gone (404), that's fine - it's already deleted
+		if helpers.Is404Error(err) {
+			return
+		}
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Global Concurrency Limit", "delete", err))
 
 		return


### PR DESCRIPTION
### Summary

Follow-up to https://github.com/PrefectHQ/terraform-provider-prefect/pull/487

Related to https://linear.app/prefect/issue/PLA-1338/add-global-concurrency-limit-to-prefect-deployment-create-and-update

The Prefect API has moved from the old `concurrency_limit` (integer) approach to a new `global_concurrency_limit_id` (UUID reference) that points to a separately managed global concurrency limit resource. This gives users better control and reusability of concurrency limits across deployments.

Changes:
- Added `global_concurrency_limit_id` attribute to deployment resource (optional, computed)
- Made it mutually exclusive with the existing `concurrency_limit` field
- Updated API structs to send/receive the new field in create and update operations
- Added the `ID` field to `CurrentGlobalConcurrencyLimit` struct (was missing)
- Added test coverage for creating and updating deployments with global concurrency limit references

The old `concurrency_limit` attribute continues to work for backwards compatibility. Users can now choose between:
- Setting `concurrency_limit` directly (old way, still works)
- Referencing a `prefect_global_concurrency_limit` resource via ID (new recommended way)

Closes #482

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [x] Documentation is added (generated by `mise run docs` from source code)
- [x] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources/prefect_<name>/data-source.tf`