### PR TITLE
Add contributor profile pictures to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ We appreciate your interest in the Prefect provider! If you find any issues or h
 - [File an issue](https://github.com/PrefectHQ/terraform-provider-prefect/issues/new?assignees=&labels=bug&projects=&template=bug.md)
 - [Send us a note](mailto:security@prefect.io) for any potential security issues
 - Reach out in the [Prefect community Slack workspace](https://communityinviter.com/apps/prefect-community/prefect-community)
+
+<a href="https://github.com/prefecthq/terraform-provider-prefect/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=prefecthq/terraform-provider-prefect" />
+</a>


### PR DESCRIPTION
## Summary
- Adds contributor avatar images to the Contributing section of the README using [contrib.rocks](https://contrib.rocks)
- The image auto-updates as new contributors are added; no CI or bot setup required

## Test plan
- [ ] Verify the contributor images render correctly on the GitHub README