### PR TITLE
fix: prevent nil pointer exception on invalid URL

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -210,7 +210,8 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 			"Invalid Prefect API Endpoint",
 			fmt.Sprintf("The Prefect API Endpoint %q is not a valid URL: %s", endpoint, err),
 		)
-		endpointURL = &url.URL{} // set to empty url if error occurred
+
+		return
 	}
 
 	// Extract the API Key from configuration or environment variable.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -210,6 +210,7 @@ func (p *PrefectProvider) Configure(ctx context.Context, req provider.ConfigureR
 			"Invalid Prefect API Endpoint",
 			fmt.Sprintf("The Prefect API Endpoint %q is not a valid URL: %s", endpoint, err),
 		)
+		endpointURL = &url.URL{} // set to empty url if error occurred
 	}
 
 	// Extract the API Key from configuration or environment variable.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -82,63 +82,6 @@ func newTestConfigureRequest(t *testing.T, model *provider.PrefectProviderModel)
 	}
 }
 
-func TestConfigure_EmptyAPIKeyProducesWarning(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	prov := &provider.PrefectProvider{}
-	resp := &tfprovider.ConfigureResponse{}
-
-	config := &provider.PrefectProviderModel{
-		APIKey: types.StringValue(""), // empty string triggers warning
-	}
-
-	req := newTestConfigureRequest(t, config)
-
-	prov.Configure(ctx, req, resp)
-
-	var found bool
-	for _, d := range resp.Diagnostics {
-		if d.Severity() == diag.SeverityError && strings.Contains(d.Summary(), "Missing Prefect API Key") {
-			found = true
-
-			break
-		}
-	}
-
-	if !found {
-		t.Fatalf("expected error for empty API key")
-	}
-}
-
-// TestConfigure_MissingAPIKeyForCloud returns error.
-func TestConfigure_MissingAPIKeyForCloud(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	prov := &provider.PrefectProvider{}
-	resp := &tfprovider.ConfigureResponse{}
-
-	config := &provider.PrefectProviderModel{
-		// APIKey is missing (null by default)
-	}
-
-	req := newTestConfigureRequest(t, config)
-
-	prov.Configure(ctx, req, resp)
-
-	var found bool
-	for _, d := range resp.Diagnostics {
-		if d.Severity() == diag.SeverityError && strings.Contains(d.Summary(), "Missing Prefect API Key") {
-			found = true
-
-			break
-		}
-	}
-
-	if !found {
-		t.Fatalf("expected error for missing API key for cloud")
-	}
-}
-
 // TestConfigure_InvalidURL returns error.
 func TestConfigure_InvalidURL(t *testing.T) {
 	t.Parallel()

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,170 @@
+package provider_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	tfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	provider "github.com/prefecthq/terraform-provider-prefect/internal/provider"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
+)
+
+func setStringAttr(attrs map[string]tftypes.Value, key string, value types.String) {
+	if !value.IsNull() {
+		attrs[key] = tftypes.NewValue(tftypes.String, value.ValueString())
+	} else {
+		attrs[key] = tftypes.NewValue(tftypes.String, nil)
+	}
+}
+
+func setBoolAttr(attrs map[string]tftypes.Value, key string, value types.Bool) {
+	if !value.IsNull() {
+		attrs[key] = tftypes.NewValue(tftypes.Bool, value.ValueBool())
+	} else {
+		attrs[key] = tftypes.NewValue(tftypes.Bool, nil)
+	}
+}
+
+func setUUIDAttr(attrs map[string]tftypes.Value, key string, value customtypes.UUIDValue) {
+	if !value.IsNull() {
+		attrs[key] = tftypes.NewValue(tftypes.String, value.ValueString())
+	} else {
+		attrs[key] = tftypes.NewValue(tftypes.String, nil)
+	}
+}
+
+func newTestConfigureRequest(t *testing.T, model *provider.PrefectProviderModel) tfprovider.ConfigureRequest {
+	t.Helper()
+
+	// Manually construct tftypes.Object from PrefectProviderModel
+	attrTypes := map[string]tftypes.Type{
+		"endpoint":       tftypes.String,
+		"api_key":        tftypes.String,
+		"basic_auth_key": tftypes.String,
+		"csrf_enabled":   tftypes.Bool,
+		"account_id":     tftypes.String, // customtypes.UUIDType is based on string
+		"workspace_id":   tftypes.String,
+		"profile":        tftypes.String,
+		"profile_file":   tftypes.String,
+	}
+
+	attrs := make(map[string]tftypes.Value)
+
+	if model != nil {
+		setStringAttr(attrs, "endpoint", model.Endpoint)
+		setStringAttr(attrs, "api_key", model.APIKey)
+		setStringAttr(attrs, "basic_auth_key", model.BasicAuthKey)
+		setBoolAttr(attrs, "csrf_enabled", model.CSRFEnabled)
+		setUUIDAttr(attrs, "account_id", model.AccountID)
+		setUUIDAttr(attrs, "workspace_id", model.WorkspaceID)
+		setStringAttr(attrs, "profile", model.Profile)
+		setStringAttr(attrs, "profile_file", model.ProfileFile)
+	}
+
+	rawObject := tftypes.NewValue(tftypes.Object{AttributeTypes: attrTypes}, attrs)
+
+	p := &provider.PrefectProvider{}
+	schemaResp := &tfprovider.SchemaResponse{}
+	p.Schema(context.Background(), tfprovider.SchemaRequest{}, schemaResp)
+
+	return tfprovider.ConfigureRequest{
+		Config: tfsdk.Config{
+			Raw:    rawObject,
+			Schema: &schemaResp.Schema,
+		},
+		TerraformVersion:   "1.6.0",
+		ClientCapabilities: tfprovider.ConfigureProviderClientCapabilities{},
+	}
+}
+
+func TestConfigure_EmptyAPIKeyProducesWarning(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	prov := &provider.PrefectProvider{}
+	resp := &tfprovider.ConfigureResponse{}
+
+	config := &provider.PrefectProviderModel{
+		APIKey: types.StringValue(""), // empty string triggers warning
+	}
+
+	req := newTestConfigureRequest(t, config)
+
+	prov.Configure(ctx, req, resp)
+
+	var found bool
+	for _, d := range resp.Diagnostics {
+		if d.Severity() == diag.SeverityError && strings.Contains(d.Summary(), "Missing Prefect API Key") {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected error for empty API key")
+	}
+}
+
+// TestConfigure_MissingAPIKeyForCloud returns error.
+func TestConfigure_MissingAPIKeyForCloud(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	prov := &provider.PrefectProvider{}
+	resp := &tfprovider.ConfigureResponse{}
+
+	config := &provider.PrefectProviderModel{
+		// APIKey is missing (null by default)
+	}
+
+	req := newTestConfigureRequest(t, config)
+
+	prov.Configure(ctx, req, resp)
+
+	var found bool
+	for _, d := range resp.Diagnostics {
+		if d.Severity() == diag.SeverityError && strings.Contains(d.Summary(), "Missing Prefect API Key") {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected error for missing API key for cloud")
+	}
+}
+
+// TestConfigure_InvalidURL returns error.
+func TestConfigure_InvalidURL(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	prov := &provider.PrefectProvider{}
+	resp := &tfprovider.ConfigureResponse{}
+
+	config := &provider.PrefectProviderModel{
+		Endpoint: types.StringValue("XTes^%:98"),
+		// APIKey is missing (null by default)
+	}
+
+	req := newTestConfigureRequest(t, config)
+
+	prov.Configure(ctx, req, resp)
+
+	var found bool
+	for _, d := range resp.Diagnostics {
+		if d.Severity() == diag.SeverityError && strings.Contains(d.Summary(), "Invalid Prefect API Endpoint") {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("expected error for invalid URL")
+	}
+}


### PR DESCRIPTION
Introduced default URL in case of unparsable URL configuration argument

### Summary

fix: added a default value for a URL variable in case the provided prefect url could not be parsed to avoid nil pointer exception

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
