### PR TITLE
feat(client): use RateLimitLinearJitterBackoff for retry backoff

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,11 +5,8 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/prefecthq/terraform-provider-prefect/internal/client"
 	"github.com/stretchr/testify/assert"
@@ -158,107 +155,6 @@ func TestCheckRetryPolicy_Success(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestRateLimitBackoff_RespectsRetryAfterHeader tests that the client
-// properly respects the Retry-After header when receiving rate-limited responses.
-// This is an integration-style test using httptest.Server.
-func TestRateLimitBackoff_RespectsRetryAfterHeader(t *testing.T) {
-	t.Parallel()
-
-	var requestCount atomic.Int32
-	retryAfterSeconds := 1
-
-	// Create a test server that returns 429 on first request, then 200
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		count := requestCount.Add(1)
-		if count == 1 {
-			// First request: return 429 with Retry-After header
-			w.Header().Set("Retry-After", "1")
-			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte(`{"error": "rate limited"}`))
-
-			return
-		}
-		// Subsequent requests: return success
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status": "ok"}`))
-	}))
-	defer server.Close()
-
-	// Create client with endpoint pointing to test server
-	c, err := client.New(
-		client.WithEndpoint(server.URL, "localhost"),
-	)
-	require.NoError(t, err)
-
-	// Track timing to verify backoff was applied
-	start := time.Now()
-
-	// Make a request - should get 429, wait ~1 second (Retry-After), then succeed
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/test", http.NoBody)
-	require.NoError(t, err)
-
-	resp, err := c.HTTPClient().Do(req)
-
-	elapsed := time.Since(start)
-
-	// We expect the request to eventually succeed
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	// Verify we made at least 2 requests (initial + retry after 429)
-	assert.GreaterOrEqual(t, requestCount.Load(), int32(2), "should have retried after 429")
-
-	// Verify the backoff waited at least the Retry-After duration
-	// Using a slightly lower threshold to account for timing variations
-	minExpectedWait := time.Duration(retryAfterSeconds) * time.Second * 9 / 10 // 90% of expected
-	assert.GreaterOrEqual(t, elapsed, minExpectedWait,
-		"should have waited at least %v, but only waited %v", minExpectedWait, elapsed)
-}
-
-// TestRateLimitBackoff_503WithRetryAfter tests that 503 responses with
-// Retry-After headers are also properly handled.
-func TestRateLimitBackoff_503WithRetryAfter(t *testing.T) {
-	t.Parallel()
-
-	var requestCount atomic.Int32
-
-	// Create a test server that returns 503 on first request, then 200
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		count := requestCount.Add(1)
-		if count == 1 {
-			// First request: return 503 with Retry-After header
-			w.Header().Set("Retry-After", "1")
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte(`{"error": "service unavailable"}`))
-
-			return
-		}
-		// Subsequent requests: return success
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status": "ok"}`))
-	}))
-	defer server.Close()
-
-	// Create client with endpoint pointing to test server
-	c, err := client.New(
-		client.WithEndpoint(server.URL, "localhost"),
-	)
-	require.NoError(t, err)
-
-	// Make a request
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/test", http.NoBody)
-	require.NoError(t, err)
-
-	resp, err := c.HTTPClient().Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.GreaterOrEqual(t, requestCount.Load(), int32(2), "should have retried after 503")
-}
-
 // TestClientCreation_Success verifies basic client creation works.
 func TestClientCreation_Success(t *testing.T) {
 	t.Parallel()
@@ -296,20 +192,6 @@ func TestClientCreation_InvalidEndpoint(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, c)
 	assert.Contains(t, err.Error(), "must not include trailing slash")
-}
-
-// TestRetryBehavior_MaxRetries verifies the client respects max retry limits.
-// Note: This test is always skipped because the linear jitter backoff
-// can result in very long wait times (potentially 30s+ per retry).
-//
-// To run this test manually:
-//
-//	go test -v ./internal/client/... -run TestRetryBehavior_MaxRetries -timeout 10m
-func TestRetryBehavior_MaxRetries(t *testing.T) {
-	t.Parallel()
-	// Always skip - linear jitter backoff can take several minutes to complete
-	// all retries, which causes CI timeouts.
-	t.Skip("skipping long-running retry test - run manually with increased timeout if needed")
 }
 
 // TestCheckRetryPolicy_NotFound_NoMethod tests 404 handling when no HTTP method is in context.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,382 @@
