### PR TITLE
fix(tests): address flaky acceptance tests with eventual consistency handling

### DIFF
--- a/internal/provider/resources/workspace_access.go
+++ b/internal/provider/resources/workspace_access.go
@@ -287,6 +287,12 @@ func (r *WorkspaceAccessResource) Delete(ctx context.Context, req resource.Delet
 
 	err = client.Delete(ctx, accessorType, accessID, accessorID)
 	if err != nil {
+		// If the resource is already deleted (404), treat as success for idempotent deletion.
+		// This can happen during test cleanup when workspace deletion cascades to delete access records.
+		if helpers.Is404Error(err) {
+			return
+		}
+
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Workspace Access", "delete", err))
 
 		return


### PR DESCRIPTION
## Problem

The automation acceptance tests have been failing intermittently on the main branch. The same test suite passes on one attempt but fails on the retry, indicating timing-dependent behavior rather than deterministic bugs.

Reference failure (attempt 2): https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/19152192965/job/54745140984
Reference success (attempt 1): https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/19152192965/job/54744917146

## Root Cause

The Prefect API exhibits eventual consistency behavior where state transformations happen asynchronously after write operations. When the provider reads immediately after a create/update, it may receive stale or partially-transformed data depending on timing.

## Changes

All fixes use the existing `retry-go` library for consistency with other resources like blocks.

### 1. Workspace Access Deletion 404s
Made deletion idempotent by treating 404 errors as success. This prevents cleanup failures when workspace deletion cascades to delete access records during parallel test execution.

### 2. Automation State Stabilization
Added retry logic using `retry-go` that waits for automation state to stabilize after create/update operations. The API asynchronously transforms the `match_related` field, and immediate reads can catch intermediate states. The retry loop:
- Reads the automation state repeatedly
- Compares consecutive reads to detect when transformation is complete
- Returns stable state once changes stop
- Uses 10 attempts with 500ms delay (up to 5 seconds total)

### 3. Webhook `enabled` Field Stabilization  
Added retry logic using `retry-go` to wait for the webhook enabled state to match the expected value after create/update operations. Same retry parameters as automation.

## Implementation Note

Uses the `github.com/avast/retry-go/v4` package for retry logic, consistent with other resources in the codebase (e.g., block resource).

Closes https://linear.app/prefect/issue/PLA-2184/flaky-automation-acceptance-tests-on-main-branch