### PR TITLE
fix: add missing container attribute to deployment data source schema

### DIFF
--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -99,6 +99,7 @@ Read-Only:
 - `access_token` (String) (For type 'git_clone') Access token for the repository. Refer to a credentials block for security purposes. Used in leiu of 'credentials'.
 - `branch` (String) (For type 'git_clone') The branch to clone. If not provided, the default branch is used.
 - `bucket` (String) (For type 'pull_from_*') The name of the bucket where files are stored.
+- `container` (String) (For type 'pull_from_azure_blob_storage') The name of the container where files are stored.
 - `credentials` (String) Credentials to use for the pull step. Refer to a {GitHub,GitLab,BitBucket} credentials block.
 - `directory` (String) (For type 'set_working_directory', 'run_shell_script', and 'pip_install_requirements') The directory where the step should run/apply.
 - `env` (Map of String) (For type 'run_shell_script') Environment variables to set when running the script.

--- a/internal/provider/datasources/deployment.go
+++ b/internal/provider/datasources/deployment.go
@@ -250,6 +250,10 @@ For more information, see [deploy overview](https://docs.prefect.io/v3/deploy/in
 							Computed:    true,
 							Description: "(For type 'pull_from_*') The name of the bucket where files are stored.",
 						},
+						"container": schema.StringAttribute{
+							Computed:    true,
+							Description: "(For type 'pull_from_azure_blob_storage') The name of the container where files are stored.",
+						},
 						"folder": schema.StringAttribute{
 							Computed:    true,
 							Description: "(For type 'pull_from_*') The folder in the bucket where files are stored.",


### PR DESCRIPTION
### Summary

The `prefect_deployment` data source was missing a `container` attribute in the `pull_steps` schema, even though the underlying `PullStepModel` struct already had the field. This caused a `Value Conversion Error` when reading any deployment that includes a `container` in its `pull_steps` (e.g. `pull_from_azure_blob_storage`).

This just adds the missing `container` `schema.StringAttribute` to the data source schema to match the struct. The resource schema already had it.

Closes #668

Closes https://linear.app/prefect/issue/PLA-2561/prefect-deployment-data-source-fails-with-value-conversion-error

### Checklist notes

- Docs were auto-regenerated by the pre-commit hook
- No new tests needed. This is a schema-only addition to align with the existing struct. The framework validates schema/struct alignment, and the existing acceptance tests cover the data source read path.