### PR TITLE
fix(deployment): return nil maps from UnmarshalOptional to avoid 409 on update

### DIFF
--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -53,8 +53,8 @@ type DeploymentCreate struct {
 	GlobalConcurrencyLimitID *uuid.UUID             `json:"global_concurrency_limit_id,omitempty"`
 	JobVariables             map[string]interface{} `json:"job_variables,omitempty"`
 	Name                     string                 `json:"name"` // required
-	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema"`
-	Parameters               map[string]interface{} `json:"parameters"`
+	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
+	Parameters               map[string]interface{} `json:"parameters,omitempty"`
 	Path                     string                 `json:"path,omitempty"`
 	Paused                   bool                   `json:"paused,omitempty"`
 	PullSteps                []PullStep             `json:"pull_steps,omitempty"`


### PR DESCRIPTION
### Summary

`UnmarshalOptional` was returning an initialized empty map even when the Terraform attribute was null/unset. Go's `json.Marshal` with `omitempty` doesn't omit empty non-nil maps, so PATCH payloads were always including `"job_variables": {}`, `"parameters": {}`, etc. — which seems to trigger the 409 Conflict from the Prefect API that folks reported in #618.

This changes `UnmarshalOptional` to return `nil` for null/unknown attributes, which `omitempty` correctly omits. Also adds `omitempty` to the two `DeploymentCreate` map fields (`parameters`, `parameter_openapi_schema`) that were missing it.

Closes #618

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)