### PR TITLE
fix(resources): ensure pull_steps don't trigger replacement

### DIFF
--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -78,6 +78,7 @@ type DeploymentUpdate struct {
 	Parameters               map[string]any      `json:"parameters,omitempty"`
 	Path                     *string             `json:"path,omitempty"`
 	Paused                   *bool               `json:"paused,omitempty"`
+	PullSteps                []PullStep          `json:"pull_steps,omitempty"`
 	StorageDocumentID        *uuid.UUID          `json:"storage_document_id,omitempty"`
 	Tags                     []string            `json:"tags,omitempty"`
 	Version                  *string             `json:"version,omitempty"`

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -387,11 +386,6 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Description: "Pull steps to prepare flows for a deployment run.",
 				Optional:    true,
 				Computed:    true,
-				PlanModifiers: []planmodifier.List{
-					// Pull steps are only set on create, so any change in their value will require a resource
-					// of the resource. See https://github.com/PrefectHQ/prefect/issues/11052 for more context.
-					listplanmodifier.RequiresReplace(),
-				},
 				Default: listdefault.StaticValue(basetypes.NewListValueMust(
 					types.ObjectType{
 						AttrTypes: map[string]attr.Type{
@@ -1040,6 +1034,12 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	pullSteps, diags := mapPullStepsTerraformToAPI(model.PullSteps)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	payload := api.DeploymentUpdate{
 		ConcurrencyLimit:         model.ConcurrencyLimit.ValueInt64Pointer(),
 		Description:              model.Description.ValueStringPointer(),
@@ -1051,6 +1051,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		Parameters:               parameters,
 		Path:                     model.Path.ValueStringPointer(),
 		Paused:                   model.Paused.ValueBoolPointer(),
+		PullSteps:                pullSteps,
 		StorageDocumentID:        model.StorageDocumentID.ValueUUIDPointer(),
 		Tags:                     tags,
 		Version:                  model.Version.ValueStringPointer(),

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -463,7 +463,7 @@ func TestAccResource_deployment(t *testing.T) {
 		// Tags: []string{"test1", "test3"}
 		Tags: cfgCreate.Tags,
 
-		// PullSteps require a replacement of the resource.
+		// PullSteps are updateable in-place.
 		PullSteps: []api.PullStep{
 			{
 				PullStepSetWorkingDirectory: &api.PullStepSetWorkingDirectory{
@@ -521,7 +521,10 @@ func TestAccResource_deployment(t *testing.T) {
 		StorageDocumentName: cfgCreate.StorageDocumentName,
 	}
 
-	var deployment api.Deployment
+	var (
+		deployment   api.Deployment
+		deploymentID string
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
@@ -537,6 +540,7 @@ func TestAccResource_deployment(t *testing.T) {
 						description: cfgCreate.Description,
 						pullSteps:   cfgCreate.PullSteps,
 					}),
+					testAccCaptureResourceID(cfgCreate.DeploymentResourceName, &deploymentID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNumber(cfgCreate.DeploymentResourceName, "concurrency_limit", cfgCreate.ConcurrencyLimit),
@@ -567,6 +571,7 @@ func TestAccResource_deployment(t *testing.T) {
 						description: cfgUpdate.Description,
 						pullSteps:   cfgUpdate.PullSteps,
 					}),
+					testAccCheckResourceIDUnchanged(cfgUpdate.DeploymentResourceName, &deploymentID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNumber(cfgUpdate.DeploymentResourceName, "concurrency_limit", cfgUpdate.ConcurrencyLimit),
@@ -771,6 +776,46 @@ func testAccCheckDeploymentValues(fetchedDeployment *api.Deployment, expectedVal
 
 		if !reflect.DeepEqual(fetchedDeployment.PullSteps, expectedValues.pullSteps) {
 			return fmt.Errorf("Expected pull steps to be: \n%v\n got \n%v", expectedValues.pullSteps, fetchedDeployment.PullSteps)
+		}
+
+		return nil
+	}
+}
+
+func testAccCaptureResourceID(resourceName string, resourceID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceName)
+		}
+
+		*resourceID = resourceState.Primary.ID
+		if *resourceID == "" {
+			return fmt.Errorf("resource %q ID is empty", resourceName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckResourceIDUnchanged(resourceName string, expectedID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceName)
+		}
+
+		if *expectedID == "" {
+			return fmt.Errorf("expected resource ID is empty for %q", resourceName)
+		}
+
+		if resourceState.Primary.ID != *expectedID {
+			return fmt.Errorf(
+				"expected resource %q to keep ID %q, got %q",
+				resourceName,
+				*expectedID,
+				resourceState.Primary.ID,
+			)
 		}
 
 		return nil


### PR DESCRIPTION
### Summary

Resolves #662 

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [ ] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`
