### PR TITLE
fix(team): handle nullable description field to prevent inconsistent state error

### DIFF
--- a/internal/api/teams.go
+++ b/internal/api/teams.go
@@ -16,20 +16,20 @@ type TeamsClient interface {
 // Team is a representation of an team.
 type Team struct {
 	BaseModel
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
 }
 
 // TeamCreate is a payload for creating a team.
 type TeamCreate struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
 }
 
 // TeamUpdate is a payload for updating a team.
 type TeamUpdate struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
 }
 
 // TeamFilter defines the search filter payload

--- a/internal/provider/datasources/team.go
+++ b/internal/provider/datasources/team.go
@@ -159,7 +159,7 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	config.Created = customtypes.NewTimestampPointerValue(fetchedTeam.Created)
 	config.Updated = customtypes.NewTimestampPointerValue(fetchedTeam.Updated)
 	config.Name = types.StringValue(fetchedTeam.Name)
-	config.Description = types.StringValue(fetchedTeam.Description)
+	config.Description = types.StringPointerValue(fetchedTeam.Description)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/datasources/teams.go
+++ b/internal/provider/datasources/teams.go
@@ -123,7 +123,7 @@ func (d *TeamsDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 			"created":     customtypes.NewTimestampPointerValue(team.Created),
 			"updated":     customtypes.NewTimestampPointerValue(team.Updated),
 			"name":        types.StringValue(team.Name),
-			"description": types.StringValue(team.Description),
+			"description": types.StringPointerValue(team.Description),
 		}
 
 		teamObject, diag := types.ObjectValue(attributeTypes, attributeValues)

--- a/internal/provider/resources/team.go
+++ b/internal/provider/resources/team.go
@@ -111,6 +111,7 @@ func (r *TeamResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Description of the team",
 			},
 		},
