### PR TITLE
chore: apply go fix results for Go 1.26

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,10 +1,10 @@
 [tools]
 1password = "2.32.0"
 # Should match go.mod
-go = "1.25"
+go = "1.26"
 "go:github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs" = "0.24.0"
 "go:github.com/BurntSushi/toml/cmd/tomlv" = "1.6.0"
-golangci-lint = "2.8.0"
+golangci-lint = "2.9.0"
 goreleaser = "2.13.3"
 gotestsum = "1.13.0"
 pre-commit = "4.5.1"

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
 	github.com/stretchr/testify v1.11.1
-	k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prefecthq/terraform-provider-prefect
 
-go 1.24.1
+go 1.26
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -306,5 +306,3 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078 h1:jGnCPejIetjiy2gqaJ5V0NLwTpF4wbQ6cZIItJCSHno=
-k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/internal/api/account_memberships.go
+++ b/internal/api/account_memberships.go
@@ -34,7 +34,7 @@ type AccountMembershipFilter struct {
 	AccountMemberships struct {
 		Email struct {
 			Any []string `json:"any_"`
-		} `json:"email,omitempty"`
+		} `json:"email"`
 	} `json:"account_memberships"`
 }
 

--- a/internal/api/automations.go
+++ b/internal/api/automations.go
@@ -42,9 +42,9 @@ type Trigger struct {
 	Type string `json:"type"`
 
 	// For EventTrigger and MetricTrigger
-	Match        map[string]interface{} `json:"match,omitempty"`
-	MatchRelated any                    `json:"match_related,omitempty"`
-	Posture      *string                `json:"posture,omitempty"`
+	Match        map[string]any `json:"match,omitempty"`
+	MatchRelated any            `json:"match_related,omitempty"`
+	Posture      *string        `json:"posture,omitempty"`
 
 	// For EventTrigger
 	After     []string `json:"after,omitempty"`
@@ -57,8 +57,8 @@ type Trigger struct {
 	Metric *MetricTriggerQuery `json:"metric,omitempty"`
 
 	// For CompoundTrigger and SequenceTrigger
-	Triggers []Trigger    `json:"triggers,omitempty"`
-	Require  *interface{} `json:"require,omitempty"` // int or string ("any"/"all")
+	Triggers []Trigger `json:"triggers,omitempty"`
+	Require  *any      `json:"require,omitempty"` // int or string ("any"/"all")
 }
 
 type MetricTriggerQuery struct {
@@ -97,8 +97,8 @@ type Action struct {
 	WorkQueueID *uuid.UUID `json:"work_queue_id,omitempty"`
 
 	// On Run Deployment action
-	Parameters   map[string]interface{} `json:"parameters,omitempty"`
-	JobVariables map[string]interface{} `json:"job_variables,omitempty"`
+	Parameters   map[string]any `json:"parameters,omitempty"`
+	JobVariables map[string]any `json:"job_variables,omitempty"`
 
 	// On Send Notification action
 	Subject *string `json:"subject,omitempty"`

--- a/internal/api/automations_test.go
+++ b/internal/api/automations_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/ptr"
 )
 
 func TestActionModel(t *testing.T) {
@@ -33,10 +32,10 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:         "run-deployment",
-				Source:       ptr.To("selected"),
-				DeploymentID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
-				Parameters:   map[string]interface{}{"foo": "bar"},
-				JobVariables: map[string]interface{}{"env": "prod"},
+				Source:       new("selected"),
+				DeploymentID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Parameters:   map[string]any{"foo": "bar"},
+				JobVariables: map[string]any{"env": "prod"},
 			},
 		},
 		{
@@ -48,8 +47,8 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:         "pause-deployment",
-				Source:       ptr.To("selected"),
-				DeploymentID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Source:       new("selected"),
+				DeploymentID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
 			},
 		},
 		{
@@ -61,8 +60,8 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:         "resume-deployment",
-				Source:       ptr.To("selected"),
-				DeploymentID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Source:       new("selected"),
+				DeploymentID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
 			},
 		},
 		{
@@ -80,9 +79,9 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:    "change-flow-run-state",
-				Name:    ptr.To("Failed"),
-				State:   ptr.To("FAILED"),
-				Message: ptr.To("Flow run failed"),
+				Name:    new("Failed"),
+				State:   new("FAILED"),
+				Message: new("Flow run failed"),
 			},
 		},
 		{
@@ -94,8 +93,8 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:        "pause-work-queue",
-				Source:      ptr.To("selected"),
-				WorkQueueID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Source:      new("selected"),
+				WorkQueueID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
 			},
 		},
 		{
@@ -107,8 +106,8 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:        "resume-work-queue",
-				Source:      ptr.To("selected"),
-				WorkQueueID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Source:      new("selected"),
+				WorkQueueID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
 			},
 		},
 		{
@@ -121,9 +120,9 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:            "send-notification",
-				BlockDocumentID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
-				Subject:         ptr.To("Alert"),
-				Body:            ptr.To("Something happened"),
+				BlockDocumentID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Subject:         new("Alert"),
+				Body:            new("Something happened"),
 			},
 		},
 		{
@@ -135,8 +134,8 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:            "call-webhook",
-				BlockDocumentID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
-				Payload:         ptr.To("{\"message\": \"test\"}"),
+				BlockDocumentID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Payload:         new("{\"message\": \"test\"}"),
 			},
 		},
 		{
@@ -148,8 +147,8 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:         "pause-automation",
-				Source:       ptr.To("selected"),
-				AutomationID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Source:       new("selected"),
+				AutomationID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
 			},
 		},
 		{
@@ -161,8 +160,8 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:         "resume-automation",
-				Source:       ptr.To("selected"),
-				AutomationID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Source:       new("selected"),
+				AutomationID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
 			},
 		},
 		{
@@ -189,8 +188,8 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:       "pause-work-pool",
-				Source:     ptr.To("selected"),
-				WorkPoolID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Source:     new("selected"),
+				WorkPoolID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
 			},
 		},
 		{
@@ -202,8 +201,8 @@ func TestActionModel(t *testing.T) {
 					}`,
 			want: api.Action{
 				Type:       "resume-work-pool",
-				Source:     ptr.To("selected"),
-				WorkPoolID: ptr.To(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
+				Source:     new("selected"),
+				WorkPoolID: new(uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")),
 			},
 		},
 	}

--- a/internal/api/block_documents.go
+++ b/internal/api/block_documents.go
@@ -19,8 +19,8 @@ type BlockDocumentClient interface {
 
 type BlockDocument struct {
 	BaseModel
-	Name string                 `json:"name"`
-	Data map[string]interface{} `json:"data"`
+	Name string         `json:"name"`
+	Data map[string]any `json:"data"`
 
 	BlockSchemaID uuid.UUID    `json:"block_schema_id"`
 	BlockSchema   *BlockSchema `json:"block_schema"`
@@ -31,16 +31,16 @@ type BlockDocument struct {
 }
 
 type BlockDocumentCreate struct {
-	Name          string                 `json:"name"`
-	Data          map[string]interface{} `json:"data"`
-	BlockSchemaID uuid.UUID              `json:"block_schema_id"`
-	BlockTypeID   uuid.UUID              `json:"block_type_id"`
+	Name          string         `json:"name"`
+	Data          map[string]any `json:"data"`
+	BlockSchemaID uuid.UUID      `json:"block_schema_id"`
+	BlockTypeID   uuid.UUID      `json:"block_type_id"`
 }
 
 type BlockDocumentUpdate struct {
-	BlockSchemaID     uuid.UUID              `json:"block_schema_id"`
-	Data              map[string]interface{} `json:"data"`
-	MergeExistingData bool                   `json:"merge_existing_data"`
+	BlockSchemaID     uuid.UUID      `json:"block_schema_id"`
+	Data              map[string]any `json:"data"`
+	MergeExistingData bool           `json:"merge_existing_data"`
 }
 
 // BlockDocumentAccessUpsert is the create/update request payload

--- a/internal/api/block_schemas.go
+++ b/internal/api/block_schemas.go
@@ -18,20 +18,20 @@ type BlockSchemaClient interface {
 type BlockSchema struct {
 	BaseModel
 
-	BlockType    BlockType   `json:"block_type"`
-	Checksum     string      `json:"checksum"`
-	BlockTypeID  uuid.UUID   `json:"block_type_id"`
-	Capabilities []string    `json:"capabilities"`
-	Version      string      `json:"version"`
-	Fields       interface{} `json:"fields"`
+	BlockType    BlockType `json:"block_type"`
+	Checksum     string    `json:"checksum"`
+	BlockTypeID  uuid.UUID `json:"block_type_id"`
+	Capabilities []string  `json:"capabilities"`
+	Version      string    `json:"version"`
+	Fields       any       `json:"fields"`
 }
 
 // BlockSchemaCreate is the create request payload.
 type BlockSchemaCreate struct {
-	BlockTypeID  uuid.UUID   `json:"block_type_id"`
-	Capabilities []string    `json:"capabilities"`
-	Version      string      `json:"version"`
-	Fields       interface{} `json:"fields"`
+	BlockTypeID  uuid.UUID `json:"block_type_id"`
+	Capabilities []string  `json:"capabilities"`
+	Version      string    `json:"version"`
+	Fields       any       `json:"fields"`
 }
 
 // BlockSchemaFilter defines the search filter payload

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -28,10 +28,10 @@ type Deployment struct {
 	Entrypoint             string                         `json:"entrypoint"`
 	FlowID                 uuid.UUID                      `json:"flow_id"`
 	GlobalConcurrencyLimit *CurrentGlobalConcurrencyLimit `json:"global_concurrency_limit"`
-	JobVariables           map[string]interface{}         `json:"job_variables"`
+	JobVariables           map[string]any                 `json:"job_variables"`
 	Name                   string                         `json:"name"`
-	ParameterOpenAPISchema map[string]interface{}         `json:"parameter_openapi_schema"`
-	Parameters             map[string]interface{}         `json:"parameters"`
+	ParameterOpenAPISchema map[string]any                 `json:"parameter_openapi_schema"`
+	Parameters             map[string]any                 `json:"parameters"`
 	Path                   string                         `json:"path"`
 	Paused                 bool                           `json:"paused"`
 	PullSteps              []PullStep                     `json:"pull_steps"`
@@ -44,45 +44,45 @@ type Deployment struct {
 
 // DeploymentCreate is a subset of Deployment used when creating deployments.
 type DeploymentCreate struct {
-	ConcurrencyLimit         *int64                 `json:"concurrency_limit,omitempty"`
-	ConcurrencyOptions       *ConcurrencyOptions    `json:"concurrency_options,omitempty"`
-	Description              string                 `json:"description,omitempty"`
-	EnforceParameterSchema   *bool                  `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint               string                 `json:"entrypoint,omitempty"`
-	FlowID                   uuid.UUID              `json:"flow_id"` // required
-	GlobalConcurrencyLimitID *uuid.UUID             `json:"global_concurrency_limit_id,omitempty"`
-	JobVariables             map[string]interface{} `json:"job_variables,omitempty"`
-	Name                     string                 `json:"name"` // required
-	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
-	Parameters               map[string]interface{} `json:"parameters,omitempty"`
-	Path                     string                 `json:"path,omitempty"`
-	Paused                   bool                   `json:"paused,omitempty"`
-	PullSteps                []PullStep             `json:"pull_steps,omitempty"`
-	StorageDocumentID        *uuid.UUID             `json:"storage_document_id,omitempty"`
-	Tags                     []string               `json:"tags,omitempty"`
-	Version                  string                 `json:"version,omitempty"`
-	WorkPoolName             string                 `json:"work_pool_name,omitempty"`
-	WorkQueueName            string                 `json:"work_queue_name,omitempty"`
+	ConcurrencyLimit         *int64              `json:"concurrency_limit,omitempty"`
+	ConcurrencyOptions       *ConcurrencyOptions `json:"concurrency_options,omitempty"`
+	Description              string              `json:"description,omitempty"`
+	EnforceParameterSchema   *bool               `json:"enforce_parameter_schema,omitempty"`
+	Entrypoint               string              `json:"entrypoint,omitempty"`
+	FlowID                   uuid.UUID           `json:"flow_id"` // required
+	GlobalConcurrencyLimitID *uuid.UUID          `json:"global_concurrency_limit_id,omitempty"`
+	JobVariables             map[string]any      `json:"job_variables,omitempty"`
+	Name                     string              `json:"name"` // required
+	ParameterOpenAPISchema   map[string]any      `json:"parameter_openapi_schema,omitempty"`
+	Parameters               map[string]any      `json:"parameters,omitempty"`
+	Path                     string              `json:"path,omitempty"`
+	Paused                   bool                `json:"paused,omitempty"`
+	PullSteps                []PullStep          `json:"pull_steps,omitempty"`
+	StorageDocumentID        *uuid.UUID          `json:"storage_document_id,omitempty"`
+	Tags                     []string            `json:"tags,omitempty"`
+	Version                  string              `json:"version,omitempty"`
+	WorkPoolName             string              `json:"work_pool_name,omitempty"`
+	WorkQueueName            string              `json:"work_queue_name,omitempty"`
 }
 
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
 type DeploymentUpdate struct {
-	ConcurrencyLimit         *int64                 `json:"concurrency_limit,omitempty"`
-	ConcurrencyOptions       *ConcurrencyOptions    `json:"concurrency_options,omitempty"`
-	Description              *string                `json:"description,omitempty"`
-	EnforceParameterSchema   *bool                  `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint               *string                `json:"entrypoint,omitempty"`
-	GlobalConcurrencyLimitID *uuid.UUID             `json:"global_concurrency_limit_id,omitempty"`
-	JobVariables             map[string]interface{} `json:"job_variables,omitempty"`
-	ParameterOpenAPISchema   map[string]interface{} `json:"parameter_openapi_schema,omitempty"`
-	Parameters               map[string]interface{} `json:"parameters,omitempty"`
-	Path                     *string                `json:"path,omitempty"`
-	Paused                   *bool                  `json:"paused,omitempty"`
-	StorageDocumentID        *uuid.UUID             `json:"storage_document_id,omitempty"`
-	Tags                     []string               `json:"tags,omitempty"`
-	Version                  *string                `json:"version,omitempty"`
-	WorkPoolName             *string                `json:"work_pool_name,omitempty"`
-	WorkQueueName            *string                `json:"work_queue_name,omitempty"`
+	ConcurrencyLimit         *int64              `json:"concurrency_limit,omitempty"`
+	ConcurrencyOptions       *ConcurrencyOptions `json:"concurrency_options,omitempty"`
+	Description              *string             `json:"description,omitempty"`
+	EnforceParameterSchema   *bool               `json:"enforce_parameter_schema,omitempty"`
+	Entrypoint               *string             `json:"entrypoint,omitempty"`
+	GlobalConcurrencyLimitID *uuid.UUID          `json:"global_concurrency_limit_id,omitempty"`
+	JobVariables             map[string]any      `json:"job_variables,omitempty"`
+	ParameterOpenAPISchema   map[string]any      `json:"parameter_openapi_schema,omitempty"`
+	Parameters               map[string]any      `json:"parameters,omitempty"`
+	Path                     *string             `json:"path,omitempty"`
+	Paused                   *bool               `json:"paused,omitempty"`
+	StorageDocumentID        *uuid.UUID          `json:"storage_document_id,omitempty"`
+	Tags                     []string            `json:"tags,omitempty"`
+	Version                  *string             `json:"version,omitempty"`
+	WorkPoolName             *string             `json:"work_pool_name,omitempty"`
+	WorkQueueName            *string             `json:"work_queue_name,omitempty"`
 }
 
 // ConcurrencyOptions is a representation of the deployment concurrency options.

--- a/internal/api/deployments_schedule.go
+++ b/internal/api/deployments_schedule.go
@@ -31,9 +31,9 @@ type DeploymentSchedulePayload struct {
 	MaxActiveRuns float32 `json:"max_active_runs,omitempty"`
 	Catchup       bool    `json:"catchup,omitempty"`
 
-	Schedule   Schedule               `json:"schedule,omitempty"`
-	Parameters map[string]interface{} `json:"parameters,omitempty"`
-	Slug       string                 `json:"slug,omitempty"`
+	Schedule   Schedule       `json:"schedule"`
+	Parameters map[string]any `json:"parameters,omitempty"`
+	Slug       string         `json:"slug,omitempty"`
 }
 
 type Schedule struct {

--- a/internal/api/service_accounts.go
+++ b/internal/api/service_accounts.go
@@ -42,7 +42,7 @@ type ServiceAccountFilter struct {
 	ServiceAccounts struct {
 		Name struct {
 			Any []string `json:"any_"`
-		} `json:"name,omitempty"`
+		} `json:"name"`
 	} `json:"service_accounts"`
 }
 

--- a/internal/api/slas.go
+++ b/internal/api/slas.go
@@ -41,6 +41,6 @@ type SLAUpsert struct {
 	Within *float64 `json:"within,omitempty"`
 
 	// For FreshnessSLA
-	ExpectedEvent *string                 `json:"expected_event,omitempty"`
-	ResourceMatch *map[string]interface{} `json:"resource_match,omitempty"`
+	ExpectedEvent *string         `json:"expected_event,omitempty"`
+	ResourceMatch *map[string]any `json:"resource_match,omitempty"`
 }

--- a/internal/api/variables.go
+++ b/internal/api/variables.go
@@ -19,23 +19,23 @@ type VariablesClient interface {
 // Variable is a representation of a variable.
 type Variable struct {
 	BaseModel
-	Name  string      `json:"name"`
-	Value interface{} `json:"value"`
-	Tags  []string    `json:"tags"`
+	Name  string   `json:"name"`
+	Value any      `json:"value"`
+	Tags  []string `json:"tags"`
 }
 
 // VariableCreate is a subset of Variable used when creating variables.
 type VariableCreate struct {
-	Name  string      `json:"name"`
-	Value interface{} `json:"value"`
-	Tags  []string    `json:"tags"`
+	Name  string   `json:"name"`
+	Value any      `json:"value"`
+	Tags  []string `json:"tags"`
 }
 
 // VariableUpdate is a subset of Variable used when updating variables.
 type VariableUpdate struct {
-	Name  string      `json:"name"`
-	Value interface{} `json:"value"`
-	Tags  []string    `json:"tags"`
+	Name  string   `json:"name"`
+	Value any      `json:"value"`
+	Tags  []string `json:"tags"`
 }
 
 // VariableFilterSettings defines settings when searching for variables.

--- a/internal/api/webhooks.go
+++ b/internal/api/webhooks.go
@@ -55,6 +55,6 @@ type WebhookFilter struct {
 	Webhooks struct {
 		Name struct {
 			Any []string `json:"any_"`
-		} `json:"name,omitempty"`
+		} `json:"name"`
 	} `json:"webhooks"`
 }

--- a/internal/api/work_pools.go
+++ b/internal/api/work_pools.go
@@ -18,31 +18,31 @@ type WorkPoolsClient interface {
 // WorkPool is a representation of a work pool.
 type WorkPool struct {
 	BaseModel
-	Name             string                 `json:"name"`
-	Description      *string                `json:"description"`
-	Type             string                 `json:"type"`
-	BaseJobTemplate  map[string]interface{} `json:"base_job_template"`
-	IsPaused         bool                   `json:"is_paused"`
-	ConcurrencyLimit *int64                 `json:"concurrency_limit"`
-	DefaultQueueID   uuid.UUID              `json:"default_queue_id"`
+	Name             string         `json:"name"`
+	Description      *string        `json:"description"`
+	Type             string         `json:"type"`
+	BaseJobTemplate  map[string]any `json:"base_job_template"`
+	IsPaused         bool           `json:"is_paused"`
+	ConcurrencyLimit *int64         `json:"concurrency_limit"`
+	DefaultQueueID   uuid.UUID      `json:"default_queue_id"`
 }
 
 // WorkPoolCreate is a subset of WorkPool used when creating pools.
 type WorkPoolCreate struct {
-	Name             string                  `json:"name"`
-	Description      *string                 `json:"description"`
-	Type             string                  `json:"type"`
-	BaseJobTemplate  *map[string]interface{} `json:"base_job_template,omitempty"`
-	IsPaused         bool                    `json:"is_paused"`
-	ConcurrencyLimit *int64                  `json:"concurrency_limit"`
+	Name             string          `json:"name"`
+	Description      *string         `json:"description"`
+	Type             string          `json:"type"`
+	BaseJobTemplate  *map[string]any `json:"base_job_template,omitempty"`
+	IsPaused         bool            `json:"is_paused"`
+	ConcurrencyLimit *int64          `json:"concurrency_limit"`
 }
 
 // WorkPoolUpdate is a subset of WorkPool used when updating pools.
 type WorkPoolUpdate struct {
-	Description      *string                 `json:"description"`
-	IsPaused         *bool                   `json:"is_paused"`
-	BaseJobTemplate  *map[string]interface{} `json:"base_job_template,omitempty"`
-	ConcurrencyLimit *int64                  `json:"concurrency_limit"`
+	Description      *string         `json:"description"`
+	IsPaused         *bool           `json:"is_paused"`
+	BaseJobTemplate  *map[string]any `json:"base_job_template,omitempty"`
+	ConcurrencyLimit *int64          `json:"concurrency_limit"`
 }
 
 // WorkPoolFilter defines filters when searching for work pools.

--- a/internal/provider/datasources/account_member.go
+++ b/internal/provider/datasources/account_member.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -97,9 +98,7 @@ func (d *AccountMemberDataSource) Schema(_ context.Context, _ datasource.SchemaR
 	// Create a copy of the base attributes
 	// and add the account ID overrides here
 	accountMemberAttributes := make(map[string]schema.Attribute)
-	for k, v := range accountMemberAttributesBase {
-		accountMemberAttributes[k] = v
-	}
+	maps.Copy(accountMemberAttributes, accountMemberAttributesBase)
 	accountMemberAttributes["account_id"] = schema.StringAttribute{
 		CustomType:  customtypes.UUIDType{},
 		Description: "Account ID (UUID) where the member resides",

--- a/internal/provider/datasources/team.go
+++ b/internal/provider/datasources/team.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -77,9 +78,7 @@ func (d *TeamDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 	// and add the account ID overrides here
 	// as they are not needed in the teams (plural) list
 	teamAttributes := make(map[string]schema.Attribute)
-	for k, v := range teamAttributesBase {
-		teamAttributes[k] = v
-	}
+	maps.Copy(teamAttributes, teamAttributesBase)
 	teamAttributes["account_id"] = schema.StringAttribute{
 		CustomType:  customtypes.UUIDType{},
 		Description: "Account ID (UUID), defaults to the account set in the provider",

--- a/internal/provider/datasources/variable.go
+++ b/internal/provider/datasources/variable.go
@@ -213,7 +213,7 @@ func getDynamicValue(model VariableDataSourceModel, variable *api.Variable) (bas
 	case bool:
 		result = types.DynamicValue(types.BoolValue(value))
 
-	case map[string]interface{}:
+	case map[string]any:
 		byteSlice, err := json.Marshal(value)
 		if err != nil {
 			diags = append(diags, helpers.SerializeDataErrorDiagnostic("data", "Variable Value", err))
@@ -221,7 +221,7 @@ func getDynamicValue(model VariableDataSourceModel, variable *api.Variable) (bas
 
 		model.Value = types.DynamicValue(jsontypes.NewNormalizedValue(string(byteSlice)))
 
-	case []interface{}:
+	case []any:
 		tupleTypes := make([]attr.Type, len(value))
 		tupleValues := make([]attr.Value, len(value))
 

--- a/internal/provider/datasources/work_pool.go
+++ b/internal/provider/datasources/work_pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -128,9 +129,7 @@ func (d *WorkPoolDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 	// and add the account/workspace ID overrides here
 	// as they are not needed in the work_pools (plural) list
 	workPoolAttributes := make(map[string]schema.Attribute)
-	for k, v := range workPoolAttributesBase {
-		workPoolAttributes[k] = v
-	}
+	maps.Copy(workPoolAttributes, workPoolAttributesBase)
 	workPoolAttributes["account_id"] = schema.StringAttribute{
 		CustomType:  customtypes.UUIDType{},
 		Description: "Account ID (UUID), defaults to the account set in the provider",

--- a/internal/provider/datasources/work_queue.go
+++ b/internal/provider/datasources/work_queue.go
@@ -2,6 +2,7 @@ package datasources
 
 import (
 	"context"
+	"maps"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -116,9 +117,7 @@ func (d *WorkQueueDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 	// as they are not needed in the work_queues (plural) list
 
 	workQueueAttributes := make(map[string]schema.Attribute)
-	for k, v := range workQueueAttributesBase {
-		workQueueAttributes[k] = v
-	}
+	maps.Copy(workQueueAttributes, workQueueAttributesBase)
 
 	workQueueAttributes["account_id"] = schema.StringAttribute{
 		CustomType:  customtypes.UUIDType{},

--- a/internal/provider/datasources/work_queue_test.go
+++ b/internal/provider/datasources/work_queue_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
-	"k8s.io/utils/ptr"
 )
 
 func fixtureAccSingleWorkQueue(
@@ -178,19 +177,19 @@ func testAccCheckworkQueueExists(workPoolResourceName string, workQueues *[]*api
 var expectedWorkQueues = []*api.WorkQueue{
 	{
 		Name:        "default",
-		Priority:    ptr.To(int64(2)),
-		Description: ptr.To("The work pool's default queue."),
+		Priority:    new(int64(2)),
+		Description: new("The work pool's default queue."),
 		IsPaused:    false,
 	},
 	{
 		Name:        "test-queue",
-		Priority:    ptr.To(int64(1)),
-		Description: ptr.To("my work queue"),
+		Priority:    new(int64(1)),
+		Description: new("my work queue"),
 		IsPaused:    false,
 	},
 	{
 		Name:        "test-queue-2",
-		Description: ptr.To(""),
+		Description: new(""),
 		IsPaused:    false,
 		// Intentionally not setting Priority.
 	},

--- a/internal/provider/helpers/marshal.go
+++ b/internal/provider/helpers/marshal.go
@@ -9,12 +9,12 @@ import (
 // nil and no diagnostics. If it is set, it attempts to unmarshal it and returns any diagnostics.
 // Returning nil (rather than an empty map) ensures that struct fields tagged with `omitempty` are
 // omitted from JSON serialization, which avoids sending empty `{}` values in PATCH payloads.
-func UnmarshalOptional(attribute jsontypes.Normalized) (map[string]interface{}, diag.Diagnostics) {
+func UnmarshalOptional(attribute jsontypes.Normalized) (map[string]any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if attribute.IsNull() || attribute.IsUnknown() {
 		return nil, diags
 	}
-	var result map[string]interface{}
+	var result map[string]any
 	diags = attribute.Unmarshal(&result)
 
 	return result, diags

--- a/internal/provider/resources/automation_resource.go
+++ b/internal/provider/resources/automation_resource.go
@@ -701,9 +701,9 @@ func mapActionsTerraformToAPI(tfActions []ActionModel) ([]api.Action, diag.Diagn
 // getUnderlyingRequireValue extracts the underlying value from a CompositeTriggerAttributesModel's Require field.
 // This helper is used when constructing the overall AutomationUpsert request payload
 // from a given Terraform model, as the .Require attribute is a types.DynamicValue.
-func getUnderlyingRequireValue(plan CompoundTriggerAttributesModel) (interface{}, diag.Diagnostics) {
+func getUnderlyingRequireValue(plan CompoundTriggerAttributesModel) (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var value interface{}
+	var value any
 
 	switch underlyingValue := plan.Require.UnderlyingValue().(type) {
 	case types.String:

--- a/internal/provider/resources/block_schema.go
+++ b/internal/provider/resources/block_schema.go
@@ -207,7 +207,7 @@ func (r *BlockSchemaResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	var fields interface{}
+	var fields any
 	if err := json.Unmarshal([]byte(plan.Fields.ValueString()), &fields); err != nil {
 		resp.Diagnostics.Append(helpers.SerializeDataErrorDiagnostic("fields", "Block Schema", err))
 

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
-	"k8s.io/utils/ptr"
 )
 
 type deploymentConfig struct {
@@ -375,7 +374,7 @@ func TestAccResource_deployment(t *testing.T) {
 		PullSteps: []api.PullStep{
 			{
 				PullStepSetWorkingDirectory: &api.PullStepSetWorkingDirectory{
-					Directory: ptr.To("/some/directory"),
+					Directory: new("/some/directory"),
 				},
 			},
 		},
@@ -420,34 +419,34 @@ func TestAccResource_deployment(t *testing.T) {
 		PullSteps: []api.PullStep{
 			{
 				PullStepSetWorkingDirectory: &api.PullStepSetWorkingDirectory{
-					Directory: ptr.To("/some/other/directory"),
+					Directory: new("/some/other/directory"),
 				},
 			},
 			{
 				PullStepGitClone: &api.PullStepGitClone{
-					Repository:        ptr.To("https://github.com/prefecthq/prefect"),
-					Branch:            ptr.To("main"),
-					AccessToken:       ptr.To("123abc"),
-					IncludeSubmodules: ptr.To(true),
+					Repository:        new("https://github.com/prefecthq/prefect"),
+					Branch:            new("main"),
+					AccessToken:       new("123abc"),
+					IncludeSubmodules: new(true),
 				},
 			},
 			{
 				PullStepPullFromAzureBlobStorage: &api.PullStepPullFromAzure{
-					Container: ptr.To("my-container"),
-					Folder:    ptr.To("my-folder"),
+					Container: new("my-container"),
+					Folder:    new("my-folder"),
 					PullStepCommon: api.PullStepCommon{
-						Credentials: ptr.To("azure-credentials"),
-						Requires:    ptr.To("prefect-azure[blob_storage]"),
+						Credentials: new("azure-credentials"),
+						Requires:    new("prefect-azure[blob_storage]"),
 					},
 				},
 			},
 			{
 				PullStepPullFromS3: &api.PullStepPullFrom{
-					Bucket: ptr.To("some-bucket"),
-					Folder: ptr.To("some-folder"),
+					Bucket: new("some-bucket"),
+					Folder: new("some-folder"),
 					PullStepCommon: api.PullStepCommon{
-						Credentials: ptr.To("some-credentials"),
-						Requires:    ptr.To("prefect-aws>=0.3.4"),
+						Credentials: new("some-credentials"),
+						Requires:    new("prefect-aws>=0.3.4"),
 					},
 				},
 			},

--- a/internal/provider/resources/service_account.go
+++ b/internal/provider/resources/service_account.go
@@ -606,8 +606,8 @@ func (r *ServiceAccountResource) Delete(ctx context.Context, req resource.Delete
 
 // ImportState imports the resource into Terraform state.
 func (r *ServiceAccountResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	if strings.HasPrefix(req.ID, "name/") {
-		name := strings.TrimPrefix(req.ID, "name/")
+	if after, ok := strings.CutPrefix(req.ID, "name/"); ok {
+		name := after
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
 	} else {
 		resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)

--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -254,7 +254,7 @@ func copyVariableToModel(ctx context.Context, variable *api.Variable, tfModel *V
 
 // convertAPIValueToDynamic converts an API value (interface{}) to a types.Dynamic
 // value that can be stored in Terraform state.
-func convertAPIValueToDynamic(ctx context.Context, value interface{}) (types.Dynamic, diag.Diagnostics) {
+func convertAPIValueToDynamic(ctx context.Context, value any) (types.Dynamic, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if value == nil {
@@ -273,7 +273,7 @@ func convertAPIValueToDynamic(ctx context.Context, value interface{}) (types.Dyn
 	case bool:
 		return types.DynamicValue(types.BoolValue(v)), diags
 
-	case []interface{}:
+	case []any:
 		// Convert to Terraform tuple
 		elements := make([]attr.Value, len(v))
 		elementTypes := make([]attr.Type, len(v))
@@ -308,7 +308,7 @@ func convertAPIValueToDynamic(ctx context.Context, value interface{}) (types.Dyn
 
 		return types.DynamicValue(tupleValue), diags
 
-	case map[string]interface{}:
+	case map[string]any:
 		// Parse JSON into attribute types and values for Terraform object
 		attrTypes := make(map[string]attr.Type)
 		attrValues := make(map[string]attr.Value)
@@ -346,9 +346,9 @@ func convertAPIValueToDynamic(ctx context.Context, value interface{}) (types.Dyn
 
 // getUnderlyingValue converts the 'value' attribute from a DynamicValue to
 // a native Go type that can be sent to the Prefect API.
-func getUnderlyingValue(plan VariableResourceModelV1) (interface{}, diag.Diagnostics) {
+func getUnderlyingValue(plan VariableResourceModelV1) (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var value interface{}
+	var value any
 
 	switch underlyingValue := plan.Value.UnderlyingValue().(type) {
 	case types.String:
@@ -376,7 +376,7 @@ func getUnderlyingValue(plan VariableResourceModelV1) (interface{}, diag.Diagnos
 		value = result
 
 	case types.Object:
-		result := map[string]interface{}{}
+		result := map[string]any{}
 		if err := json.Unmarshal([]byte(underlyingValue.String()), &result); err != nil {
 			diags.Append(diag.NewErrorDiagnostic(
 				"unable to convert object to map[string]interface",

--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -635,8 +635,8 @@ func (r *VariableResource) ImportState(ctx context.Context, req resource.ImportS
 
 	variableIdentifier := parts[0]
 
-	if strings.HasPrefix(variableIdentifier, "name/") {
-		name := strings.TrimPrefix(variableIdentifier, "name/")
+	if after, ok := strings.CutPrefix(variableIdentifier, "name/"); ok {
+		name := after
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), name)...)
 	} else {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), variableIdentifier)...)

--- a/internal/provider/resources/variable_conversion_test.go
+++ b/internal/provider/resources/variable_conversion_test.go
@@ -16,9 +16,9 @@ func TestConvertAPIValueToDynamic(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		input         interface{}
+		input         any
 		expectedType  string
-		expectedValue interface{}
+		expectedValue any
 		expectError   bool
 	}{
 		{
@@ -51,19 +51,19 @@ func TestConvertAPIValueToDynamic(t *testing.T) {
 		},
 		{
 			name:         "array value",
-			input:        []interface{}{"foo", "bar"},
+			input:        []any{"foo", "bar"},
 			expectedType: "types.Tuple",
 			expectError:  false,
 		},
 		{
 			name:         "array value with quoted strings (from API)",
-			input:        []interface{}{`"foo"`, `"bar"`},
+			input:        []any{`"foo"`, `"bar"`},
 			expectedType: "types.Tuple",
 			expectError:  false,
 		},
 		{
 			name:         "object value",
-			input:        map[string]interface{}{"key": "value", "number": float64(42)},
+			input:        map[string]any{"key": "value", "number": float64(42)},
 			expectedType: "types.Object",
 			expectError:  false,
 		},

--- a/internal/provider/resources/variable_test.go
+++ b/internal/provider/resources/variable_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/testutils"
 )
 
-func fixtureAccVariableResource(workspace, workspaceIDArg, name string, value interface{}) string {
+func fixtureAccVariableResource(workspace, workspaceIDArg, name string, value any) string {
 	return fmt.Sprintf(`
 %s
 
@@ -26,7 +26,7 @@ resource "prefect_variable" "test" {
 	`, workspace, name, value, workspaceIDArg)
 }
 
-func fixtureAccVariableResourceWithTags(workspace, workspaceIDARg, name string, value interface{}) string {
+func fixtureAccVariableResourceWithTags(workspace, workspaceIDARg, name string, value any) string {
 	return fmt.Sprintf(`
 %s
 
@@ -51,9 +51,9 @@ func TestAccResource_variable(t *testing.T) {
 	valueNumber := float64(123)
 	valueBool := true
 	valueTuple := `["foo", "bar"]`
-	valueTupleExpected := []interface{}{`"foo"`, `"bar"`}
+	valueTupleExpected := []any{`"foo"`, `"bar"`}
 	valueObject := `{"foo" = "bar"}`
-	valueObjectExpected := map[string]interface{}{"foo": "bar"}
+	valueObjectExpected := map[string]any{"foo": "bar"}
 
 	workspace := testutils.NewEphemeralWorkspace()
 

--- a/internal/provider/resources/work_queue.go
+++ b/internal/provider/resources/work_queue.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
-	"k8s.io/utils/ptr"
 )
 
 var (
@@ -279,7 +278,7 @@ func (r *WorkQueueResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	if plan.Description.IsNull() {
-		updateRequest.Description = ptr.To("")
+		updateRequest.Description = new("")
 	} else {
 		updateRequest.Description = plan.Description.ValueStringPointer()
 	}

--- a/internal/provider/resources/workspace.go
+++ b/internal/provider/resources/workspace.go
@@ -437,8 +437,8 @@ func (r *WorkspaceResource) Delete(ctx context.Context, req resource.DeleteReque
 
 // ImportState imports the resource into Terraform state.
 func (r *WorkspaceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	if strings.HasPrefix(req.ID, "handle/") {
-		handle := strings.TrimPrefix(req.ID, "handle/")
+	if after, ok := strings.CutPrefix(req.ID, "handle/"); ok {
+		handle := after
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("handle"), handle)...)
 	} else {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -17,7 +17,7 @@ import (
 // convertToNormalizedJSON converts an interface to a jsontypes.Normalized.
 // This is useful in tests, where we need to mimic the normalization
 // that Terraform does to attributes of type jsontypes.Normalized.
-func convertToNormalizedJSON(i interface{}) (jsontypes.Normalized, error) {
+func convertToNormalizedJSON(i any) (jsontypes.Normalized, error) {
 	jsonByteSlice, err := json.Marshal(i)
 	if err != nil {
 		return jsontypes.Normalized{}, fmt.Errorf("error marshalling interface to JSON: %w", err)
@@ -38,7 +38,7 @@ func convertToNormalizedJSON(i interface{}) (jsontypes.Normalized, error) {
 func NormalizedValueForJSON(t *testing.T, jsonValue string) string {
 	t.Helper()
 
-	var jsonObj interface{}
+	var jsonObj any
 	if err := json.Unmarshal([]byte(jsonValue), &jsonObj); err != nil {
 		t.Fatalf("error unmarshalling JSON value %s: %s", jsonValue, err.Error())
 	}

--- a/internal/testutils/template.go
+++ b/internal/testutils/template.go
@@ -11,7 +11,7 @@ import (
 // Where:
 //   - tpl is a string like "Hello, {{.Name}}"
 //   - data is a struct like `mydata{Name: "World"}`
-func RenderTemplate(tpl string, data interface{}) string {
+func RenderTemplate(tpl string, data any) string {
 	var result bytes.Buffer
 
 	tmpl, err := template.New("template").Parse(tpl)


### PR DESCRIPTION
Related to https://linear.app/prefect/issue/PLA-2340

### Summary

Bumps the project to Go 1.26 and applies the results of `go fix ./...`. The
fixes are split into separate commits for easier review:

- Bump Go to 1.26 and update `.mise.toml`
- `interface{}` → `any`
- `ptr.To(x)` → `new(x)` (builtin)
- `maps.Copy` where applicable
- `strings.CutPrefix` where applicable
- Remove no-op `omitempty` on nested struct fields
- Bump `go.mod`/`go.sum`

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)