### PR TITLE
fix(release): exclude unsupported GOOS/GOARCH pairs from goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,14 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm
+    - goos: solaris
+      goarch: '386'
+    - goos: solaris
+      goarch: arm
+    - goos: solaris
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - formats: [ 'zip' ]


### PR DESCRIPTION
### Summary

The [v2.92.4 release](https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/22201767983/job/64330183939) failed after ~6.5 minutes of builds because Go 1.24+ dropped support for `windows/arm`. Since we're on Go 1.26, a few other `solaris` pairs are also invalid.

This adds ignore rules for the unsupported targets: `windows/arm`, `solaris/386`, `solaris/arm`, and `solaris/arm64`. Confirmed against `go tool dist list`.

Related to https://linear.app/prefect/issue/PLA-2354

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review