### PR TITLE
fix(flows): use FlowFilter instead of WorkspaceFilter in List()

### DIFF
--- a/internal/api/flows.go
+++ b/internal/api/flows.go
@@ -10,7 +10,7 @@ import (
 type FlowsClient interface {
 	Create(ctx context.Context, data FlowCreate) (*Flow, error)
 	Get(ctx context.Context, flowID uuid.UUID) (*Flow, error)
-	List(ctx context.Context, handleNames []string) ([]*Flow, error)
+	List(ctx context.Context, names []string) ([]*Flow, error)
 	Update(ctx context.Context, flowID uuid.UUID, data FlowUpdate) error
 	Delete(ctx context.Context, flowID uuid.UUID) error
 }
@@ -38,11 +38,11 @@ type FlowUpdate struct {
 // FlowFilter defines the search filter payload
 // when searching for flows by name.
 // example request payload:
-// {"flows": {"handle": {"any_": ["test"]}}}.
+// {"flows": {"name": {"any_": ["test"]}}}.
 type FlowFilter struct {
 	Flows struct {
-		Handle struct {
+		Name struct {
 			Any []string `json:"any_"`
-		} `json:"handle"`
+		} `json:"name"`
 	} `json:"flows"`
 }

--- a/internal/client/flows.go
+++ b/internal/client/flows.go
@@ -72,12 +72,12 @@ func (c *FlowsClient) Create(ctx context.Context, data api.FlowCreate) (*api.Flo
 	return &flow, nil
 }
 
-// List returns a list of Flows, based on the provided list of handle names.
-func (c *FlowsClient) List(ctx context.Context, handleNames []string) ([]*api.Flow, error) {
-	filterQuery := api.WorkspaceFilter{}
+// List returns a list of Flows, based on the provided list of flow names.
+func (c *FlowsClient) List(ctx context.Context, names []string) ([]*api.Flow, error) {
+	filterQuery := api.FlowFilter{}
 
-	if len(handleNames) != 0 {
-		filterQuery.Workspaces.Handle.Any = handleNames
+	if len(names) != 0 {
+		filterQuery.Flows.Name.Any = names
 	}
 
 	cfg := requestConfig{


### PR DESCRIPTION
### Summary

The `FlowsClient.List()` method was using `api.WorkspaceFilter` to build the `POST /flows/filter` request body, which filters on workspace handles rather than flow names. This switches it to use `api.FlowFilter` and also fixes the `FlowFilter` struct to use `"name"` instead of `"handle"` to match the Prefect server schema (`FlowFilterName`).

`List()` isn't called anywhere in the provider today, so this is a safe correctness fix with no runtime callers to break.

Closes #635

Closes https://linear.app/prefect/issue/PLA-2349/bug-flows-client-uses-workspacefilter-instead-of-a-flowfilter

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)