### PR TITLE
fix(resources): add missing early returns to prevent nil pointer crashes

### DIFF
--- a/internal/provider/resources/block.go
+++ b/internal/provider/resources/block.go
@@ -350,6 +350,8 @@ func (r *BlockResource) Read(ctx context.Context, req resource.ReadRequest, resp
 			"ID is unset",
 			"This is a bug in the Terraform provider. Please report it to the maintainers.",
 		)
+
+		return
 	}
 
 	client, err := r.client.BlockDocuments(state.AccountID.ValueUUID(), state.WorkspaceID.ValueUUID())

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -706,6 +706,8 @@ func (r *DeploymentResource) Create(ctx context.Context, req resource.CreateRequ
 			"Error creating deployment client",
 			fmt.Sprintf("Could not create deployment client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
 		)
+
+		return
 	}
 
 	var tags []string
@@ -802,6 +804,8 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 			"Error creating deployment client",
 			fmt.Sprintf("Could not create deployment client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
 		)
+
+		return
 	}
 
 	// A deployment can be imported + read by either ID or Handle
@@ -977,6 +981,8 @@ func (r *DeploymentResource) Delete(ctx context.Context, req resource.DeleteRequ
 			"Error creating deployment client",
 			fmt.Sprintf("Could not create deployment client, unexpected error: %s. This is a bug in the provider, please report this to the maintainers.", err.Error()),
 		)
+
+		return
 	}
 
 	deploymentID, err := uuid.Parse(state.ID.ValueString())

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -318,9 +318,7 @@ func (r *DeploymentScheduleResource) Read(ctx context.Context, req resource.Read
 
 	schedule, err := getScheduleByID(state, schedules)
 	if err != nil {
-		// If the specific schedule is not found in the list, it was likely
-		// deleted externally. Remove it from state so Terraform can recreate it.
-		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError("Unable to get schedule by ID", err.Error())
 
 		return
 	}

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -273,6 +273,9 @@ func (r *DeploymentScheduleResource) Create(ctx context.Context, req resource.Cr
 	// Additionally, we couldn't use getResourceByID here because of a race condition:
 	// we'd need an ID in the state to compare against, which doesn't exist yet.
 	resp.Diagnostics.Append(copyScheduleModelToResourceModel(schedules[0], &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -324,6 +327,9 @@ func (r *DeploymentScheduleResource) Read(ctx context.Context, req resource.Read
 	}
 
 	resp.Diagnostics.Append(copyScheduleModelToResourceModel(schedule, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -394,6 +400,9 @@ func (r *DeploymentScheduleResource) Update(ctx context.Context, req resource.Up
 	}
 
 	resp.Diagnostics.Append(copyScheduleModelToResourceModel(schedule, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -318,7 +318,11 @@ func (r *DeploymentScheduleResource) Read(ctx context.Context, req resource.Read
 
 	schedule, err := getScheduleByID(state, schedules)
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to get schedule by ID", err.Error())
+		// If the specific schedule is not found in the list, it was likely
+		// deleted externally. Remove it from state so Terraform can recreate it.
+		resp.State.RemoveResource(ctx)
+
+		return
 	}
 
 	resp.Diagnostics.Append(copyScheduleModelToResourceModel(schedule, &state)...)
@@ -387,6 +391,8 @@ func (r *DeploymentScheduleResource) Update(ctx context.Context, req resource.Up
 	schedule, err := getScheduleByID(plan, schedules)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to get schedule by ID", err.Error())
+
+		return
 	}
 
 	resp.Diagnostics.Append(copyScheduleModelToResourceModel(schedule, &plan)...)


### PR DESCRIPTION
### Summary

Fixes missing early returns after error diagnostics across several resources. Without these returns, execution falls through to use nil clients or write invalid state, causing provider crashes.

**`deployment_schedule.go`** (original fix, Closes #639):
- `Read` and `Update` were missing early returns after `getScheduleByID()` errors, causing a nil pointer crash on every `terraform plan` after initial apply.
- `Read` now returns an error diagnostic instead of crashing. Silent state removal was rejected since `getScheduleByID` doesn't produce 404s.
- `Create`, `Read`, and `Update` now check `HasError` after `copyScheduleModelToResourceModel` before writing to state, matching the pattern in `deployment.go`.

**`deployment.go`**:
- `Create`, `Read`, and `Delete` were missing returns after the deployment client init error. A nil `client` would be used on the next line. (`Update` already had the return.)

**`block.go`**:
- `Read` was missing a return after detecting a null ID, allowing execution to continue with an invalid state.

<details>
<summary>Session context</summary>

Started from the user-reported crash in #639 (stack trace pointed at deployment_schedule.go:428). After fixing that, audited all resource files for the same pattern: AddError without return. Found 4 additional crash-causing sites in deployment.go and block.go, plus 3 missing HasError checks in deployment_schedule.go. The false positives (account.go, user.go, etc.) are entire function bodies that end after the error, so no fall-through risk.
</details>