### PR TITLE
fix(teams): paginate List() to avoid silent truncation at 200 results

### DIFF
--- a/internal/api/teams.go
+++ b/internal/api/teams.go
@@ -43,3 +43,11 @@ type TeamFilter struct {
 		} `json:"name"`
 	} `json:"teams"`
 }
+
+// TeamFilterRequest wraps TeamFilter with pagination parameters
+// for the POST /teams/filter endpoint.
+type TeamFilterRequest struct {
+	TeamFilter
+	Limit  *int64 `json:"limit,omitempty"`
+	Offset *int64 `json:"offset,omitempty"`
+}


### PR DESCRIPTION
Related to https://linear.app/prefect/issue/PLA-2348

### Summary

The Prefect API's `POST /teams/filter` endpoint enforces a default limit of 200 results. The previous single-request `List()` implementation silently dropped results for accounts exceeding that threshold.

This adds an offset/limit pagination loop in `TeamsClient.List()` so it fetches all pages automatically. The method signature is unchanged, so callers (including the `prefect_teams` data source) need no modifications.

Changes:
- Added `TeamFilterRequest` struct in `internal/api/teams.go` that embeds `TeamFilter` with `Limit`/`Offset` pagination fields
- Rewrote `List()` in `internal/client/teams.go` with a pagination loop (200 items per page, fetches until a partial page is returned)

Other data sources (`service_accounts`, `work_pools`, `account_roles`, `workspace_roles`, `account_memberships`, `flows`) have the same single-request pattern and could be addressed in follow-up work.

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

<details>
<summary>Session context</summary>

Noticed that `TeamsClient.List()` made a single request to the filter endpoint, which silently caps at 200 results. Added a `TeamFilterRequest` wrapper that embeds the existing `TeamFilter` with offset/limit fields, then rewrote `List()` to page through results. Considered adding pagination acceptance tests but the cost (~500 API calls to create/delete 201+ teams) makes it impractical. The existing acceptance tests validate the wire format is correct. Scoped this to teams only to keep the change small and reviewable.
</details>