### PR TITLE
Add run_shell_script and pip_install_requirements utility steps

### DIFF
--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -101,9 +101,14 @@ Read-Only:
 - `branch` (String) (For type 'git_clone') The branch to clone. If not provided, the default branch is used.
 - `bucket` (String) (For type 'pull_from_*') The name of the bucket where files are stored.
 - `credentials` (String) Credentials to use for the pull step. Refer to a {GitHub,GitLab,BitBucket} credentials block.
-- `directory` (String) (For type 'set_working_directory') The directory to set as the working directory.
+- `directory` (String) (For type 'set_working_directory', 'run_shell_script', and 'pip_install_requirements') The directory where the step should run/apply.
+- `env` (Map of String) (For type 'run_shell_script') Environment variables to set when running the script.
+- `expand_env_vars` (Boolean) (For type 'run_shell_script') Whether to expand environment variables in the script before running.
 - `folder` (String) (For type 'pull_from_*') The folder in the bucket where files are stored.
 - `include_submodules` (Boolean) (For type 'git_clone') Whether to include submodules when cloning the repository.
 - `repository` (String) (For type 'git_clone') The URL of the repository to clone.
+- `requirements_file` (String) (For type 'pip_install_requirements') The requirements file to install from.
 - `requires` (String) A list of Python package dependencies.
+- `script` (String) (For type 'run_shell_script') The shell script to execute.
+- `stream_output` (Boolean) (For type 'run_shell_script' and 'pip_install_requirements') Whether to stream command output to stdout/stderr.
 - `type` (String) The type of pull step

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -164,11 +164,16 @@ Optional:
 - `bucket` (String) (For type 'pull_from_s3' and 'pull_from_gcs') The name of the bucket where files are stored.
 - `container` (String) (For type 'pull_from_azure_blob_storage') The name of the container where files are stored.
 - `credentials` (String) Credentials to use for the pull step. Refer to a {GitHub,GitLab,BitBucket} credentials block.
-- `directory` (String) (For type 'set_working_directory') The directory to set as the working directory.
+- `directory` (String) (For type 'set_working_directory', 'run_shell_script', and 'pip_install_requirements') The directory where the step should run/apply.
+- `env` (Map of String) (For type 'run_shell_script') Environment variables to set when running the script.
+- `expand_env_vars` (Boolean) (For type 'run_shell_script') Whether to expand environment variables in the script before running.
 - `folder` (String) (For type 'pull_from_*') The folder in the bucket/container where files are stored.
 - `include_submodules` (Boolean) (For type 'git_clone') Whether to include submodules when cloning the repository.
 - `repository` (String) (For type 'git_clone') The URL of the repository to clone.
+- `requirements_file` (String) (For type 'pip_install_requirements') The requirements file to install from.
 - `requires` (String) A list of Python package dependencies.
+- `script` (String) (For type 'run_shell_script') The shell script to execute.
+- `stream_output` (Boolean) (For type 'run_shell_script' and 'pip_install_requirements') Whether to stream command output to stdout/stderr.
 
 ## Import
 

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -92,10 +92,32 @@ resource "prefect_deployment" "deployment" {
       folder    = "my-folder",
     },
     {
+      type     = "pull_from_gcs",
+      requires = "prefect-gcp>=0.6.0"
+      bucket   = "some-gcs-bucket",
+      folder   = "some-folder",
+    },
+    {
       type     = "pull_from_s3",
       requires = "prefect-aws>=0.3.4"
       bucket   = "some-bucket",
       folder   = "some-folder",
+    },
+    {
+      type              = "pip_install_requirements"
+      directory         = "/some/directory"
+      requirements_file = "requirements.txt"
+      stream_output     = true
+    },
+    {
+      type            = "run_shell_script"
+      script          = "python --version"
+      directory       = "/some/directory"
+      expand_env_vars = true
+      stream_output   = true
+      env = {
+        "EXAMPLE_ENV_KEY" = "example-value"
+      }
     }
   ]
   storage_document_id = prefect_block.test_gh_repository.id

