### PR TITLE
ci(docs): install terraform via mise for tfplugindocs

### DIFF
--- a/.github/workflows/build-terraform-docs.yaml
+++ b/.github/workflows/build-terraform-docs.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tool dependencies
         uses: jdx/mise-action@v4
         with:
-          install_args: go:github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+          install_args: terraform go:github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
       - name: Disable mise auto-install for task runs
         run: mise settings set task_run_auto_install false
       - name: Build Terraform Docs


### PR DESCRIPTION
## Summary

The Build Terraform Docs job has been failing because mise only installed `tfplugindocs` (per `install_args`) and not Terraform. `tfplugindocs` then fell back to downloading its own Terraform binary and tripped on an expired HashiCorp PGP key:

> Error executing command: unable to generate website: error exporting provider schema from Terraform: unable to download Terraform binary: unable to verify checksums signature: openpgp: key expired

Adding `terraform` to `install_args` picks up the pinned 1.14.8 from `.mise.toml` without pulling in the rest of the toolchain.

## Why a separate PR

`pull_request_target` runs the workflow file from the base branch, so any PR that also touches this workflow can't actually exercise the new version. Landing here first lets in-flight PRs get a green docs check on their next push.

Failing run: https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/25410426753/job/74530727655

## Test plan

- [ ] Merge, then re-run docs on an open PR (e.g. #675) and confirm it passes