### PR TITLE
fix: prevent mise from auto-installing unnecessary tools in CI

### DIFF
--- a/.github/workflows/acceptance-tests-oss.yaml
+++ b/.github/workflows/acceptance-tests-oss.yaml
@@ -35,6 +35,9 @@ jobs:
         with:
           install_args: gotestsum terraform
 
+      - name: Disable mise auto-install for task runs
+        run: mise settings set task_run_auto_install false
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/acceptance-tests-oss.yaml
+++ b/.github/workflows/acceptance-tests-oss.yaml
@@ -46,5 +46,3 @@ jobs:
 
       - name: Run acceptance tests - OSS
         run: mise run testacc-oss
-        env:
-          MISE_TASK_RUN_AUTO_INSTALL: false

--- a/.github/workflows/acceptance-tests-oss.yaml
+++ b/.github/workflows/acceptance-tests-oss.yaml
@@ -43,3 +43,5 @@ jobs:
 
       - name: Run acceptance tests - OSS
         run: mise run testacc-oss
+        env:
+          MISE_AUTO_INSTALL: false

--- a/.github/workflows/acceptance-tests-oss.yaml
+++ b/.github/workflows/acceptance-tests-oss.yaml
@@ -44,4 +44,4 @@ jobs:
       - name: Run acceptance tests - OSS
         run: mise run testacc-oss
         env:
-          MISE_AUTO_INSTALL: false
+          MISE_TASK_RUN_AUTO_INSTALL: false

--- a/.github/workflows/acceptance-tests-sweepers.yaml
+++ b/.github/workflows/acceptance-tests-sweepers.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Run sweeper tests
         run: mise run testacc-sweepers
         env:
+          MISE_AUTO_INSTALL: false
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           PREFECT_API_KEY: ${{ secrets.ACC_TEST_PREFECT_API_KEY }}
           PREFECT_CLOUD_ACCOUNT_ID: ${{ secrets.ACC_TEST_PREFECT_CLOUD_ACCOUNT_ID }}

--- a/.github/workflows/acceptance-tests-sweepers.yaml
+++ b/.github/workflows/acceptance-tests-sweepers.yaml
@@ -30,6 +30,8 @@ jobs:
         uses: jdx/mise-action@v3
         with:
           install_args: terraform
+      - name: Disable mise auto-install for task runs
+        run: mise settings set task_run_auto_install false
       - name: Run sweeper tests
         run: mise run testacc-sweepers
         env:

--- a/.github/workflows/acceptance-tests-sweepers.yaml
+++ b/.github/workflows/acceptance-tests-sweepers.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Run sweeper tests
         run: mise run testacc-sweepers
         env:
-          MISE_AUTO_INSTALL: false
+          MISE_TASK_RUN_AUTO_INSTALL: false
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           PREFECT_API_KEY: ${{ secrets.ACC_TEST_PREFECT_API_KEY }}
           PREFECT_CLOUD_ACCOUNT_ID: ${{ secrets.ACC_TEST_PREFECT_CLOUD_ACCOUNT_ID }}

--- a/.github/workflows/acceptance-tests-sweepers.yaml
+++ b/.github/workflows/acceptance-tests-sweepers.yaml
@@ -35,7 +35,6 @@ jobs:
       - name: Run sweeper tests
         run: mise run testacc-sweepers
         env:
-          MISE_TASK_RUN_AUTO_INSTALL: false
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           PREFECT_API_KEY: ${{ secrets.ACC_TEST_PREFECT_API_KEY }}
           PREFECT_CLOUD_ACCOUNT_ID: ${{ secrets.ACC_TEST_PREFECT_CLOUD_ACCOUNT_ID }}

--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -52,6 +52,7 @@ jobs:
       - name: Run acceptance tests
         run: mise run testacc
         env:
+          MISE_AUTO_INSTALL: false
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           # This is an API key generated as the `All Powerful Acceptance Test Bot`
           # service account.
@@ -61,6 +62,7 @@ jobs:
       - name: Run acceptance tests (user resource)
         run: mise run testacc
         env:
+          MISE_AUTO_INSTALL: false
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           # This is an API key generated as the Marvin user (marvin@prefect.io).
           # We do this because the User API requires requests to come from an API

--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -49,6 +49,9 @@ jobs:
         with:
           install_args: gotestsum terraform
 
+      - name: Disable mise auto-install for task runs
+        run: mise settings set task_run_auto_install false
+
       - name: Run acceptance tests
         run: mise run testacc
         env:

--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -55,7 +55,6 @@ jobs:
       - name: Run acceptance tests
         run: mise run testacc
         env:
-          MISE_TASK_RUN_AUTO_INSTALL: false
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           # This is an API key generated as the `All Powerful Acceptance Test Bot`
           # service account.
@@ -65,7 +64,6 @@ jobs:
       - name: Run acceptance tests (user resource)
         run: mise run testacc
         env:
