### PR TITLE
refactor(tests): use index-based string interpolation

### DIFF
--- a/internal/provider/datasources/variable_test.go
+++ b/internal/provider/datasources/variable_test.go
@@ -11,20 +11,20 @@ import (
 
 func fixtureAccVariableByName(workspace, workspaceIDArg, name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "prefect_variable" "test" {
-	name = "%s"
+	name = "%[3]s"
 	value = "variable value goes here"
-	%s
+	%[2]s
 }
 
 data "prefect_variable" "test" {
-	name = "%s"
-	%s
+	name = "%[3]s"
+	%[2]s
 	depends_on = [prefect_variable.test]
 }
-	`, workspace, name, workspaceIDArg, name, workspaceIDArg)
+	`, workspace, workspaceIDArg, name)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/datasources/work_pool_test.go
+++ b/internal/provider/datasources/work_pool_test.go
@@ -11,34 +11,34 @@ import (
 
 func fixtureAccSingleWorkPool(workspace, workspaceIDArg, name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "prefect_work_pool" "test" {
-	name = "%s"
+	name = "%[3]s"
 	type = "kubernetes"
-	%s
+	%[2]s
 }
 
 data "prefect_work_pool" "test" {
-	name = "%s"
-	%s
+	name = "%[3]s"
+	%[2]s
 	depends_on = [prefect_work_pool.test]
 }
-`, workspace, name, workspaceIDArg, name, workspaceIDArg)
+`, workspace, workspaceIDArg, name)
 }
 
 func fixtureAccMultipleWorkPools(workspace, workspaceIDArg, name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "prefect_work_pool" "test" {
-	name = "%s"
+	name = "%[3]s"
 	type = "kubernetes"
-	%s
+	%[2]s
 }
 
 data "prefect_work_pools" "test" {
-	%s
+	%[2]s
 
 	filter_any = [
 	  prefect_work_pool.test.id,
@@ -46,7 +46,7 @@ data "prefect_work_pools" "test" {
 
 	depends_on = [prefect_work_pool.test]
 }
-`, workspace, name, workspaceIDArg, workspaceIDArg)
+`, workspace, workspaceIDArg, name)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/datasources/work_queue_test.go
+++ b/internal/provider/datasources/work_queue_test.go
@@ -54,32 +54,32 @@ func fixtureAccMultipleWorkQueue(
 	workQueue2Name string,
 ) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "prefect_work_pool" "test_multi" {
-  name = "%s"
+  name = "%[3]s"
   type = "kubernetes"
   paused = "false"
-	%s
+	%[2]s
 }
 
 resource "prefect_work_queue" "test_queue1" {
-  name = "%s"
+  name = "%[4]s"
   work_pool_name = prefect_work_pool.test_multi.name
   priority = 1
   description = "my work queue"
-	%s
+	%[2]s
 }
 
 resource "prefect_work_queue" "test_queue2" {
-  name = "%s"
+  name = "%[5]s"
   work_pool_name = prefect_work_pool.test_multi.name
-	%s
+	%[2]s
 }
 
 data "prefect_work_queues" "test" {
   work_pool_name = prefect_work_pool.test_multi.name
-	%s
+	%[2]s
   depends_on = [
     prefect_work_pool.test_multi,
     prefect_work_queue.test_queue1,
@@ -87,7 +87,7 @@ data "prefect_work_queues" "test" {
   ]
 }
 
-`, workspace, workPoolName, workspaceIDArg, workQueue1Name, workspaceIDArg, workQueue2Name, workspaceIDArg, workspaceIDArg)
+`, workspace, workspaceIDArg, workPoolName, workQueue1Name, workQueue2Name)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/datasources/work_queue_test.go
+++ b/internal/provider/datasources/work_queue_test.go
@@ -20,30 +20,30 @@ func fixtureAccSingleWorkQueue(
 	workQueueName string,
 ) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "prefect_work_pool" "test" {
-  name = "%s"
+  name = "%[2]s"
   type = "kubernetes"
   paused = "false"
-	%s
+	%[3]s
 }
 
 resource "prefect_work_queue" "test" {
-  name = "%s"
+  name = "%[4]s"
   work_pool_name = prefect_work_pool.test.name
   priority = 1
   description = "my work queue"
-	%s
+	%[3]s
 }
 
 data "prefect_work_queue" "test" {
   name = prefect_work_queue.test.name
   work_pool_name = prefect_work_pool.test.name
-	%s
+	%[3]s
 }
 
-`, workspace, workPoolName, workspaceIDArg, workQueueName, workspaceIDArg, workspaceIDArg)
+`, workspace, workPoolName, workspaceIDArg, workQueueName)
 }
 
 func fixtureAccMultipleWorkQueue(

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -194,61 +194,61 @@ func TestAccResource_deployment_with_global_concurrency_limit(t *testing.T) {
 
 	// Configuration for creating deployment with first global concurrency limit
 	cfgCreate := fmt.Sprintf(`
-%s
+%[1]s
 
-resource "prefect_flow" "%s" {
-	name = "%s"
-	%s
+resource "prefect_flow" "%[2]s" {
+	name = "%[2]s"
+	%[3]s
 }
 
 resource "prefect_global_concurrency_limit" "test1" {
-	name = "%s"
+	name = "%[4]s"
 	limit = 5
-	%s
+	%[3]s
 }
 
 resource "prefect_global_concurrency_limit" "test2" {
-	name = "%s"
+	name = "%[5]s"
 	limit = 10
-	%s
+	%[3]s
 }
 
-resource "prefect_deployment" "%s" {
-	name = "%s"
-	flow_id = prefect_flow.%s.id
+resource "prefect_deployment" "%[6]s" {
+	name = "%[6]s"
+	flow_id = prefect_flow.%[2]s.id
 	global_concurrency_limit_id = prefect_global_concurrency_limit.test1.id
-	%s
+	%[3]s
 }
-`, workspace.Resource, flowName, flowName, workspace.IDArg, gcl1Name, workspace.IDArg, gcl2Name, workspace.IDArg, deploymentName, deploymentName, flowName, workspace.IDArg)
+`, workspace.Resource, flowName, workspace.IDArg, gcl1Name, gcl2Name, deploymentName)
 
 	// Configuration for updating deployment to use second global concurrency limit
 	cfgUpdate := fmt.Sprintf(`
-%s
+%[1]s
 
-resource "prefect_flow" "%s" {
-	name = "%s"
-	%s
+resource "prefect_flow" "%[2]s" {
+	name = "%[2]s"
+	%[3]s
 }
 
 resource "prefect_global_concurrency_limit" "test1" {
-	name = "%s"
+	name = "%[4]s"
 	limit = 5
-	%s
+	%[3]s
 }
 
 resource "prefect_global_concurrency_limit" "test2" {
-	name = "%s"
+	name = "%[5]s"
 	limit = 10
-	%s
+	%[3]s
 }
 
-resource "prefect_deployment" "%s" {
-	name = "%s"
-	flow_id = prefect_flow.%s.id
+resource "prefect_deployment" "%[6]s" {
+	name = "%[6]s"
+	flow_id = prefect_flow.%[2]s.id
 	global_concurrency_limit_id = prefect_global_concurrency_limit.test2.id
-	%s
+	%[3]s
 }
-`, workspace.Resource, flowName, flowName, workspace.IDArg, gcl1Name, workspace.IDArg, gcl2Name, workspace.IDArg, deploymentName, deploymentName, flowName, workspace.IDArg)
+`, workspace.Resource, flowName, workspace.IDArg, gcl1Name, gcl2Name, deploymentName)
 
 	deploymentResourceName := fmt.Sprintf("prefect_deployment.%s", deploymentName)
 

--- a/internal/provider/resources/webhooks_test.go
+++ b/internal/provider/resources/webhooks_test.go
@@ -15,34 +15,34 @@ import (
 
 func fixtureAccWebhook(workspace, name, template string, enabled bool) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
-resource "prefect_webhook" "%s" {
-	name = "%s"
-	template = jsonencode(%s)
-	enabled = %t
+resource "prefect_webhook" "%[2]s" {
+	name = "%[2]s"
+	template = jsonencode(%[3]s)
+	enabled = %[4]t
 	workspace_id = prefect_workspace.test.id
 }
-`, workspace, name, name, template, enabled)
+`, workspace, name, template, enabled)
 }
 
 func fixtureAccWebhookWithServiceAccount(workspace, name, template string, enabled bool) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "prefect_service_account" "service_account" {
   name = "service-account"
   account_role_name = "Member"
 }
 
-resource "prefect_webhook" "%s" {
-	name = "%s"
-	template = jsonencode(%s)
-	enabled = %t
+resource "prefect_webhook" "%[2]s" {
+	name = "%[2]s"
+	template = jsonencode(%[3]s)
+	enabled = %[4]t
 	workspace_id = prefect_workspace.test.id
 	service_account_id = prefect_service_account.service_account.id
 }
-`, workspace, name, name, template, enabled)
+`, workspace, name, template, enabled)
 }
 
 func fixtureAccWebhookWithRawTemplate(workspace, name string, enabled bool) string {

--- a/internal/provider/resources/work_pool_test.go
+++ b/internal/provider/resources/work_pool_test.go
@@ -23,16 +23,16 @@ resource "prefect_work_pool" "invalid_work_pool" {
 
 func fixtureAccWorkPoolCreate(workspace, workspaceIDArg, name, poolType, baseJobTemplate string, paused bool) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
-resource "prefect_work_pool" "%s" {
-	name = "%s"
-	type = "%s"
-	paused = %t
-	base_job_template = jsonencode(%s)
-	%s
+resource "prefect_work_pool" "%[3]s" {
+	name = "%[3]s"
+	type = "%[4]s"
+	paused = %[6]t
+	base_job_template = jsonencode(%[5]s)
+	%[2]s
 }
-`, workspace, name, name, poolType, paused, baseJobTemplate, workspaceIDArg)
+`, workspace, workspaceIDArg, name, poolType, baseJobTemplate, paused)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead

--- a/internal/provider/resources/work_queue_test.go
+++ b/internal/provider/resources/work_queue_test.go
@@ -24,25 +24,25 @@ func fixtureAccWorkQueueCreate(
 	description string,
 ) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
-resource "prefect_work_pool" "%s" {
-  name = "%s"
-  type = "%s"
-  paused = %t
-  base_job_template = jsonencode(%s)
-  %s
+resource "prefect_work_pool" "%[3]s" {
+  name = "%[3]s"
+  type = "%[4]s"
+  paused = %[6]t
+  base_job_template = jsonencode(%[5]s)
+  %[2]s
 }
 
-resource "prefect_work_queue" "%s" {
-  name = "%s"
-  work_pool_name = prefect_work_pool.%s.name
-  priority = %d
-  description = "%s"
-  %s
+resource "prefect_work_queue" "%[7]s" {
+  name = "%[7]s"
+  work_pool_name = prefect_work_pool.%[3]s.name
+  priority = %[8]d
+  description = "%[9]s"
+  %[2]s
 }
 
-`, workspace, workPoolName, workPoolName, poolType, paused, baseJobTemplate, workspaceIDArg, workQueueName, workQueueName, workPoolName, priority, description, workspaceIDArg)
+`, workspace, workspaceIDArg, workPoolName, poolType, baseJobTemplate, paused, workQueueName, priority, description)
 }
 
 //nolint:paralleltest // we use the resource.ParallelTest helper instead


### PR DESCRIPTION
Convert fixtureAccSingleWorkQueue to use index-based fmt.Sprintf
interpolation (%[1]s, %[2]s, etc.) instead of positional interpolation.
This allows the workspaceIDArg parameter to be reused multiple times
without repeating it in the arguments list, improving maintainability.

Closes https://linear.app/prefect/issue/PLA-2139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

### Summary

<!-- Add a brief description of your change here -->

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