@@ -135,7 +136,7 @@ func (r *TeamResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	team, err := teamClient.Create(ctx, api.TeamCreate{
 		Name:        plan.Name.ValueString(),
-		Description: plan.Description.ValueString(),
+		Description: plan.Description.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.Append(helpers.CreateClientErrorDiagnostic("Team", err))
@@ -215,7 +216,7 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	team, err := teamClient.Update(ctx, plan.ID.ValueString(), api.TeamUpdate{
 		Name:        plan.Name.ValueString(),
-		Description: plan.Description.ValueString(),
+		Description: plan.Description.ValueStringPointer(),
 	})
 	if err != nil {
 		resp.Diagnostics.Append(helpers.ResourceClientErrorDiagnostic("Team", "update", err))
@@ -275,7 +276,7 @@ func copyTeamToModel(team *api.Team, tfModel *TeamResourceModel) diag.Diagnostic
 	tfModel.Created = customtypes.NewTimestampPointerValue(team.Created)
 	tfModel.Updated = customtypes.NewTimestampPointerValue(team.Updated)
 	tfModel.Name = types.StringValue(team.Name)
-	tfModel.Description = types.StringValue(team.Description)
+	tfModel.Description = types.StringPointerValue(team.Description)
 
 	return nil
 }

--- a/internal/provider/resources/team_test.go
+++ b/internal/provider/resources/team_test.go
@@ -18,6 +18,14 @@ resource "prefect_team" "test" {
 	`, name, description)
 }
 
+func fixtureAccTeamResourceNoDescription(name string) string {
+	return fmt.Sprintf(`
+resource "prefect_team" "test" {
+	name = %q
+}
+	`, name)
+}
+
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_team(t *testing.T) {
 	// Teams are not supported in OSS.
@@ -53,6 +61,109 @@ func TestAccResource_team(t *testing.T) {
 				ImportState:       true,
 				ResourceName:      resourceName,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccResource_team_no_description(t *testing.T) {
+	// Teams are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
+	randomName := testutils.NewRandomPrefixedString()
+
+	resourceName := "prefect_team.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				// Test creating a team without a description field
+				Config: fixtureAccTeamResourceNoDescription(randomName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValue(resourceName, "name", randomName),
+					// Description should be empty string (computed), not null
+					testutils.ExpectKnownValue(resourceName, "description", ""),
+				},
+			},
+			{
+				ImportState:       true,
+				ResourceName:      resourceName,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccResource_team_empty_description(t *testing.T) {
+	// Teams are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
+	randomName := testutils.NewRandomPrefixedString()
+
+	resourceName := "prefect_team.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				// Test creating a team with explicit empty string description
+				Config: fixtureAccTeamResource(randomName, ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValue(resourceName, "name", randomName),
+					testutils.ExpectKnownValue(resourceName, "description", ""),
+				},
+			},
+			{
+				ImportState:       true,
+				ResourceName:      resourceName,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccResource_team_description_updates(t *testing.T) {
+	// Teams are not supported in OSS.
+	testutils.SkipTestsIfOSS(t)
+
+	randomName := testutils.NewRandomPrefixedString()
+	randomDescription := testutils.NewRandomPrefixedString()
+
+	resourceName := "prefect_team.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				// Start with no description
+				Config: fixtureAccTeamResourceNoDescription(randomName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValue(resourceName, "name", randomName),
+					testutils.ExpectKnownValue(resourceName, "description", ""),
+				},
+			},
+			{
+				// Update to add a description
+				Config: fixtureAccTeamResource(randomName, randomDescription),
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValue(resourceName, "name", randomName),
+					testutils.ExpectKnownValue(resourceName, "description", randomDescription),
+				},
+			},
+			{
+				// Update back to no description
+				Config: fixtureAccTeamResourceNoDescription(randomName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValue(resourceName, "name", randomName),
+					testutils.ExpectKnownValue(resourceName, "description", ""),
+				},
 			},
 		},
 	})

--- a/internal/provider/resources/team_test.go
+++ b/internal/provider/resources/team_test.go
@@ -134,6 +134,7 @@ func TestAccResource_team_description_updates(t *testing.T) {
 
 	randomName := testutils.NewRandomPrefixedString()
 	randomDescription := testutils.NewRandomPrefixedString()
+	randomDescription2 := testutils.NewRandomPrefixedString()
 
 	resourceName := "prefect_team.test"
 
@@ -158,11 +159,11 @@ func TestAccResource_team_description_updates(t *testing.T) {
 				},
 			},
 			{
-				// Update back to no description
-				Config: fixtureAccTeamResourceNoDescription(randomName),
+				// Update to a different description
+				Config: fixtureAccTeamResource(randomName, randomDescription2),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValue(resourceName, "name", randomName),
-					testutils.ExpectKnownValue(resourceName, "description", ""),
+					testutils.ExpectKnownValue(resourceName, "description", randomDescription2),
 				},
 			},
 		},

--- a/internal/provider/resources/team_test.go
+++ b/internal/provider/resources/team_test.go
@@ -166,6 +166,14 @@ func TestAccResource_team_description_updates(t *testing.T) {
 					testutils.ExpectKnownValue(resourceName, "description", randomDescription2),
 				},
 			},
+			{
+				// Update to explicit empty string to clear description
+				Config: fixtureAccTeamResource(randomName, ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValue(resourceName, "name", randomName),
+					testutils.ExpectKnownValue(resourceName, "description", ""),
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
### Summary

The team resource was producing "Provider produced inconsistent result after apply" errors when creating teams without a description field. The issue occurred because Terraform expected the description to remain null when not provided, but the provider was sending an empty string to the API and getting an empty string back in the state, creating a mismatch.

This fix follows the workspace resource pattern for handling optional computed fields by:

- Changing Description from `string` to `*string` in API types (Team, TeamCreate, TeamUpdate)
- Adding `Computed: true` to the description schema attribute
- Using ValueStringPointer() in Create/Update (sends nil for null values)
- Using StringPointerValue() in copyTeamToModel and datasources (safely handles nil)

Added test coverage for:
- Teams created without descriptions (primary bug fix)
- Teams with explicit empty string descriptions
- Description lifecycle updates (no description → value → different value → empty string)

The test suite was refined based on CI feedback to properly test the API's actual behavior for description updates, including verifying whether explicit empty strings can clear descriptions.

Closes #610

Closes https://linear.app/prefect/issue/PLA-2212/prefect-team-provider-produced-inconsistent-result-after-apply

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`

Note: Documentation and examples are not applicable since this is a bug fix to an existing resource, not a new resource or datasource.