-          MISE_TASK_RUN_AUTO_INSTALL: false
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           # This is an API key generated as the Marvin user (marvin@prefect.io).
           # We do this because the User API requires requests to come from an API

--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Run acceptance tests
         run: mise run testacc
         env:
-          MISE_AUTO_INSTALL: false
+          MISE_TASK_RUN_AUTO_INSTALL: false
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           # This is an API key generated as the `All Powerful Acceptance Test Bot`
           # service account.
@@ -62,7 +62,7 @@ jobs:
       - name: Run acceptance tests (user resource)
         run: mise run testacc
         env:
-          MISE_AUTO_INSTALL: false
+          MISE_TASK_RUN_AUTO_INSTALL: false
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           # This is an API key generated as the Marvin user (marvin@prefect.io).
           # We do this because the User API requires requests to come from an API

--- a/.github/workflows/build-terraform-docs.yaml
+++ b/.github/workflows/build-terraform-docs.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Build Terraform Docs
         run: mise run docs
         env:
-          MISE_AUTO_INSTALL: false
+          MISE_TASK_RUN_AUTO_INSTALL: false
       - name: Commit changes
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/build-terraform-docs.yaml
+++ b/.github/workflows/build-terraform-docs.yaml
@@ -34,8 +34,6 @@ jobs:
         run: mise settings set task_run_auto_install false
       - name: Build Terraform Docs
         run: mise run docs
-        env:
-          MISE_TASK_RUN_AUTO_INSTALL: false
       - name: Commit changes
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/build-terraform-docs.yaml
+++ b/.github/workflows/build-terraform-docs.yaml
@@ -30,6 +30,8 @@ jobs:
         uses: jdx/mise-action@v3
         with:
           install_args: tfplugindocs
+      - name: Disable mise auto-install for task runs
+        run: mise settings set task_run_auto_install false
       - name: Build Terraform Docs
         run: mise run docs
         env:

--- a/.github/workflows/build-terraform-docs.yaml
+++ b/.github/workflows/build-terraform-docs.yaml
@@ -28,8 +28,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install tool dependencies
         uses: jdx/mise-action@v3
+        with:
+          install_args: tfplugindocs
       - name: Build Terraform Docs
         run: mise run docs
+        env:
+          MISE_AUTO_INSTALL: false
       - name: Commit changes
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/provider-build.yaml
+++ b/.github/workflows/provider-build.yaml
@@ -46,6 +46,8 @@ jobs:
         uses: jdx/mise-action@v3
         with:
           install_args: gotestsum
+      - name: Disable mise auto-install for task runs
+        run: mise settings set task_run_auto_install false
       - name: Build
         run: mise run build
         env:

--- a/.github/workflows/provider-build.yaml
+++ b/.github/workflows/provider-build.yaml
@@ -48,8 +48,12 @@ jobs:
           install_args: gotestsum
       - name: Build
         run: mise run build
+        env:
+          MISE_AUTO_INSTALL: false
       - name: Unit Test
         run: mise run test
+        env:
+          MISE_AUTO_INSTALL: false
 
   lint:
     permissions:

--- a/.github/workflows/provider-build.yaml
+++ b/.github/workflows/provider-build.yaml
@@ -49,11 +49,11 @@ jobs:
       - name: Build
         run: mise run build
         env:
-          MISE_AUTO_INSTALL: false
+          MISE_TASK_RUN_AUTO_INSTALL: false
       - name: Unit Test
         run: mise run test
         env:
-          MISE_AUTO_INSTALL: false
+          MISE_TASK_RUN_AUTO_INSTALL: false
 
   lint:
     permissions:

--- a/.github/workflows/provider-build.yaml
+++ b/.github/workflows/provider-build.yaml
@@ -50,12 +50,8 @@ jobs:
         run: mise settings set task_run_auto_install false
       - name: Build
         run: mise run build
-        env:
-          MISE_TASK_RUN_AUTO_INSTALL: false
       - name: Unit Test
         run: mise run test
-        env:
-          MISE_TASK_RUN_AUTO_INSTALL: false
 
   lint:
     permissions:


### PR DESCRIPTION
### Summary

When using `mise run`, mise was auto-installing all tools defined in .mise.toml regardless of what was specified via `install_args`. This caused workflows to install tools like 1password, golangci-lint, and goreleaser even when they weren't needed.

Set `MISE_AUTO_INSTALL: false` on all `mise run` commands and adjusted `install_args` to only include tools actually required by each workflow:
- provider-build: gotestsum
- acceptance-tests: gotestsum, terraform
- acceptance-tests-oss: gotestsum, terraform  
- acceptance-tests-sweepers: terraform
- build-terraform-docs: tfplugindocs

Example of the issue: https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/18730533697/job/53426163198

Related to [PLA-2157](https://linear.app/prefect/issue/PLA-2157/prevent-mise-from-auto-installing-unnecessary-tools-in-ci)

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
- [ ] For resources, the following are added:
- [ ] For datasources, the following is added: