### PR TITLE
fix(resources): reset work pool access to wildcard on deletion

### DIFF
--- a/internal/provider/resources/work_pool_access.go
+++ b/internal/provider/resources/work_pool_access.go
@@ -347,7 +347,6 @@ func (r *WorkPoolAccessResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-
 	payload := api.WorkPoolAccessSet{}
 	payload.AccessControl.ManageActorIDs = []string{"*"}
 	payload.AccessControl.ViewActorIDs = []string{"*"}
@@ -355,7 +354,6 @@ func (r *WorkPoolAccessResource) Delete(ctx context.Context, req resource.Delete
 	payload.AccessControl.ViewTeamIDs = []string{}
 	payload.AccessControl.RunActorIDs = []string{"*"}
 	payload.AccessControl.RunTeamIDs = []string{}
-
 
 	err = client.Set(ctx, state.WorkPoolName.ValueString(), payload)
 	if err != nil {

--- a/internal/provider/resources/work_pool_access.go
+++ b/internal/provider/resources/work_pool_access.go
@@ -347,13 +347,15 @@ func (r *WorkPoolAccessResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
+
 	payload := api.WorkPoolAccessSet{}
-	payload.AccessControl.ManageActorIDs = []string{}
-	payload.AccessControl.ViewActorIDs = []string{}
+	payload.AccessControl.ManageActorIDs = []string{"*"}
+	payload.AccessControl.ViewActorIDs = []string{"*"}
 	payload.AccessControl.ManageTeamIDs = []string{}
 	payload.AccessControl.ViewTeamIDs = []string{}
-	payload.AccessControl.RunActorIDs = []string{}
+	payload.AccessControl.RunActorIDs = []string{"*"}
 	payload.AccessControl.RunTeamIDs = []string{}
+
 
 	err = client.Set(ctx, state.WorkPoolName.ValueString(), payload)
 	if err != nil {

--- a/internal/provider/resources/work_pool_access_test.go
+++ b/internal/provider/resources/work_pool_access_test.go
@@ -16,6 +16,7 @@ type workPoolAccessConfig struct {
 	WorkspaceResource     string
 	WorkspaceResourceName string
 	ServiceAccountName    string
+	IncludeAccess         bool
 }
 
 func fixtureAccWorkPoolAccess(cfg workPoolAccessConfig) string {
@@ -59,6 +60,7 @@ resource "prefect_work_pool" "test" {
 	workspace_id = {{.WorkspaceResourceName}}.id
 }
 
+{{if .IncludeAccess}}
 resource "prefect_work_pool_access" "test" {
 	workspace_id = {{.WorkspaceResourceName}}.id
 	work_pool_name = prefect_work_pool.test.name
@@ -71,6 +73,7 @@ resource "prefect_work_pool_access" "test" {
 	run_team_ids = [data.prefect_team.test.id]
 	view_team_ids = [data.prefect_team.test.id]
 }
+{{end}}
 `
 
 	return testutils.RenderTemplate(tmpl, cfg)
@@ -85,7 +88,7 @@ func TestAccResource_work_pool_access(t *testing.T) {
 	serviceAccountName := testutils.NewRandomPrefixedString()
 	teamName := "my-team"
 
-	cfgSet := workPoolAccessConfig{
+	baseCfg := workPoolAccessConfig{
 		WorkspaceResource:     workspace.Resource,
 		WorkspaceResourceName: testutils.WorkspaceResourceName,
 		ServiceAccountName:    serviceAccountName,
@@ -99,7 +102,12 @@ func TestAccResource_work_pool_access(t *testing.T) {
 		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: fixtureAccWorkPoolAccess(cfgSet),
+				Config: fixtureAccWorkPoolAccess(workPoolAccessConfig{
+					WorkspaceResource:     baseCfg.WorkspaceResource,
+					WorkspaceResourceName: baseCfg.WorkspaceResourceName,
+					ServiceAccountName:    baseCfg.ServiceAccountName,
+					IncludeAccess:         true,
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckWorkPoolExists("prefect_work_pool.test", &workPool),
 					testAccCheckWorkPoolAccessExists("prefect_work_pool_access.test", &workPoolAccess),
@@ -117,6 +125,12 @@ func TestAccResource_work_pool_access(t *testing.T) {
 							{Name: teamName, Type: api.TeamAccessor},
 						},
 					}),
+				),
+			},
+			{
+				Config: fixtureAccWorkPoolAccess(baseCfg),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckWorkPoolAccessDestroy("prefect_work_pool.test"),
 				),
 			},
 		},
@@ -180,6 +194,53 @@ func testAccCheckWorkPoolAccessValues(fetchedWorkPoolAccess *api.WorkPoolAccessC
 			err := actorFound(test.fetched, test.expected)
 			if err != nil {
 				return fmt.Errorf("%s: %w", name, err)
+			}
+		}
+
+		return nil
+	}
+}
+
+// testAccCheckWorkPoolAccessDestroy is a Custom Check Function that
+// verifies that the API object was destroyed correctly.
+func testAccCheckWorkPoolAccessDestroy(workPoolResourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Get the workspace resource we just created from the state
+		workspaceID, err := testutils.GetResourceIDFromState(s, testutils.WorkspaceResourceName)
+		if err != nil {
+			return fmt.Errorf("error fetching workspace ID: %w", err)
+		}
+
+		workPoolName, err := testutils.GetResourceAttributeFromStateByAttribute(s, workPoolResourceName, "name")
+		if err != nil {
+			return fmt.Errorf("error fetching work pool name: %w", err)
+		}
+
+		// Initialize the client with the associated workspaceID
+		// NOTE: the accountID is inherited by the one set in the test environment
+		c, _ := testutils.NewTestClient()
+		workPoolAccessClient, _ := c.WorkPoolAccess(uuid.Nil, workspaceID)
+
+		fetchedWorkPoolAccess, err := workPoolAccessClient.Read(context.Background(), workPoolName)
+		if err != nil {
+			return fmt.Errorf("error fetching work pool access: %w", err)
+		}
+
+		expectedActors := []api.ObjectActorAccess{
+			{ID: "*", Name: "*", Type: api.AllAccessors},
+		}
+
+		checks := map[string][]api.ObjectActorAccess{
+			"manage_actors": fetchedWorkPoolAccess.ManageActors,
+			"run_actors":    fetchedWorkPoolAccess.RunActors,
+			"view_actors":   fetchedWorkPoolAccess.ViewActors,
+		}
+		for name, actors := range checks {
+			if len(actors) != len(expectedActors) {
+				return fmt.Errorf("expected %s to have %d entries, got %d", name, len(expectedActors), len(actors))
+			}
+			if actors[0].ID != "*" || actors[0].Type != api.AllAccessors {
+				return fmt.Errorf("expected %s to be wildcard access, got %+v", name, actors[0])
 			}
 		}
 


### PR DESCRIPTION
### Summary

- Fix `Delete` on `prefect_work_pool_access` to reset actor IDs to wildcard (`"*"`) instead of empty slices. Empty slices resulted in a restrictive state where no one had access to the work pool after resource deletion, rather than restoring the default open access.
- Add acceptance test for the delete path using a two-step approach: first step creates the access control, second step removes only the `prefect_work_pool_access` resource (keeping the work pool alive) and verifies that access control is reset to wildcard defaults.

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org/) format
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Acceptance tests are added/updated (including import tests, when needed)
<img width="703" height="53" alt="IMG_3627" src="https://github.com/user-attachments/assets/f094248e-3ee2-4222-877b-f9f9954d3bad" />
