### PR TITLE
fix(deployment): avoid 409 Conflict errors when updating job_variables

### DIFF
--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -66,8 +66,6 @@ type DeploymentCreate struct {
 }
 
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
-// All fields use pointers or have omitempty to ensure only changed fields
-// are sent in PATCH requests, avoiding 409 Conflict errors from the API.
 type DeploymentUpdate struct {
 	ConcurrencyLimit         *int64                 `json:"concurrency_limit,omitempty"`
 	ConcurrencyOptions       *ConcurrencyOptions    `json:"concurrency_options,omitempty"`

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -66,24 +66,25 @@ type DeploymentCreate struct {
 }
 
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
+// All fields use pointers or have omitempty to ensure only changed fields
+// are sent in PATCH requests, avoiding 409 Conflict errors from the API.
 type DeploymentUpdate struct {
 	ConcurrencyLimit         *int64                 `json:"concurrency_limit,omitempty"`
-	ConcurrencyOptions       *ConcurrencyOptions    `json:"concurrency_options"`
-	Description              string                 `json:"description,omitempty"`
+	ConcurrencyOptions       *ConcurrencyOptions    `json:"concurrency_options,omitempty"`
+	Description              *string                `json:"description,omitempty"`
 	EnforceParameterSchema   *bool                  `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint               string                 `json:"entrypoint,omitempty"`
+	Entrypoint               *string                `json:"entrypoint,omitempty"`
 	GlobalConcurrencyLimitID *uuid.UUID             `json:"global_concurrency_limit_id,omitempty"`
 	JobVariables             map[string]interface{} `json:"job_variables,omitempty"`
-	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema"`
-	Parameters               map[string]interface{} `json:"parameters"`
-	Path                     string                 `json:"path,omitempty"`
-	Paused                   bool                   `json:"paused,omitempty"`
-	PullSteps                []PullStep             `json:"pull_steps,omitempty"`
+	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
+	Parameters               map[string]interface{} `json:"parameters,omitempty"`
+	Path                     *string                `json:"path,omitempty"`
+	Paused                   *bool                  `json:"paused,omitempty"`
 	StorageDocumentID        *uuid.UUID             `json:"storage_document_id,omitempty"`
 	Tags                     []string               `json:"tags,omitempty"`
-	Version                  string                 `json:"version,omitempty"`
-	WorkPoolName             string                 `json:"work_pool_name,omitempty"`
-	WorkQueueName            string                 `json:"work_queue_name,omitempty"`
+	Version                  *string                `json:"version,omitempty"`
+	WorkPoolName             *string                `json:"work_pool_name,omitempty"`
+	WorkQueueName            *string                `json:"work_queue_name,omitempty"`
 }
 
 // ConcurrencyOptions is a representation of the deployment concurrency options.

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -893,29 +893,17 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	// Convert empty map to nil to ensure omitempty works correctly
-	if len(parameters) == 0 {
-		parameters = nil
-	}
 
 	jobVariables, diags := helpers.UnmarshalOptional(model.JobVariables)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	// Convert empty map to nil to ensure omitempty works correctly
-	if len(jobVariables) == 0 {
-		jobVariables = nil
-	}
 
 	parameterOpenAPISchema, diags := helpers.UnmarshalOptional(model.ParameterOpenAPISchema)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
-	}
-	// Convert empty map to nil to ensure omitempty works correctly
-	if len(parameterOpenAPISchema) == 0 {
-		parameterOpenAPISchema = nil
 	}
 
 	payload := api.DeploymentUpdate{

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -893,11 +893,19 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Convert empty map to nil to ensure omitempty works correctly
+	if len(parameters) == 0 {
+		parameters = nil
+	}
 
 	jobVariables, diags := helpers.UnmarshalOptional(model.JobVariables)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+	// Convert empty map to nil to ensure omitempty works correctly
+	if len(jobVariables) == 0 {
+		jobVariables = nil
 	}
 
 	parameterOpenAPISchema, diags := helpers.UnmarshalOptional(model.ParameterOpenAPISchema)
@@ -905,23 +913,27 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Convert empty map to nil to ensure omitempty works correctly
+	if len(parameterOpenAPISchema) == 0 {
+		parameterOpenAPISchema = nil
+	}
 
 	payload := api.DeploymentUpdate{
 		ConcurrencyLimit:         model.ConcurrencyLimit.ValueInt64Pointer(),
-		Description:              model.Description.ValueString(),
+		Description:              model.Description.ValueStringPointer(),
 		EnforceParameterSchema:   model.EnforceParameterSchema.ValueBoolPointer(),
-		Entrypoint:               model.Entrypoint.ValueString(),
+		Entrypoint:               model.Entrypoint.ValueStringPointer(),
 		GlobalConcurrencyLimitID: model.GlobalConcurrencyLimitID.ValueUUIDPointer(),
 		JobVariables:             jobVariables,
 		ParameterOpenAPISchema:   parameterOpenAPISchema,
 		Parameters:               parameters,
-		Path:                     model.Path.ValueString(),
-		Paused:                   model.Paused.ValueBool(),
+		Path:                     model.Path.ValueStringPointer(),
+		Paused:                   model.Paused.ValueBoolPointer(),
 		StorageDocumentID:        model.StorageDocumentID.ValueUUIDPointer(),
 		Tags:                     tags,
-		Version:                  model.Version.ValueString(),
-		WorkPoolName:             model.WorkPoolName.ValueString(),
-		WorkQueueName:            model.WorkQueueName.ValueString(),
+		Version:                  model.Version.ValueStringPointer(),
+		WorkPoolName:             model.WorkPoolName.ValueStringPointer(),
+		WorkQueueName:            model.WorkQueueName.ValueStringPointer(),
 	}
 
 	if model.ConcurrencyOptions != nil {


### PR DESCRIPTION
### Summary

When updating `job_variables` on a deployment, users were hitting 409 Conflict errors from the Prefect API. Turns out the PATCH request was sending zero/default values for unchanged fields (empty strings, `false` booleans, empty maps `{}`), which triggered server-side validation.

This switches `DeploymentUpdate` to use pointer types and adds `omitempty` tags so only fields with actual values get serialized. Also converts empty maps to `nil` so they're properly omitted.

Closes #618

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)