### PR TITLE
fix(ci): forward test filter argument in testacc mise task

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -63,7 +63,7 @@ jobs:
           PREFECT_API_KEY: ${{ secrets.ACC_TEST_PREFECT_API_KEY }}
           PREFECT_CLOUD_ACCOUNT_ID: ${{ secrets.ACC_TEST_PREFECT_CLOUD_ACCOUNT_ID }}
       - name: Run acceptance tests (user resource)
-        run: mise run testacc
+        run: mise run testacc "TestAccResource_user*"
         env:
           PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
           # This is an API key generated as the Marvin user (marvin@prefect.io).
@@ -75,9 +75,3 @@ jobs:
           # This is the user ID retrieved by logging in as the Marvin user
           # and copying the ID on the "Profile" page.
           ACC_TEST_USER_RESOURCE_ID: "48750018-b4c4-4484-8fbf-b61baf3926b5"
-          # This ensures only the User resource tests run, instead of running
-          # all the tests again because that was completed in the last step.
-          # Regex ensures that the following tests are included:
-          # - TestAccResource_user
-          # - TestAccResourcE_user_api_key
-          TESTS: "TestAccResource_user*"

--- a/.mise.toml
+++ b/.mise.toml
@@ -60,7 +60,7 @@ run_windows = 'gotestsum --max-fails=50 ./...'
 [tasks.testacc]
 alias = "ta"
 description = "Run acceptance tests against real infrastructure ({{vars.helper_tests_arg}})"
-run = 'TF_ACC=1 mise run test'
+run = 'TF_ACC=1 mise run test {{arg(name="tests", default="")}}'
 
 [tasks.testacc-dev]
 alias = "tad"


### PR DESCRIPTION
### Summary

Related to https://linear.app/prefect/issue/PLA-2329/ci-fix-failing-acceptance-tests-for-user-resource

The "Run acceptance tests (user resource)" CI step has been running all 124 tests instead of just the `TestAccResource_user*` subset. The `TESTS` env var it was setting was never actually read by the mise task chain — the `testacc` task calls `mise run test` without forwarding any arguments, and `test` uses `{{arg(...)}}` positional args, not env vars. So the Marvin user's API key (which only has permission for user resources) was being used for every test, producing 51 failures with `401 Unauthorized`.

This has been broken since at least Jan 1 — every `pull_request_target` run since then shows the same pattern. The first step (all tests, bot API key) passes fine; the second step (intended to be user-only, Marvin API key) fails because it re-runs everything.

The fix:
- `testacc` now forwards its arg to `test` via `{{arg(name="tests", default="")}}`
- The workflow passes the filter as a CLI argument (`mise run testacc "TestAccResource_user*"`) instead of a dead env var

**Note:** CI on this PR will still fail because `pull_request_target` reads the workflow YAML from the base branch (`main`), not from the PR. The `.mise.toml` change takes effect (it's in the checked-out code), but the workflow still uses the old `run: mise run testacc` without the filter argument. This will work correctly once merged — [the PR's CI run](https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/21848430110/job/63049522923?pr=630) confirms the `.mise.toml` side is working (`mise run test ''` shows the arg forwarding).

Recent failing runs for reference:
- https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/21843349018
- https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/21843291915

🤖 Generated with [Claude Code](https://claude.com/claude-code)