### PR TITLE
fix(service_account): preserve API key when stabilizing after creation

### DIFF
--- a/internal/provider/resources/service_account_test.go
+++ b/internal/provider/resources/service_account_test.go
@@ -349,6 +349,12 @@ func textAccCheckServiceAccountAPIKeyStored(resourceName string, passedKey *stri
 			return fmt.Errorf("Resource not found in state: %s", resourceName)
 		}
 		key := rs.Primary.Attributes["api_key"]
+
+		// Validate that the API key is non-empty to prevent regression of issue #606
+		if key == "" {
+			return fmt.Errorf("API key is empty - this should never happen after resource creation")
+		}
+
 		*passedKey = key
 
 		return nil
@@ -386,6 +392,11 @@ func testAccCheckServiceAccountAPIKeyRotated(n string, passedKey *string) resour
 		}
 
 		key := rs.Primary.Attributes["api_key"]
+
+		// Validate that the rotated API key is non-empty to prevent regression of issue #606
+		if key == "" {
+			return fmt.Errorf("API key is empty after rotation - this should never happen")
+		}
 
 		if *passedKey == key {
 			return fmt.Errorf("key rotation did not occur correctly, as the old key=%s is the same as the new key=%s", *passedKey, key)


### PR DESCRIPTION
### Summary

In v2.90.1, the stabilization helper was added to handle eventual consistency after service account creation. However, the helper calls `Get()` which doesn't return the API key value (only metadata like ID, name, etc.). This caused the API key to be lost and stored as an empty string in state.

The fix saves the API key from the `Create()` response before calling the stabilization helper, then uses that saved value when setting state.

Also added explicit validations in acceptance tests to check that API keys are non-empty after creation and rotation. Without the fix, these tests now fail with a clear error message about empty keys.

Closes #606

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>