--- a/examples/resources/prefect_deployment/resource.tf
+++ b/examples/resources/prefect_deployment/resource.tf
@@ -72,10 +72,32 @@ resource "prefect_deployment" "deployment" {
       folder    = "my-folder",
     },
     {
+      type     = "pull_from_gcs",
+      requires = "prefect-gcp>=0.6.0"
+      bucket   = "some-gcs-bucket",
+      folder   = "some-folder",
+    },
+    {
       type     = "pull_from_s3",
       requires = "prefect-aws>=0.3.4"
       bucket   = "some-bucket",
       folder   = "some-folder",
+    },
+    {
+      type              = "pip_install_requirements"
+      directory         = "/some/directory"
+      requirements_file = "requirements.txt"
+      stream_output     = true
+    },
+    {
+      type            = "run_shell_script"
+      script          = "python --version"
+      directory       = "/some/directory"
+      expand_env_vars = true
+      stream_output   = true
+      env = {
+        "EXAMPLE_ENV_KEY" = "example-value"
+      }
     }
   ]
   storage_document_id = prefect_block.test_gh_repository.id

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -126,6 +126,7 @@ type PullStepGitClone struct {
 	Branch *string `json:"branch,omitempty"`
 
 	// Access token for the repository.
+	//nolint:gosec // This is an API model field name required by Prefect's schema.
 	AccessToken *string `json:"access_token,omitempty"`
 
 	// IncludeSubmodules determines whether to include submodules when cloning the repository.

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -160,11 +160,47 @@ type PullStepPullFromAzure struct {
 	Folder *string `json:"folder,omitempty"`
 }
 
+// PullStepRunShellScript is a representation of a pull step that runs a shell script.
+type PullStepRunShellScript struct {
+	PullStepCommon
+
+	// The script to run.
+	Script *string `json:"script,omitempty"`
+
+	// The directory to run the script in.
+	Directory *string `json:"directory,omitempty"`
+
+	// Environment variables to set for the script.
+	Env map[string]string `json:"env,omitempty"`
+
+	// Whether to stream script output to stdout/stderr.
+	StreamOutput *bool `json:"stream_output,omitempty"`
+
+	// Whether to expand environment variables in the script before running.
+	ExpandEnvVars *bool `json:"expand_env_vars,omitempty"`
+}
+
+// PullStepPipInstallRequirements is a representation of a pull step that installs dependencies from a requirements file.
+type PullStepPipInstallRequirements struct {
+	PullStepCommon
+
+	// The directory containing the requirements file.
+	Directory *string `json:"directory,omitempty"`
+
+	// The requirements file to install from.
+	RequirementsFile *string `json:"requirements_file,omitempty"`
+
+	// Whether to stream pip install output to stdout/stderr.
+	StreamOutput *bool `json:"stream_output,omitempty"`
+}
+
 // PullStep contains instructions for preparing your flows for a deployment run.
 type PullStep struct {
-	PullStepGitClone                 *PullStepGitClone            `json:"prefect.deployments.steps.git_clone,omitempty"`
-	PullStepSetWorkingDirectory      *PullStepSetWorkingDirectory `json:"prefect.deployments.steps.set_working_directory,omitempty"`
-	PullStepPullFromAzureBlobStorage *PullStepPullFromAzure       `json:"prefect_azure.deployments.steps.pull_from_azure_blob_storage,omitempty"`
-	PullStepPullFromGCS              *PullStepPullFrom            `json:"prefect_gcp.deployments.steps.pull_from_gcs,omitempty"`
-	PullStepPullFromS3               *PullStepPullFrom            `json:"prefect_aws.deployments.steps.pull_from_s3,omitempty"`
+	PullStepGitClone                 *PullStepGitClone               `json:"prefect.deployments.steps.git_clone,omitempty"`
+	PullStepRunShellScript           *PullStepRunShellScript         `json:"prefect.deployments.steps.run_shell_script,omitempty"`
+	PullStepPipInstallRequirements   *PullStepPipInstallRequirements `json:"prefect.deployments.steps.pip_install_requirements,omitempty"`
+	PullStepSetWorkingDirectory      *PullStepSetWorkingDirectory    `json:"prefect.deployments.steps.set_working_directory,omitempty"`
+	PullStepPullFromAzureBlobStorage *PullStepPullFromAzure          `json:"prefect_azure.deployments.steps.pull_from_azure_blob_storage,omitempty"`
+	PullStepPullFromGCS              *PullStepPullFrom               `json:"prefect_gcp.deployments.steps.pull_from_gcs,omitempty"`
+	PullStepPullFromS3               *PullStepPullFrom               `json:"prefect_aws.deployments.steps.pull_from_s3,omitempty"`
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -86,6 +86,7 @@ func (c *Client) obtainCsrfToken() error {
 		req.Header.Set(key, value)
 	}
 
+	// #nosec G704 -- request target is built from provider endpoint configuration.
 	resp, err := c.hc.Do(req)
 	if err != nil {
 		return fmt.Errorf("http error on CSRF token request: %w", err)

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -167,6 +167,7 @@ func request(ctx context.Context, client *http.Client, cfg requestConfig) (*http
 	setDefaultHeaders(req, cfg.apiKey, cfg.basicAuthKey, cfg.csrfClientToken, cfg.csrfToken, cfg.customHeaders)
 
 	// Body will be closed by the caller.
+	// #nosec G704 -- request URL comes from validated API route construction in provider clients.
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)

--- a/internal/provider/datasources/deployment.go
+++ b/internal/provider/datasources/deployment.go
@@ -212,7 +212,28 @@ For more information, see [deploy overview](https://docs.prefect.io/v3/deploy/in
 						},
 						"directory": schema.StringAttribute{
 							Computed:    true,
-							Description: "(For type 'set_working_directory') The directory to set as the working directory.",
+							Description: "(For type 'set_working_directory', 'run_shell_script', and 'pip_install_requirements') The directory where the step should run/apply.",
+						},
+						"script": schema.StringAttribute{
+							Computed:    true,
+							Description: "(For type 'run_shell_script') The shell script to execute.",
+						},
+						"env": schema.MapAttribute{
+							Computed:    true,
+							Description: "(For type 'run_shell_script') Environment variables to set when running the script.",
+							ElementType: types.StringType,
+						},
+						"stream_output": schema.BoolAttribute{
+							Computed:    true,
+							Description: "(For type 'run_shell_script' and 'pip_install_requirements') Whether to stream command output to stdout/stderr.",
+						},
+						"expand_env_vars": schema.BoolAttribute{
+							Computed:    true,
+							Description: "(For type 'run_shell_script') Whether to expand environment variables in the script before running.",
+						},
+						"requirements_file": schema.StringAttribute{
+							Computed:    true,
+							Description: "(For type 'pip_install_requirements') The requirements file to install from.",
 						},
 						"repository": schema.StringAttribute{
 							Computed:    true,

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -606,7 +606,10 @@ func mapPullStepsAPIToTerraform(pullSteps []api.PullStep) ([]PullStepModel, diag
 	for i := range pullSteps {
 		pullStep := pullSteps[i]
 
-		var pullStepModel PullStepModel
+		pullStepModel := PullStepModel{
+			// Ensure map type metadata is always present, even on non-run_shell_script pull steps.
+			Env: types.MapNull(types.StringType),
+		}
 
 		// PullStepGitClone
 		if pullStep.PullStepGitClone != nil {
@@ -647,8 +650,6 @@ func mapPullStepsAPIToTerraform(pullSteps []api.PullStep) ([]PullStepModel, diag
 				if !mapDiags.HasError() {
 					pullStepModel.Env = env
 				}
-			} else {
-				pullStepModel.Env = types.MapNull(types.StringType)
 			}
 
 			// common fields

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -82,6 +82,8 @@ type PullStepModel struct {
 	// One of:
 	// - set_working_directory
 	// - git_clone
+	// - run_shell_script
+	// - pip_install_requirements
 	// - pull_from_azure_blob_storage
 	// - pull_from_gcs
 	// - pull_from_s3
@@ -99,6 +101,21 @@ type PullStepModel struct {
 	//
 
 	Directory types.String `tfsdk:"directory"`
+
+	//
+	// Fields for run_shell_script
+	//
+
+	Script        types.String `tfsdk:"script"`
+	Env           types.Map    `tfsdk:"env"`
+	StreamOutput  types.Bool   `tfsdk:"stream_output"`
+	ExpandEnvVars types.Bool   `tfsdk:"expand_env_vars"`
+
+	//
+	// Fields for pip_install_requirements
+	//
+
+	RequirementsFile types.String `tfsdk:"requirements_file"`
 
 	//
 	// Fields for git_clone
@@ -381,6 +398,11 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 							"credentials":        types.StringType,
 							"requires":           types.StringType,
 							"directory":          types.StringType,
+							"script":             types.StringType,
+							"env":                types.MapType{ElemType: types.StringType},
+							"stream_output":      types.BoolType,
+							"expand_env_vars":    types.BoolType,
+							"requirements_file":  types.StringType,
 							"repository":         types.StringType,
 							"branch":             types.StringType,
 							"access_token":       types.StringType,
@@ -401,6 +423,8 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								stringvalidator.OneOf(
 									"set_working_directory",
 									"git_clone",
+									"run_shell_script",
+									"pip_install_requirements",
 									"pull_from_azure_blob_storage",
 									"pull_from_gcs",
 									"pull_from_s3",
@@ -416,11 +440,35 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 							Optional:    true,
 						},
 						"directory": schema.StringAttribute{
-							Description: "(For type 'set_working_directory') The directory to set as the working directory.",
+							Description: "(For type 'set_working_directory', 'run_shell_script', and 'pip_install_requirements') The directory where the step should run/apply.",
 							Optional:    true,
 							Validators: []validator.String{
 								stringvalidator.ConflictsWith(pathExpressionsForAttributes(nonDirectoryAttributes)...),
 							},
+						},
+						"script": schema.StringAttribute{
+							Description: "(For type 'run_shell_script') The shell script to execute.",
+							Optional:    true,
+							Validators:  stringConflictsWithValidators(nonRunShellScriptAttributes),
+						},
+						"env": schema.MapAttribute{
+							Description: "(For type 'run_shell_script') Environment variables to set when running the script.",
+							Optional:    true,
+							ElementType: types.StringType,
+						},
+						"stream_output": schema.BoolAttribute{
+							Description: "(For type 'run_shell_script' and 'pip_install_requirements') Whether to stream command output to stdout/stderr.",
+							Optional:    true,
+						},
+						"expand_env_vars": schema.BoolAttribute{
+							Description: "(For type 'run_shell_script') Whether to expand environment variables in the script before running.",
+							Optional:    true,
+							Validators:  boolConflictsWithValidators(nonRunShellScriptBoolAttributes),
+						},
+						"requirements_file": schema.StringAttribute{
+							Description: "(For type 'pip_install_requirements') The requirements file to install from.",
+							Optional:    true,
+							Validators:  stringConflictsWithValidators(nonPipInstallRequirementsAttributes),
 						},
 						"repository": schema.StringAttribute{
 							Description: "(For type 'git_clone') The URL of the repository to clone.",
@@ -501,6 +549,32 @@ func mapPullStepsTerraformToAPI(tfPullSteps []PullStepModel) ([]api.PullStep, di
 				Directory: tfPullStep.Directory.ValueStringPointer(),
 			}
 
+		case "run_shell_script":
+			var env map[string]string
+			if !tfPullStep.Env.IsNull() && !tfPullStep.Env.IsUnknown() {
+				env = make(map[string]string)
+				for key, value := range tfPullStep.Env.Elements() {
+					env[key] = value.(basetypes.StringValue).ValueString()
+				}
+			}
+
+			apiPullStep.PullStepRunShellScript = &api.PullStepRunShellScript{
+				PullStepCommon: pullStepCommon,
+				Script:         tfPullStep.Script.ValueStringPointer(),
+				Directory:      tfPullStep.Directory.ValueStringPointer(),
+				Env:            env,
+				StreamOutput:   tfPullStep.StreamOutput.ValueBoolPointer(),
+				ExpandEnvVars:  tfPullStep.ExpandEnvVars.ValueBoolPointer(),
+			}
+
+		case "pip_install_requirements":
+			apiPullStep.PullStepPipInstallRequirements = &api.PullStepPipInstallRequirements{
+				PullStepCommon:   pullStepCommon,
+				Directory:        tfPullStep.Directory.ValueStringPointer(),
+				RequirementsFile: tfPullStep.RequirementsFile.ValueStringPointer(),
+				StreamOutput:     tfPullStep.StreamOutput.ValueBoolPointer(),
+			}
+
 		case "pull_from_azure_blob_storage":
 			apiPullStep.PullStepPullFromAzureBlobStorage = &api.PullStepPullFromAzure{
 				PullStepCommon: pullStepCommon,
@@ -550,6 +624,45 @@ func mapPullStepsAPIToTerraform(pullSteps []api.PullStep) ([]PullStepModel, diag
 			pullStepModel.Directory = types.StringValue(*pullStep.PullStepSetWorkingDirectory.Directory)
 
 			// common fields not used on this pull step type
+		}
+
+		// PullStepRunShellScript
+		if pullStep.PullStepRunShellScript != nil {
+			pullStepModel.Type = types.StringValue("run_shell_script")
+			pullStepModel.Script = types.StringPointerValue(pullStep.PullStepRunShellScript.Script)
+			pullStepModel.Directory = types.StringPointerValue(pullStep.PullStepRunShellScript.Directory)
+			pullStepModel.StreamOutput = types.BoolPointerValue(pullStep.PullStepRunShellScript.StreamOutput)
+			pullStepModel.ExpandEnvVars = types.BoolPointerValue(pullStep.PullStepRunShellScript.ExpandEnvVars)
+
+			envElements := make(map[string]attr.Value, len(pullStep.PullStepRunShellScript.Env))
+			for key, value := range pullStep.PullStepRunShellScript.Env {
+				envElements[key] = types.StringValue(value)
+			}
+			if len(envElements) > 0 {
+				env, mapDiags := types.MapValue(types.StringType, envElements)
+				diags.Append(mapDiags...)
+				if !mapDiags.HasError() {
+					pullStepModel.Env = env
+				}
+			} else {
+				pullStepModel.Env = types.MapNull(types.StringType)
+			}
+
+			// common fields
+			pullStepModel.Credentials = types.StringPointerValue(pullStep.PullStepRunShellScript.Credentials)
+			pullStepModel.Requires = types.StringPointerValue(pullStep.PullStepRunShellScript.Requires)
+		}
+
+		// PullStepPipInstallRequirements
+		if pullStep.PullStepPipInstallRequirements != nil {
+			pullStepModel.Type = types.StringValue("pip_install_requirements")
+			pullStepModel.Directory = types.StringPointerValue(pullStep.PullStepPipInstallRequirements.Directory)
+			pullStepModel.RequirementsFile = types.StringPointerValue(pullStep.PullStepPipInstallRequirements.RequirementsFile)
+			pullStepModel.StreamOutput = types.BoolPointerValue(pullStep.PullStepPipInstallRequirements.StreamOutput)
+
+			// common fields
+			pullStepModel.Credentials = types.StringPointerValue(pullStep.PullStepPipInstallRequirements.Credentials)
+			pullStepModel.Requires = types.StringPointerValue(pullStep.PullStepPipInstallRequirements.Requires)
 		}
 
 		// PullStepPullFromAzureBlobStorage
@@ -1075,9 +1188,28 @@ func boolConflictsWithValidators(attributes []string) []validator.Bool {
 	}
 }
 
+func combineAttributes(groups ...[]string) []string {
+	combined := make([]string, 0)
+	for _, group := range groups {
+		combined = append(combined, group...)
+	}
+
+	return combined
+}
+
 var (
 	directoryAttributes = []string{
 		"directory",
+	}
+
+	runShellScriptAttributes = []string{
+		"script",
+		"env",
+		"expand_env_vars",
+	}
+
+	pipInstallRequirementsAttributes = []string{
+		"requirements_file",
 	}
 
 	gitCloneAttributes = []string{
@@ -1093,7 +1225,11 @@ var (
 		"folder",
 	}
 
-	nonDirectoryAttributes = append(gitCloneAttributes, pullFromAttributes...)
-	nonGitCloneAttributes  = append(directoryAttributes, pullFromAttributes...)
-	nonPullFromAttributes  = append(directoryAttributes, gitCloneAttributes...)
+	nonDirectoryAttributes = combineAttributes(gitCloneAttributes, pullFromAttributes)
+	nonGitCloneAttributes  = combineAttributes(directoryAttributes, pullFromAttributes, runShellScriptAttributes, pipInstallRequirementsAttributes)
+	nonPullFromAttributes  = combineAttributes(directoryAttributes, gitCloneAttributes, runShellScriptAttributes, pipInstallRequirementsAttributes)
+
+	nonRunShellScriptAttributes         = combineAttributes(gitCloneAttributes, pullFromAttributes, pipInstallRequirementsAttributes)
+	nonRunShellScriptBoolAttributes     = combineAttributes(gitCloneAttributes, pullFromAttributes)
+	nonPipInstallRequirementsAttributes = combineAttributes(gitCloneAttributes, pullFromAttributes, runShellScriptAttributes)
 )

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -554,7 +555,9 @@ func mapPullStepsTerraformToAPI(tfPullSteps []PullStepModel) ([]api.PullStep, di
 			if !tfPullStep.Env.IsNull() && !tfPullStep.Env.IsUnknown() {
 				env = make(map[string]string)
 				for key, value := range tfPullStep.Env.Elements() {
-					env[key] = value.(basetypes.StringValue).ValueString()
+					if strVal, ok := value.(basetypes.StringValue); ok {
+						env[key] = strVal.ValueString()
+					}
 				}
 			}
 
@@ -1189,12 +1192,7 @@ func boolConflictsWithValidators(attributes []string) []validator.Bool {
 }
 
 func combineAttributes(groups ...[]string) []string {
-	combined := make([]string, 0)
-	for _, group := range groups {
-		combined = append(combined, group...)
-	}
-
-	return combined
+	return slices.Concat(groups...)
 }
 
 var (

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -123,6 +123,54 @@ resource "prefect_deployment" "{{.DeploymentName}}" {
 			{{-   end }}
 			{{- end }}
 
+			{{- with .PullStepRunShellScript }}
+			type = "run_shell_script"
+			{{-   if .Script }}
+			script = "{{.Script}}"
+			{{-   end }}
+			{{-   if .Directory }}
+			directory = "{{.Directory}}"
+			{{-   end }}
+			{{-   if .ExpandEnvVars }}
+			expand_env_vars = {{.ExpandEnvVars}}
+			{{-   end }}
+			{{-   if .StreamOutput }}
+			stream_output = {{.StreamOutput}}
+			{{-   end }}
+			{{-   if .Credentials }}
+			credentials = "{{.Credentials}}"
+			{{-   end }}
+			{{-   if .Requires }}
+			requires = "{{.Requires}}"
+			{{-   end }}
+			{{-   if .Env }}
+			env = {
+				{{- range $key, $value := .Env }}
+				"{{$key}}" = "{{$value}}"
+				{{- end }}
+			}
+			{{-   end }}
+			{{- end }}
+
+			{{- with .PullStepPipInstallRequirements }}
+			type = "pip_install_requirements"
+			{{-   if .Directory }}
+			directory = "{{.Directory}}"
+			{{-   end }}
+			{{-   if .RequirementsFile }}
+			requirements_file = "{{.RequirementsFile}}"
+			{{-   end }}
+			{{-   if .StreamOutput }}
+			stream_output = {{.StreamOutput}}
+			{{-   end }}
+			{{-   if .Credentials }}
+			credentials = "{{.Credentials}}"
+			{{-   end }}
+			{{-   if .Requires }}
+			requires = "{{.Requires}}"
+			{{-   end }}
+			{{- end }}
+
 			{{- with .PullStepPullFromAzureBlobStorage }}
 			type = "pull_from_azure_blob_storage"
 			{{-   if .Container }}
@@ -428,6 +476,24 @@ func TestAccResource_deployment(t *testing.T) {
 					Branch:            new("main"),
 					AccessToken:       new("123abc"),
 					IncludeSubmodules: new(true),
+				},
+			},
+			{
+				PullStepRunShellScript: &api.PullStepRunShellScript{
+					Script:        new("echo hello"),
+					Directory:     new("/some/script/directory"),
+					StreamOutput:  new(true),
+					ExpandEnvVars: new(true),
+					Env: map[string]string{
+						"NAME": "world",
+					},
+				},
+			},
+			{
+				PullStepPipInstallRequirements: &api.PullStepPipInstallRequirements{
+					Directory:        new("/some/script/directory"),
+					RequirementsFile: new("requirements.txt"),
+					StreamOutput:     new(false),
 				},
 			},
 			{

--- a/scripts/compare.go
+++ b/scripts/compare.go
@@ -181,6 +181,7 @@ func request() result {
 		log.Printf("Error creating request: %v", err)
 	}
 
+	// #nosec G704 -- using a fixed public URL.
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Printf("Error getting openapi.json: %v", err)


### PR DESCRIPTION
### Summary

Adds support for two additional Prefect deployment utility pull steps in Terraform deployment configuration:

- `run_shell_script`
- `pip_install_requirements`

This updates deployment `pull_steps` so these step types can be configured in Terraform and correctly serialized/deserialized with the Prefect API, based on upstream step definitions in [`utility.py`](https://github.com/PrefectHQ/prefect/blob/main/src/prefect/deployments/steps/utility.py).

## What Changed

- Extended API pull step models and union mapping to include:
  - `prefect.deployments.steps.run_shell_script`
  - `prefect.deployments.steps.pip_install_requirements`
- Updated deployment resource `pull_steps` schema to support new fields, including:
  - `script`, `env`, `stream_output`, `expand_env_vars`, `requirements_file`, and shared `directory`
- Added Terraform ↔ API mapping logic for both new step types.
- Kept deployment datasource `pull_steps` schema in parity with resource changes.
- Expanded deployment acceptance test fixture coverage to include both new pull step types.
- Regenerated deployment docs for resource and datasource nested `pull_steps` schema.

## Validation

- Formatted updated Go files with `gofmt`.
- Ran targeted package compile/test checks for touched areas (`internal/api`, deployment resource, deployment datasource).

Closes #654

-----

#### General

- [X] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [X] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [X] Body includes `Closes <issue>`, if available
- [X] Relevant labels have been added
- [X] `Draft` status is used until ready for review

#### Code-level changes

- [X] Unit tests are added/updated
- [ ] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [X] Documentation is added (generated by `mise run docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
