### PR TITLE
fix: address flaky tests for provider profile feature

### DIFF
--- a/internal/provider/profile_test.go
+++ b/internal/provider/profile_test.go
@@ -24,7 +24,7 @@ func envFromOS() string {
 }
 
 func TestLoadPrefectProviderModel(t *testing.T) {
-	t.Parallel()
+	// Note: Cannot use t.Parallel() when subtests use t.Setenv() to modify environment variables
 
 	tests := []struct {
 		name            string
@@ -99,7 +99,7 @@ invalid toml content
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// Note: Cannot use t.Parallel() when using t.Setenv() to modify environment variables
 
 			// Create a temporary directory for the test
 			tempDir := t.TempDir()
@@ -114,11 +114,7 @@ invalid toml content
 
 			// Mock the user home directory
 			env := envFromOS()
-			originalHome := os.Getenv(env)
-			t.Cleanup(func() {
-				os.Setenv(env, originalHome)
-			})
-			os.Setenv(env, tempDir)
+			t.Setenv(env, tempDir)
 
 			// Test the function
 			auth, err := provider.LoadProfileAuth(context.Background(), "", "")
@@ -135,18 +131,14 @@ invalid toml content
 }
 
 func TestLoadPrefectProviderModel_NoProfilesFile(t *testing.T) {
-	t.Parallel()
+	// Note: Cannot use t.Parallel() when using t.Setenv() to modify environment variables
 
 	// Create a temporary directory without a profiles file
 	tempDir := t.TempDir()
 
 	// Mock the user home directory
 	env := envFromOS()
-	originalHome := os.Getenv(env)
-	t.Cleanup(func() {
-		os.Setenv(env, originalHome)
-	})
-	os.Setenv(env, tempDir)
+	t.Setenv(env, tempDir)
 
 	// Test the function
 	auth, err := provider.LoadProfileAuth(context.Background(), "", "")
@@ -156,7 +148,7 @@ func TestLoadPrefectProviderModel_NoProfilesFile(t *testing.T) {
 }
 
 func TestLoadPrefectProviderModel_EmptyProfilesFile(t *testing.T) {
-	t.Parallel()
+	// Note: Cannot use t.Parallel() when using t.Setenv() to modify environment variables
 
 	// Create a temporary directory with an empty profiles file
 	tempDir := t.TempDir()
@@ -170,11 +162,7 @@ func TestLoadPrefectProviderModel_EmptyProfilesFile(t *testing.T) {
 
 	// Mock the user home directory
 	env := envFromOS()
-	originalHome := os.Getenv(env)
-	t.Cleanup(func() {
-		os.Setenv(env, originalHome)
-	})
-	os.Setenv(env, tempDir)
+	t.Setenv(env, tempDir)
 
 	// Test the function
 	auth, err := provider.LoadProfileAuth(context.Background(), "", "")
@@ -184,7 +172,7 @@ func TestLoadPrefectProviderModel_EmptyProfilesFile(t *testing.T) {
 }
 
 func TestLoadPrefectProviderModel_SpecificProfile(t *testing.T) {
-	t.Parallel()
+	// Note: Cannot use t.Parallel() when subtests use t.Setenv() to modify environment variables
 
 	tests := []struct {
 		name            string
@@ -245,7 +233,7 @@ PREFECT_API_KEY = "active-key"
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// Note: Cannot use t.Parallel() when using t.Setenv() to modify environment variables
 
 			// Create a temporary directory for the test
 			tempDir := t.TempDir()
@@ -260,11 +248,7 @@ PREFECT_API_KEY = "active-key"
 
 			// Mock the user home directory
 			env := envFromOS()
-			originalHome := os.Getenv(env)
-			t.Cleanup(func() {
-				os.Setenv(env, originalHome)
-			})
-			os.Setenv(env, tempDir)
+			t.Setenv(env, tempDir)
 
 			// Test the function
 			auth, err := provider.LoadProfileAuth(context.Background(), tt.profileName, "")

--- a/internal/provider/provider_profile_integration_test.go
+++ b/internal/provider/provider_profile_integration_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestProviderWithProfileIntegration(t *testing.T) {
-	t.Parallel()
+	// Note: Cannot use t.Parallel() when using t.Setenv() to modify environment variables
 
 	// Create a temporary directory for the test
 	tempDir := t.TempDir()
@@ -40,11 +40,7 @@ PREFECT_CSRF_ENABLED = "true"
 
 	// Mock the user home directory
 	env := envFromOS()
-	originalHome := os.Getenv(env)
-	t.Cleanup(func() {
-		os.Setenv(env, originalHome)
-	})
-	os.Setenv(env, tempDir)
+	t.Setenv(env, tempDir)
 
 	// Test that the provider can be created
 	p := provider.New()
@@ -55,7 +51,7 @@ PREFECT_CSRF_ENABLED = "true"
 }
 
 func TestProviderProfilePrecedence(t *testing.T) {
-	t.Parallel()
+	// Note: Cannot use t.Parallel() when using t.Setenv() to modify environment variables
 
 	// Create a temporary directory for the test
 	tempDir := t.TempDir()
@@ -78,13 +74,7 @@ PREFECT_API_KEY = "profile-api-key"
 
 	// Mock the user home directory
 	env := envFromOS()
-	originalHome := os.Getenv(env)
-	t.Cleanup(func() {
-		os.Setenv(env, originalHome)
-		os.Unsetenv("PREFECT_API_URL")
-		os.Unsetenv("PREFECT_API_KEY")
-	})
-	os.Setenv(env, tempDir)
+	t.Setenv(env, tempDir)
 
 	// Test 1: Profile should be used when no environment variables are set
 	auth, err := provider.LoadProfileAuth(context.Background(), "", "")
@@ -94,8 +84,8 @@ PREFECT_API_KEY = "profile-api-key"
 	assert.Equal(t, customtypes.NewUUIDNull(), auth.AccountID)
 
 	// Test 2: Environment variables should override profile
-	os.Setenv("PREFECT_API_URL", "https://env-api.prefect.cloud/api")
-	os.Setenv("PREFECT_API_KEY", "env-api-key")
+	t.Setenv("PREFECT_API_URL", "https://env-api.prefect.cloud/api")
+	t.Setenv("PREFECT_API_KEY", "env-api-key")
 
 	// Reload profile (in real usage, this would be handled by the provider)
 	auth, err = provider.LoadProfileAuth(context.Background(), "", "")


### PR DESCRIPTION
### Summary

Fixes a flaky test failure in `TestProviderProfilePrecedence` that was caused by a race condition when tests ran in parallel while modifying the HOME/USERPROFILE environment variable.

The issue occurred when multiple tests using `t.Parallel()` modified the same environment variable simultaneously. This caused tests to occasionally read from the wrong temporary directory, resulting in empty profile values (`auth.Endpoint` and `auth.APIKey` returning empty strings).

Go's testing framework explicitly prevents using `t.Setenv()` with `t.Parallel()` to avoid exactly this type of race. The fix removes `t.Parallel()` from tests that need to modify environment variables, allowing them to run sequentially while still using `t.Setenv()` for proper automatic cleanup.

Tests that don't modify environment variables (like `TestLoadPrefectProviderModel_CustomProfileFile`) continue to run in parallel for better performance.

Verified the fix with 100+ consecutive test runs showing no failures.

Closes [PLA-2140](https://linear.app/prefect/issue/PLA-2140/fix-flaky-testproviderprofileprecedence-due-to-parallel-environment)

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`