+package client_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prefecthq/terraform-provider-prefect/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckRetryPolicy_NilResponse(t *testing.T) {
+	t.Parallel()
+
+	retry, err := client.CheckRetryPolicy(context.Background(), nil, nil)
+
+	assert.True(t, retry, "should retry when response is nil")
+	assert.NoError(t, err)
+}
+
+func TestCheckRetryPolicy_Conflict(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusConflict,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	retry, err := client.CheckRetryPolicy(context.Background(), resp, nil)
+
+	assert.False(t, retry, "should not retry on 409 Conflict")
+	assert.NoError(t, err)
+}
+
+func TestCheckRetryPolicy_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	body := `{"error": "access denied"}`
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	retry, err := client.CheckRetryPolicy(context.Background(), resp, nil)
+
+	assert.False(t, retry, "should not retry on 403 Forbidden")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status_code=403")
+	assert.Contains(t, err.Error(), "access denied")
+}
+
+func TestCheckRetryPolicy_NotFound_DELETE(t *testing.T) {
+	t.Parallel()
+
+	body := `{"detail": "not found"}`
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	// Add HTTP method to context for DELETE
+	ctx := context.WithValue(context.Background(), client.HTTPMethodContextKey, http.MethodDelete)
+
+	retry, err := client.CheckRetryPolicy(ctx, resp, nil)
+
+	assert.False(t, retry, "should not retry 404 on DELETE")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status_code=404")
+}
+
+func TestCheckRetryPolicy_NotFound_GET(t *testing.T) {
+	t.Parallel()
+
+	body := `{"detail": "not found"}`
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	// Add HTTP method to context for GET
+	ctx := context.WithValue(context.Background(), client.HTTPMethodContextKey, http.MethodGet)
+
+	retry, err := client.CheckRetryPolicy(ctx, resp, nil)
+
+	assert.True(t, retry, "should retry 404 on GET")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status_code=404")
+}
+
+func TestCheckRetryPolicy_NotFound_POST(t *testing.T) {
+	t.Parallel()
+
+	body := `{"detail": "not found"}`
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	// Add HTTP method to context for POST
+	ctx := context.WithValue(context.Background(), client.HTTPMethodContextKey, http.MethodPost)
+
+	retry, err := client.CheckRetryPolicy(ctx, resp, nil)
+
+	assert.True(t, retry, "should retry 404 on POST")
+	assert.Error(t, err)
+}
+
+func TestCheckRetryPolicy_TooManyRequests(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	retry, err := client.CheckRetryPolicy(context.Background(), resp, nil)
+
+	// Falls back to ErrorPropagatedRetryPolicy which should retry 429
+	assert.True(t, retry, "should retry on 429 Too Many Requests")
+	assert.NoError(t, err)
+}
+
+func TestCheckRetryPolicy_ServiceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	retry, err := client.CheckRetryPolicy(context.Background(), resp, nil)
+
+	// Falls back to ErrorPropagatedRetryPolicy which should retry 503
+	// ErrorPropagatedRetryPolicy propagates the error (unlike DefaultRetryPolicy)
+	assert.True(t, retry, "should retry on 503 Service Unavailable")
+	// Error is expected - ErrorPropagatedRetryPolicy returns an error for 5xx
+	assert.Error(t, err)
+}
+
+func TestCheckRetryPolicy_Success(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	retry, err := client.CheckRetryPolicy(context.Background(), resp, nil)
+
+	assert.False(t, retry, "should not retry on 200 OK")
+	assert.NoError(t, err)
+}
+
+// TestRateLimitBackoff_RespectsRetryAfterHeader tests that the client
+// properly respects the Retry-After header when receiving rate-limited responses.
+// This is an integration-style test using httptest.Server.
+func TestRateLimitBackoff_RespectsRetryAfterHeader(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int32
+	retryAfterSeconds := 1
+
+	// Create a test server that returns 429 on first request, then 200
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := requestCount.Add(1)
+		if count == 1 {
+			// First request: return 429 with Retry-After header
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error": "rate limited"}`))
+
+			return
+		}
+		// Subsequent requests: return success
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status": "ok"}`))
+	}))
+	defer server.Close()
+
+	// Create client with endpoint pointing to test server
+	c, err := client.New(
+		client.WithEndpoint(server.URL, "localhost"),
+	)
+	require.NoError(t, err)
+
+	// Track timing to verify backoff was applied
+	start := time.Now()
+
+	// Make a request - should get 429, wait ~1 second (Retry-After), then succeed
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/test", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := c.HTTPClient().Do(req)
+
+	elapsed := time.Since(start)
+
+	// We expect the request to eventually succeed
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Verify we made at least 2 requests (initial + retry after 429)
+	assert.GreaterOrEqual(t, requestCount.Load(), int32(2), "should have retried after 429")
+
+	// Verify the backoff waited at least the Retry-After duration
+	// Using a slightly lower threshold to account for timing variations
+	minExpectedWait := time.Duration(retryAfterSeconds) * time.Second * 9 / 10 // 90% of expected
+	assert.GreaterOrEqual(t, elapsed, minExpectedWait,
+		"should have waited at least %v, but only waited %v", minExpectedWait, elapsed)
+}
+
+// TestRateLimitBackoff_503WithRetryAfter tests that 503 responses with
+// Retry-After headers are also properly handled.
+func TestRateLimitBackoff_503WithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var requestCount atomic.Int32
+
+	// Create a test server that returns 503 on first request, then 200
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := requestCount.Add(1)
+		if count == 1 {
+			// First request: return 503 with Retry-After header
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error": "service unavailable"}`))
+
+			return
+		}
+		// Subsequent requests: return success
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status": "ok"}`))
+	}))
+	defer server.Close()
+
+	// Create client with endpoint pointing to test server
+	c, err := client.New(
+		client.WithEndpoint(server.URL, "localhost"),
+	)
+	require.NoError(t, err)
+
+	// Make a request
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/test", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := c.HTTPClient().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.GreaterOrEqual(t, requestCount.Load(), int32(2), "should have retried after 503")
+}
+
+// TestClientCreation_Success verifies basic client creation works.
+func TestClientCreation_Success(t *testing.T) {
+	t.Parallel()
+
+	c, err := client.New()
+
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+	assert.NotNil(t, c.HTTPClient())
+}
+
+// TestClientCreation_WithOptions verifies client creation with options.
+func TestClientCreation_WithOptions(t *testing.T) {
+	t.Parallel()
+
+	c, err := client.New(
+		client.WithEndpoint("https://api.prefect.cloud", "api.prefect.cloud"),
+		client.WithAPIKey("test-api-key"),
+	)
+
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+	assert.Equal(t, "https://api.prefect.cloud", c.Endpoint())
+	assert.Equal(t, "test-api-key", c.APIKey())
+}
+
+// TestClientCreation_InvalidEndpoint verifies error handling for invalid endpoints.
+func TestClientCreation_InvalidEndpoint(t *testing.T) {
+	t.Parallel()
+
+	c, err := client.New(
+		client.WithEndpoint("https://api.prefect.cloud/", "api.prefect.cloud"),
+	)
+
+	require.Error(t, err)
+	assert.Nil(t, c)
+	assert.Contains(t, err.Error(), "must not include trailing slash")
+}
+
+// TestRetryBehavior_MaxRetries verifies the client respects max retry limits.
+// Note: This test is skipped by default because the linear jitter backoff
+// can result in long wait times. The test validates that the client eventually
+// gives up after exhausting retries.
+func TestRetryBehavior_MaxRetries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	t.Parallel()
+
+	var requestCount atomic.Int32
+
+	// Create a test server that always returns 500
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "internal error"}`))
+	}))
+	defer server.Close()
+
+	c, err := client.New(
+		client.WithEndpoint(server.URL, "localhost"),
+	)
+	require.NoError(t, err)
+
+	// Use a context with timeout to bound the test duration
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/test", http.NoBody)
+	require.NoError(t, err)
+
+	// This should fail after max retries (default is 4 retries = 5 total requests)
+	resp, err := c.HTTPClient().Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	// Should have made initial request + 4 retries = 5 total
+	// The default max retries in go-retryablehttp is 4
+	assert.Equal(t, int32(5), requestCount.Load(), "should have made 5 total requests (1 initial + 4 retries)")
+
+	// The request should have failed
+	assert.Error(t, err)
+}
+
+// TestCheckRetryPolicy_NotFound_NoMethod tests 404 handling when no HTTP method is in context.
+func TestCheckRetryPolicy_NotFound_NoMethod(t *testing.T) {
+	t.Parallel()
+
+	body := `{"detail": "not found"}`
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	// No HTTP method in context
+	retry, err := client.CheckRetryPolicy(context.Background(), resp, nil)
+
+	// Should retry since it's not a DELETE
+	assert.True(t, retry, "should retry 404 when method is not DELETE")
+	assert.Error(t, err)
+}
+
+// TestCheckRetryPolicy_WithBodyReset tests that the response body can be read after policy check.
+// This is important because client.CheckRetryPolicy reads the body for error messages.
+func TestCheckRetryPolicy_BodyReadBehavior(t *testing.T) {
+	t.Parallel()
+
+	body := `{"detail": "forbidden access"}`
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+
+	_, err := client.CheckRetryPolicy(context.Background(), resp, nil)
+
+	// The error should contain the body content
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden access")
+}

--- a/internal/client/export_test.go
+++ b/internal/client/export_test.go
@@ -1,0 +1,27 @@
+package client
+
+import "net/http"
+
+// Export internal functions and types for testing.
+// This file is only compiled during tests.
+
+// CheckRetryPolicy exports checkRetryPolicy for testing.
+var CheckRetryPolicy = checkRetryPolicy
+
+// HTTPMethodContextKey exports httpMethodContextKey for testing.
+const HTTPMethodContextKey = httpMethodContextKey
+
+// HTTPClient returns the internal HTTP client for testing purposes.
+func (c *Client) HTTPClient() *http.Client {
+	return c.hc
+}
+
+// Endpoint returns the endpoint for testing purposes.
+func (c *Client) Endpoint() string {
+	return c.endpoint
+}
+
+// APIKey returns the API key for testing purposes.
+func (c *Client) APIKey() string {
+	return c.apiKey
+}


### PR DESCRIPTION
### Summary

Switches the HTTP client from the default exponential backoff to `RateLimitLinearJitterBackoff`, which was added in [go-retryablehttp v0.7.8](https://github.com/hashicorp/go-retryablehttp/pull/260). This should improve behavior when Prefect Cloud returns 429 or 503 responses with `Retry-After` headers - the client will now respect those headers instead of using its own timing.

Also adds unit tests for the `checkRetryPolicy` function and integration tests that verify the `Retry-After` header handling works as expected.

Closes #539

Closes https://linear.app/prefect/issue/PLA-1580/client-look-into-new-ratelimitlinearjitterbackoff-retry-policy

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)