### PR TITLE
fix(client): add customHeaders to block_types.go

### DIFF
--- a/internal/client/block_types.go
+++ b/internal/client/block_types.go
@@ -19,6 +19,7 @@ type BlockTypeClient struct {
 	basicAuthKey    string
 	csrfClientToken string
 	csrfToken       string
+	customHeaders   map[string]string
 }
 
 // BlockTypes returns a BlockTypeClient.
@@ -43,6 +44,7 @@ func (c *Client) BlockTypes(accountID uuid.UUID, workspaceID uuid.UUID) (api.Blo
 		routePrefix:     getWorkspaceScopedURL(c.endpoint, accountID, workspaceID, "block_types"),
 		csrfClientToken: c.csrfClientToken,
 		csrfToken:       c.csrfToken,
+		customHeaders:   c.customHeaders,
 	}, nil
 }
 
@@ -56,6 +58,7 @@ func (c *BlockTypeClient) Get(ctx context.Context, id uuid.UUID) (*api.BlockType
 		basicAuthKey:    c.basicAuthKey,
 		csrfClientToken: c.csrfClientToken,
 		csrfToken:       c.csrfToken,
+		customHeaders:   c.customHeaders,
 		successCodes:    successCodesStatusOK,
 	}
 
@@ -77,6 +80,7 @@ func (c *BlockTypeClient) GetBySlug(ctx context.Context, slug string) (*api.Bloc
 		basicAuthKey:    c.basicAuthKey,
 		csrfClientToken: c.csrfClientToken,
 		csrfToken:       c.csrfToken,
+		customHeaders:   c.customHeaders,
 		successCodes:    successCodesStatusOK,
 	}
 
@@ -91,12 +95,13 @@ func (c *BlockTypeClient) GetBySlug(ctx context.Context, slug string) (*api.Bloc
 // Create creates a new BlockType.
 func (c *BlockTypeClient) Create(ctx context.Context, payload *api.BlockTypeCreate) (*api.BlockType, error) {
 	cfg := requestConfig{
-		method:       http.MethodPost,
-		url:          c.routePrefix,
-		body:         payload,
-		apiKey:       c.apiKey,
-		basicAuthKey: c.basicAuthKey,
-		successCodes: successCodesStatusCreated,
+		method:        http.MethodPost,
+		url:           c.routePrefix,
+		body:          payload,
+		apiKey:        c.apiKey,
+		basicAuthKey:  c.basicAuthKey,
+		customHeaders: c.customHeaders,
+		successCodes:  successCodesStatusCreated,
 	}
 
 	var createdBlockType *api.BlockType
@@ -110,12 +115,13 @@ func (c *BlockTypeClient) Create(ctx context.Context, payload *api.BlockTypeCrea
 // Update updates a BlockType.
 func (c *BlockTypeClient) Update(ctx context.Context, id uuid.UUID, payload *api.BlockTypeUpdate) error {
 	cfg := requestConfig{
-		method:       http.MethodPatch,
-		url:          c.routePrefix + "/" + id.String(),
-		body:         payload,
-		apiKey:       c.apiKey,
-		basicAuthKey: c.basicAuthKey,
-		successCodes: successCodesStatusNoContent,
+		method:        http.MethodPatch,
+		url:           c.routePrefix + "/" + id.String(),
+		body:          payload,
+		apiKey:        c.apiKey,
+		basicAuthKey:  c.basicAuthKey,
+		customHeaders: c.customHeaders,
+		successCodes:  successCodesStatusNoContent,
 	}
 
 	resp, err := request(ctx, c.hc, cfg)
@@ -130,12 +136,13 @@ func (c *BlockTypeClient) Update(ctx context.Context, id uuid.UUID, payload *api
 // Delete deletes a BlockType.
 func (c *BlockTypeClient) Delete(ctx context.Context, id uuid.UUID) error {
 	cfg := requestConfig{
-		method:       http.MethodDelete,
-		url:          c.routePrefix + "/" + id.String(),
-		body:         http.NoBody,
-		apiKey:       c.apiKey,
-		basicAuthKey: c.basicAuthKey,
-		successCodes: successCodesStatusNoContent,
+		method:        http.MethodDelete,
+		url:           c.routePrefix + "/" + id.String(),
+		body:          http.NoBody,
+		apiKey:        c.apiKey,
+		basicAuthKey:  c.basicAuthKey,
+		customHeaders: c.customHeaders,
+		successCodes:  successCodesStatusNoContent,
 	}
 
 	resp, err := request(ctx, c.hc, cfg)


### PR DESCRIPTION
### Summary

Looks like `block_types.go` was missed when adding custom headers support in #616. This caused block creation to fail for users with `PREFECT_CLIENT_CUSTOM_HEADERS` configured (e.g., for Cloudflare Access authentication) since the headers weren't being sent on block type API requests.

Hat tip to @mattijsdp for spotting this in [#619](https://github.com/PrefectHQ/terraform-provider-prefect/issues/619#issuecomment-3664887082).

Closes #619

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- N/A - Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- N/A - This is a bug fix to an existing client file, not a new resource/datasource