### PR TITLE
fix(variable): stop double-escaping JSON string values in variable resource

### DIFF
--- a/internal/provider/resources/variable.go
+++ b/internal/provider/resources/variable.go
@@ -2,10 +2,8 @@ package resources
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -278,16 +276,6 @@ func convertAPIValueToDynamic(ctx context.Context, value any) (types.Dynamic, di
 		elements := make([]attr.Value, len(v))
 		elementTypes := make([]attr.Type, len(v))
 		for i, elem := range v {
-			// The API returns tuple elements as quoted strings (e.g., '"foo"' instead of 'foo')
-			// because getUnderlyingValue uses e.String() which adds quotes.
-			// We need to unquote them when converting back.
-			if strElem, ok := elem.(string); ok {
-				// Try to unquote if it's a quoted string
-				if unquoted, err := strconv.Unquote(strElem); err == nil {
-					elem = unquoted
-				}
-			}
-
 			// Recursively convert each element
 			elemDynamic, elemDiags := convertAPIValueToDynamic(ctx, elem)
 			if elemDiags.HasError() {
@@ -344,56 +332,63 @@ func convertAPIValueToDynamic(ctx context.Context, value any) (types.Dynamic, di
 	}
 }
 
-// getUnderlyingValue converts the 'value' attribute from a DynamicValue to
-// a native Go type that can be sent to the Prefect API.
-func getUnderlyingValue(plan VariableResourceModelV1) (any, diag.Diagnostics) {
+// convertAttrValueToNative converts a Terraform attr.Value to a native Go type
+// that can be JSON-serialized and sent to the Prefect API.
+func convertAttrValueToNative(v attr.Value) (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var value any
 
-	switch underlyingValue := plan.Value.UnderlyingValue().(type) {
+	switch val := v.(type) {
 	case types.String:
-		value = underlyingValue.ValueString()
+		return val.ValueString(), diags
 
 	case types.Number:
-		var err error
-		value, err = strconv.ParseFloat(underlyingValue.String(), 64)
-		if err != nil {
-			diags.Append(diag.NewErrorDiagnostic(
-				"unable to convert number to float64",
-				fmt.Sprintf("number: %v, error: %v", value, err),
-			))
-		}
+		f, _ := val.ValueBigFloat().Float64()
+
+		return f, diags
 
 	case types.Bool:
-		value = underlyingValue.ValueBool()
+		return val.ValueBool(), diags
 
 	case types.Tuple:
-		result := make([]string, len(underlyingValue.Elements()))
-		for i, e := range underlyingValue.Elements() {
-			result[i] = e.String()
+		result := make([]any, len(val.Elements()))
+		for i, elem := range val.Elements() {
+			elemVal, elemDiags := convertAttrValueToNative(elem)
+			diags.Append(elemDiags...)
+			if diags.HasError() {
+				return nil, diags
+			}
+			result[i] = elemVal
 		}
 
-		value = result
+		return result, diags
 
 	case types.Object:
-		result := map[string]any{}
-		if err := json.Unmarshal([]byte(underlyingValue.String()), &result); err != nil {
-			diags.Append(diag.NewErrorDiagnostic(
-				"unable to convert object to map[string]interface",
-				fmt.Sprintf("object: %v, error: %v", value, err),
-			))
+		result := make(map[string]any, len(val.Attributes()))
+		for key, attrVal := range val.Attributes() {
+			elemVal, elemDiags := convertAttrValueToNative(attrVal)
+			diags.Append(elemDiags...)
+			if diags.HasError() {
+				return nil, diags
+			}
+			result[key] = elemVal
 		}
 
-		value = result
+		return result, diags
 
 	default:
 		diags.Append(diag.NewErrorDiagnostic(
 			"unexpected value type",
-			fmt.Sprintf("type: %T", underlyingValue),
+			fmt.Sprintf("type: %T", v),
 		))
-	}
 
-	return value, diags
+		return nil, diags
+	}
+}
+
+// getUnderlyingValue converts the 'value' attribute from a DynamicValue to
+// a native Go type that can be sent to the Prefect API.
+func getUnderlyingValue(plan VariableResourceModelV1) (any, diag.Diagnostics) {
+	return convertAttrValueToNative(plan.Value.UnderlyingValue())
 }
 
 // Create creates the resource and sets the initial Terraform state.

--- a/internal/provider/resources/variable_conversion_test.go
+++ b/internal/provider/resources/variable_conversion_test.go
@@ -2,8 +2,10 @@ package resources // nolint:testpackage // need access to private convertAPIValu
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,12 +54,6 @@ func TestConvertAPIValueToDynamic(t *testing.T) {
 		{
 			name:         "array value",
 			input:        []any{"foo", "bar"},
-			expectedType: "types.Tuple",
-			expectError:  false,
-		},
-		{
-			name:         "array value with quoted strings (from API)",
-			input:        []any{`"foo"`, `"bar"`},
 			expectedType: "types.Tuple",
 			expectError:  false,
 		},
@@ -119,4 +115,110 @@ func TestConvertAPIValueToDynamic(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConvertAttrValueToNative(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string value", func(t *testing.T) {
+		t.Parallel()
+		result, diags := convertAttrValueToNative(types.StringValue("hello"))
+		require.False(t, diags.HasError())
+		assert.Equal(t, "hello", result)
+	})
+
+	t.Run("JSON string value is preserved as-is", func(t *testing.T) {
+		t.Parallel()
+		result, diags := convertAttrValueToNative(types.StringValue(`{"name":"dev"}`))
+		require.False(t, diags.HasError())
+		assert.Equal(t, `{"name":"dev"}`, result)
+	})
+
+	t.Run("number value", func(t *testing.T) {
+		t.Parallel()
+		result, diags := convertAttrValueToNative(types.NumberValue(big.NewFloat(42)))
+		require.False(t, diags.HasError())
+		assert.Equal(t, float64(42), result)
+	})
+
+	t.Run("boolean value", func(t *testing.T) {
+		t.Parallel()
+		result, diags := convertAttrValueToNative(types.BoolValue(true))
+		require.False(t, diags.HasError())
+		assert.Equal(t, true, result)
+	})
+
+	t.Run("tuple of strings", func(t *testing.T) {
+		t.Parallel()
+		tupleVal, tupleDiags := types.TupleValue(
+			[]attr.Type{types.StringType, types.StringType},
+			[]attr.Value{types.StringValue("foo"), types.StringValue("bar")},
+		)
+		require.False(t, tupleDiags.HasError())
+
+		result, diags := convertAttrValueToNative(tupleVal)
+		require.False(t, diags.HasError())
+		assert.Equal(t, []any{"foo", "bar"}, result)
+	})
+
+	t.Run("tuple of mixed types", func(t *testing.T) {
+		t.Parallel()
+		tupleVal, tupleDiags := types.TupleValue(
+			[]attr.Type{types.StringType, types.NumberType, types.BoolType},
+			[]attr.Value{
+				types.StringValue("foo"),
+				types.NumberValue(big.NewFloat(123)),
+				types.BoolValue(true),
+			},
+		)
+		require.False(t, tupleDiags.HasError())
+
+		result, diags := convertAttrValueToNative(tupleVal)
+		require.False(t, diags.HasError())
+		assert.Equal(t, []any{"foo", float64(123), true}, result)
+	})
+
+	t.Run("object value", func(t *testing.T) {
+		t.Parallel()
+		objVal, objDiags := types.ObjectValue(
+			map[string]attr.Type{"key": types.StringType, "number": types.NumberType},
+			map[string]attr.Value{
+				"key":    types.StringValue("value"),
+				"number": types.NumberValue(big.NewFloat(42)),
+			},
+		)
+		require.False(t, objDiags.HasError())
+
+		result, diags := convertAttrValueToNative(objVal)
+		require.False(t, diags.HasError())
+		assert.Equal(t, map[string]any{"key": "value", "number": float64(42)}, result)
+	})
+
+	t.Run("nested object containing tuple", func(t *testing.T) {
+		t.Parallel()
+		tupleVal, tupleDiags := types.TupleValue(
+			[]attr.Type{types.StringType, types.StringType},
+			[]attr.Value{types.StringValue("a"), types.StringValue("b")},
+		)
+		require.False(t, tupleDiags.HasError())
+
+		objVal, objDiags := types.ObjectValue(
+			map[string]attr.Type{
+				"name": types.StringType,
+				"list": tupleVal.Type(context.Background()),
+			},
+			map[string]attr.Value{
+				"name": types.StringValue("test"),
+				"list": tupleVal,
+			},
+		)
+		require.False(t, objDiags.HasError())
+
+		result, diags := convertAttrValueToNative(objVal)
+		require.False(t, diags.HasError())
+		assert.Equal(t, map[string]any{
+			"name": "test",
+			"list": []any{"a", "b"},
+		}, result)
+	})
 }

--- a/internal/provider/resources/variable_test.go
+++ b/internal/provider/resources/variable_test.go
@@ -51,7 +51,7 @@ func TestAccResource_variable(t *testing.T) {
 	valueNumber := float64(123)
 	valueBool := true
 	valueTuple := `["foo", "bar"]`
-	valueTupleExpected := []any{`"foo"`, `"bar"`}
+	valueTupleExpected := []any{"foo", "bar"}
 	valueObject := `{"foo" = "bar"}`
 	valueObjectExpected := map[string]any{"foo": "bar"}
 


### PR DESCRIPTION
### Summary

`getUnderlyingValue()` was converting Terraform types to Go types incorrectly before sending them to the API. For tuples, it called `.String()` on each element, which wraps strings in escaped quotes (e.g., `"foo"` becomes `"\"foo\""`). For objects, it tried to `json.Unmarshal` the `.String()` output, which isn't valid JSON. Both paths caused values to get double-escaped when the HTTP client JSON-serialized the request body.

This replaces the conversion logic with a recursive `convertAttrValueToNative()` that uses the correct SDK accessors (`ValueString()`, `ValueBool()`, `Attributes()`, `Elements()`) to extract actual values. Also removes a `strconv.Unquote` workaround in `convertAPIValueToDynamic()` that was compensating for the double-quoting on the read path.

Closes #641

### Upgrade note

Users who have `prefect_variable` resources with tuple or object values may see a one-time plan diff after upgrading. This is expected. The previously stored values in the API contain extra escape characters from the bug, and the provider will now send the correct unescaped values. Running `terraform apply` will fix the stored values. No manual intervention is needed.

<details>
<summary>Session context</summary>

Traced the full data flow from Terraform schema through the resource handler to the HTTP client. The `.String()` method on Terraform SDK types returns a debug/display representation with JSON quoting, not the raw value. The object case was even more broken since Terraform's `.String()` output isn't valid JSON at all. The `strconv.Unquote` workaround on the read path was a clue that something was off on the write path.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)