### PR TITLE
chore: suppress pre-existing gosec lint warnings

### DIFF
--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -126,7 +126,7 @@ type PullStepGitClone struct {
 	Branch *string `json:"branch,omitempty"`
 
 	// Access token for the repository.
-	AccessToken *string `json:"access_token,omitempty"`
+	AccessToken *string `json:"access_token,omitempty"` //nolint:gosec // this is a JSON field name, not a credential
 
 	// IncludeSubmodules determines whether to include submodules when cloning the repository.
 	IncludeSubmodules *bool `json:"include_submodules,omitempty"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -86,7 +86,7 @@ func (c *Client) obtainCsrfToken() error {
 		req.Header.Set(key, value)
 	}
 
-	resp, err := c.hc.Do(req)
+	resp, err := c.hc.Do(req) //nolint:gosec // URL is constructed from provider configuration, not user input
 	if err != nil {
 		return fmt.Errorf("http error on CSRF token request: %w", err)
 	}

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -167,7 +167,7 @@ func request(ctx context.Context, client *http.Client, cfg requestConfig) (*http
 	setDefaultHeaders(req, cfg.apiKey, cfg.basicAuthKey, cfg.csrfClientToken, cfg.csrfToken, cfg.customHeaders)
 
 	// Body will be closed by the caller.
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec // URL is constructed from provider configuration, not user input
 	if err != nil {
 		return nil, fmt.Errorf("http error: %w", err)
 	}

--- a/scripts/compare.go
+++ b/scripts/compare.go
@@ -181,7 +181,7 @@ func request() result {
 		log.Printf("Error creating request: %v", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // URL is a known API endpoint from command-line args
 	if err != nil {
 		log.Printf("Error getting openapi.json: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add `//nolint:gosec` directives to 4 pre-existing warnings that have been failing pre-commit hooks on every branch
- G117 (secret pattern): `AccessToken` struct field is a JSON key, not a credential
- G704 (SSRF): URLs are constructed from provider configuration or CLI args, not untrusted user input

<details>
<summary>Session context</summary>

These warnings were discovered while trying to commit an unrelated fix on another branch. The gosec linter was failing pre-commit hooks for all commits across all branches, blocking development.
</details>