### PR TITLE
fix(work_pools): paginate List() to avoid silent truncation at 200 results

### DIFF
--- a/internal/api/work_pools.go
+++ b/internal/api/work_pools.go
@@ -53,3 +53,11 @@ type WorkPoolFilter struct {
 		} `json:"id"`
 	} `json:"work_pools"`
 }
+
+// WorkPoolFilterRequest wraps WorkPoolFilter with pagination parameters
+// for the POST /work_pools/filter endpoint.
+type WorkPoolFilterRequest struct {
+	WorkPoolFilter
+	Limit  *int64 `json:"limit,omitempty"`
+	Offset *int64 `json:"offset,omitempty"`
+}


### PR DESCRIPTION
### Summary

Same mechanical fix as #634 for teams. The Prefect API's `POST /work_pools/filter` endpoint enforces a default limit of 200, so workspaces exceeding that threshold were silently dropping results. This adds an offset/limit pagination loop to `WorkPoolsClient.List()` so all results are returned regardless of count.

Closes #636