### PR TITLE
fix(lint): preallocate slices and suppress revive var-naming for api package

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -142,6 +142,11 @@ linters:
         - yodaStyleExpr
   exclusions:
     generated: lax
+    rules:
+      - linters:
+          - revive
+        path: internal/api/
+        text: "var-naming: avoid meaningless package names"
     presets:
       - comments
       - common-false-positives

--- a/internal/provider/datasources/account_role_test.go
+++ b/internal/provider/datasources/account_role_test.go
@@ -32,7 +32,7 @@ func TestAccDatasource_account_role_defaults(t *testing.T) {
 	// Default account role names - these exist in every account
 	defaultAccountRoles := []defaultAccountRole{{"Admin", 44}, {"Member", 13}, {"Owner", 46}}
 
-	testSteps := []resource.TestStep{}
+	testSteps := make([]resource.TestStep, 0, len(defaultAccountRoles))
 
 	for _, role := range defaultAccountRoles {
 		testSteps = append(testSteps, resource.TestStep{

--- a/internal/provider/datasources/workspace_role_test.go
+++ b/internal/provider/datasources/workspace_role_test.go
@@ -27,7 +27,7 @@ func TestAccDatasource_workspace_role_defaults(t *testing.T) {
 	// Default workspace role names - these exist in every account
 	defaultWorkspaceRoles := []string{"Owner", "Worker", "Developer", "Viewer", "Runner"}
 
-	testSteps := []resource.TestStep{}
+	testSteps := make([]resource.TestStep, 0, len(defaultWorkspaceRoles))
 
 	for _, role := range defaultWorkspaceRoles {
 		testSteps = append(testSteps, resource.TestStep{

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -467,7 +467,7 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 func mapPullStepsTerraformToAPI(tfPullSteps []PullStepModel) ([]api.PullStep, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	pullSteps := make([]api.PullStep, 0)
+	pullSteps := make([]api.PullStep, 0, len(tfPullSteps))
 
 	for i := range tfPullSteps {
 		tfPullStep := tfPullSteps[i]
@@ -524,7 +524,7 @@ func mapPullStepsTerraformToAPI(tfPullSteps []PullStepModel) ([]api.PullStep, di
 func mapPullStepsAPIToTerraform(pullSteps []api.PullStep) ([]PullStepModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	tfPullStepsModel := make([]PullStepModel, 0)
+	tfPullStepsModel := make([]PullStepModel, 0, len(pullSteps))
 
 	for i := range pullSteps {
 		pullStep := pullSteps[i]
@@ -1023,7 +1023,7 @@ func (r *DeploymentResource) ImportState(ctx context.Context, req resource.Impor
 // ConfigValidators instead would be much more verbose, and disconnected from
 // the source of truth.
 func pathExpressionsForAttributes(attributes []string) []path.Expression {
-	pathExpressions := make([]path.Expression, 0)
+	pathExpressions := make([]path.Expression, 0, len(attributes))
 
 	for _, key := range attributes {
 		pathExpressions = append(pathExpressions, path.MatchRelative().AtParent().AtName(key))

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -93,7 +93,7 @@ func ExpectKnownValue(resourceName, path, value string) statecheck.StateCheck {
 //
 //nolint:ireturn // required for testing
 func ExpectKnownValueList(resourceName, path string, values []string) statecheck.StateCheck {
-	knownValueChecks := []knownvalue.Check{}
+	knownValueChecks := make([]knownvalue.Check, 0, len(values))
 	for _, value := range values {
 		knownValueChecks = append(knownValueChecks, knownvalue.StringExact(value))
 	}
@@ -114,7 +114,7 @@ func ExpectKnownValueListSize(resourceName, path string, size int) statecheck.St
 //
 //nolint:ireturn // required for testing
 func ExpectKnownValueSet(resourceName, path string, values []string) statecheck.StateCheck {
-	knownValueChecks := []knownvalue.Check{}
+	knownValueChecks := make([]knownvalue.Check, 0, len(values))
 	for _, value := range values {
 		knownValueChecks = append(knownValueChecks, knownvalue.StringExact(value))
 	}


### PR DESCRIPTION
### Summary

Fixes the 8 linting issues currently reported by `golangci-lint`:

- Preallocated 7 slices with known capacity where the `prealloc` linter flagged unnecessary dynamic growth
- Added a lint exclusion for `revive`'s `var-naming` rule on `internal/api/` — renaming `package api` would be a pretty disproportionate change for a stylistic preference

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)