### PR TITLE
chore(CI): update GPG secret names to use keybase keyring

### DIFF
--- a/.github/workflows/provider-release.yaml
+++ b/.github/workflows/provider-release.yaml
@@ -28,8 +28,8 @@ jobs:
         uses: crazy-max/ghaction-import-gpg@v6
         id: import_gpg
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_KEYRING_BASE64 }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Summary

Updates GitHub Actions secrets used in the provider release workflow to align with the migration from marvin GPG key to keybase GPG key for signing Terraform provider releases.

## Changes

- Updated `.github/workflows/provider-release.yaml`:
  - `GPG_PRIVATE_KEY` → `GPG_KEYRING_BASE64`
  - `PASSPHRASE` → `GPG_PASSPHRASE`

## Context

This change corresponds to the migration in an internal repository where the Terraform provider GitHub secrets were updated to use the keybase keyring instead of the marvin GPG key.

The new secrets need to be configured in the GitHub repository settings before merging this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code)