### PR TITLE
fix(resources): preserve user rrule round-trip for deployment_schedule

### DIFF
--- a/internal/provider/resources/deployment_schedule.go
+++ b/internal/provider/resources/deployment_schedule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -439,7 +440,7 @@ func copyScheduleModelToResourceModel(schedule *api.DeploymentSchedule, model *D
 	model.AnchorDate = types.StringValue(schedule.Schedule.AnchorDate)
 	model.Cron = types.StringValue(schedule.Schedule.Cron)
 	model.DayOr = types.BoolValue(schedule.Schedule.DayOr)
-	model.RRule = types.StringValue(schedule.Schedule.RRule)
+	model.RRule = types.StringValue(normalizeRRuleForState(schedule.Schedule.RRule, model.RRule.ValueString()))
 
 	model.Slug = types.StringValue(schedule.Slug)
 
@@ -472,6 +473,55 @@ func validateSchedules(schedules []*api.DeploymentSchedule) diag.Diagnostic {
 	}
 
 	return nil
+}
+
+// normalizeRRuleForState returns the rrule value to write into Terraform state.
+//
+// The Prefect server normalizes rrule values by prepending an explicit
+// `DTSTART:...\n` line when the submitted rrule lacks one. If we copy that
+// normalized form into state verbatim, Terraform sees a different value than
+// the plan and fails with "Provider produced inconsistent result after apply".
+//
+// To preserve round-trip stability, strip a leading `DTSTART...\n` line from
+// the server response when the prior local value (plan during Create, state
+// during Read/Update) did not itself begin with a DTSTART line. Users who
+// supply their own DTSTART get the server's value as-is.
+func normalizeRRuleForState(serverRRule, priorRRule string) string {
+	if serverRRule == "" {
+		return serverRRule
+	}
+
+	if hasDTStartPrefix(priorRRule) {
+		return serverRRule
+	}
+
+	if !hasDTStartPrefix(serverRRule) {
+		return serverRRule
+	}
+
+	if newline := strings.IndexByte(serverRRule, '\n'); newline >= 0 {
+		return serverRRule[newline+1:]
+	}
+
+	return serverRRule
+}
+
+// hasDTStartPrefix reports whether s starts with a DTSTART iCalendar line
+// (`DTSTART:...` or `DTSTART;TZID=...:...`), case-insensitive.
+func hasDTStartPrefix(s string) bool {
+	const prefix = "DTSTART"
+	if len(s) < len(prefix)+1 {
+		return false
+	}
+	if !strings.EqualFold(s[:len(prefix)], prefix) {
+		return false
+	}
+	switch s[len(prefix)] {
+	case ':', ';':
+		return true
+	default:
+		return false
+	}
 }
 
 // getScheduleByID gets a schedule by ID from a list of schedules.

--- a/internal/provider/resources/deployment_schedule_internal_test.go
+++ b/internal/provider/resources/deployment_schedule_internal_test.go
@@ -1,0 +1,102 @@
+package resources
+
+import "testing"
+
+func TestNormalizeRRuleForState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		server string
+		prior  string
+		want   string
+	}{
+		{
+			name:   "empty server value passes through",
+			server: "",
+			prior:  "",
+			want:   "",
+		},
+		{
+			name:   "no DTSTART on either side passes through",
+			server: "FREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+			prior:  "FREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+			want:   "FREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+		},
+		{
+			name:   "server prepends DTSTART, prior had none, strip it",
+			server: "DTSTART:20200101T000000\nFREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+			prior:  "FREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+			want:   "FREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+		},
+		{
+			name:   "server prepends DTSTART, prior empty (Create path), strip it",
+			server: "DTSTART:20200101T000000\nFREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+			prior:  "",
+			want:   "FREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+		},
+		{
+			name:   "user-supplied DTSTART preserved verbatim",
+			server: "DTSTART:20240101T000000\nFREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+			prior:  "DTSTART:20240101T000000\nFREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+			want:   "DTSTART:20240101T000000\nFREQ=DAILY;BYHOUR=10;BYMINUTE=30",
+		},
+		{
+			name:   "user-supplied DTSTART;TZID preserved verbatim",
+			server: "DTSTART;TZID=America/New_York:20240101T000000\nFREQ=DAILY",
+			prior:  "DTSTART;TZID=America/New_York:20240101T000000\nFREQ=DAILY",
+			want:   "DTSTART;TZID=America/New_York:20240101T000000\nFREQ=DAILY",
+		},
+		{
+			name:   "case-insensitive DTSTART recognition on prior",
+			server: "DTSTART:20240101T000000\nFREQ=DAILY",
+			prior:  "dtstart:20240101T000000\nFREQ=DAILY",
+			want:   "DTSTART:20240101T000000\nFREQ=DAILY",
+		},
+		{
+			name:   "DTSTART without a trailing newline is left alone",
+			server: "DTSTART:20200101T000000",
+			prior:  "",
+			want:   "DTSTART:20200101T000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := normalizeRRuleForState(tt.server, tt.prior)
+			if got != tt.want {
+				t.Errorf("normalizeRRuleForState(%q, %q) = %q; want %q", tt.server, tt.prior, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasDTStartPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"FREQ=DAILY", false},
+		{"DTSTART", false},
+		{"DTSTART:20200101T000000", true},
+		{"dtstart:20200101T000000", true},
+		{"DTSTART;TZID=UTC:20200101T000000", true},
+		{"DTSTARTX:foo", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+
+			got := hasDTStartPrefix(tt.in)
+			if got != tt.want {
+				t.Errorf("hasDTStartPrefix(%q) = %v; want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

Prefect OSS now normalizes rrule values by prepending an explicit `DTSTART:20200101T000000\n` line on write, so the GET response no longer matches what the provider sent. Terraform sees plan vs. state divergence and aborts with `Provider produced inconsistent result after apply`, which has been failing step 4 of `TestAccResource_deployment_schedule` on every PR (e.g. [run 25409601316](https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/25409601316)).

This strips a leading `DTSTART...\n` line from the server response when the prior local value didn't itself have one. Users who supply their own DTSTART get the server's value verbatim — no permanent diff in either direction.

Verified end-to-end: `./scripts/testacc-oss TestAccResource_deployment_schedule` passes all 5 steps against `prefecthq/prefect:3-latest`. The interval and cron schedule kinds were already passing, so the same class of issue isn't lurking there.

Closes [PLA-2677](https://linear.app/prefect/issue/PLA-2677/prefect-deployment-schedule-rrule-round-trip-fails-after-server)

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

<details>
<summary>Session context</summary>

Considered three approaches from the issue:

- **(a) Accept the server-normalized form into state.** Cleanest at the seam, but flips observable state for every existing rrule user on upgrade.
- **(b) Strip `DTSTART:...\n` from server responses.** Simple, but if applied unconditionally would clobber user-supplied DTSTARTs.
- **(c) Always send rrule with explicit DTSTART.** Mutates user input and locks the provider to whatever anchor the server happens to use today.

Landed on (b) with a guard: compare the server response against the prior local value (the plan during Create, prior state during Read/Update) and only strip the `DTSTART:` line when the local value didn't have one. That keeps both shapes round-trippable.

The helper is `normalizeRRuleForState(serverRRule, priorRRule)` plus a small `hasDTStartPrefix` check that handles both `DTSTART:` and `DTSTART;TZID=...:` forms, case-insensitive. White-box unit tests live in `deployment_schedule_internal_test.go`.

</details>