### PR TITLE
fix(resources): self-heal workspace_access when TEAM grant is deleted out-of-band

### DIFF
--- a/internal/client/team_access.go
+++ b/internal/client/team_access.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 )
 
 var _ = api.TeamAccessClient(&TeamAccessClient{})
@@ -107,7 +108,7 @@ func (c *TeamAccessClient) Read(ctx context.Context, teamID, memberID, memberAct
 	}
 
 	if teamAccess == nil {
-		return nil, fmt.Errorf("client.Read: team access not found for member ID: %s", memberActorID.String())
+		return nil, fmt.Errorf("client.Read: team access not found for member ID: %s: %w", memberActorID.String(), helpers.ErrNotFound)
 	}
 
 	return teamAccess, nil

--- a/internal/client/workspace_access.go
+++ b/internal/client/workspace_access.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
 	"github.com/prefecthq/terraform-provider-prefect/internal/utils"
 )
 
@@ -178,7 +179,7 @@ func (c *WorkspaceAccessClient) Get(ctx context.Context, accessorType string, ac
 	}
 
 	if workspaceAccess.ID == uuid.Nil {
-		return nil, fmt.Errorf("workspace access not found for accessID: %s", accessID.String())
+		return nil, fmt.Errorf("workspace access not found for accessID: %s: %w", accessID.String(), helpers.ErrNotFound)
 	}
 
 	return &workspaceAccess, nil

--- a/internal/provider/helpers/errors.go
+++ b/internal/provider/helpers/errors.go
@@ -1,11 +1,20 @@
 package helpers
 
-import "strings"
+import (
+	"errors"
+	"strings"
+)
 
 const (
 	Err404 = "status_code=404"
 )
 
+// ErrNotFound is a sentinel for client responses that semantically mean
+// "the remote object does not exist" but did not arrive as an HTTP 404
+// (e.g. a 200 OK list filter that returns no matching record). Wrap it so
+// resource Read methods can treat the object as deleted and drop it from state.
+var ErrNotFound = errors.New("resource not found")
+
 func Is404Error(err error) bool {
-	return strings.Contains(err.Error(), Err404)
+	return strings.Contains(err.Error(), Err404) || errors.Is(err, ErrNotFound)
 }

--- a/internal/provider/helpers/errors_test.go
+++ b/internal/provider/helpers/errors_test.go
@@ -1,0 +1,67 @@
+package helpers_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/helpers"
+)
+
+func TestIs404Error(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    error
+		expected bool
+	}{
+		{
+			name:     "http error encoding status_code=404",
+			input:    fmt.Errorf("http error: status_code=404, error=not found, body="),
+			expected: true,
+		},
+		{
+			name: "synthetic not-found wrapping ErrNotFound (workspace_access shape)",
+			input: fmt.Errorf("workspace access not found for accessID: %s: %w",
+				"be2d9981-300a-4c66-a4f7-7ed298a8830c", helpers.ErrNotFound),
+			expected: true,
+		},
+		{
+			name: "synthetic not-found wrapping ErrNotFound (team_access shape)",
+			input: fmt.Errorf("client.Read: team access not found for member ID: %s: %w",
+				"be2d9981-300a-4c66-a4f7-7ed298a8830c", helpers.ErrNotFound),
+			expected: true,
+		},
+		{
+			name:     "bare ErrNotFound sentinel",
+			input:    helpers.ErrNotFound,
+			expected: true,
+		},
+		{
+			name:     "deeply wrapped ErrNotFound",
+			input:    fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", helpers.ErrNotFound)),
+			expected: true,
+		},
+		{
+			name:     "unrelated server error",
+			input:    fmt.Errorf("http error: status_code=500, error=boom, body="),
+			expected: false,
+		},
+		{
+			name:     "generic error without status code or sentinel",
+			input:    errors.New("something else went wrong"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := helpers.Is404Error(tt.input); got != tt.expected {
+				t.Errorf("Is404Error(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/provider/resources/workspace_access_test.go
+++ b/internal/provider/resources/workspace_access_test.go
@@ -154,6 +154,10 @@ func TestAccResource_team_workspace_access(t *testing.T) {
 	// We use this variable to store the fetched resource from the API
 	// and it will be shared between TestSteps via a pointer.
 	var workspaceAccess api.WorkspaceAccess
+	// workspaceID is captured during the test so that the PreConfig hook
+	// (which does not receive the Terraform state) can build a scoped client
+	// to delete the access grant out-of-band.
+	var workspaceID uuid.UUID
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
@@ -178,12 +182,37 @@ func TestAccResource_team_workspace_access(t *testing.T) {
 					// Check updating the role of the workspace access resource, with matching linked attributes
 					testAccCheckWorkspaceAccessExists(utils.Team, accessResourceName, &workspaceAccess),
 					testAccCheckWorkspaceAccessValuesForAccessor(utils.Team, &workspaceAccess, teamResourceName, runnerRoleDatsourceName),
+					captureWorkspaceAccessWorkspaceID(&workspaceID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.CompareValuePairs(accessResourceName, "accessor_id", teamResourceName, "id"),
 					testutils.CompareValuePairs(accessResourceName, "workspace_id", testutils.WorkspaceResourceName, "id"),
 					testutils.CompareValuePairs(accessResourceName, "workspace_role_id", runnerRoleDatsourceName, "id"),
 				},
+			},
+			// Delete the TEAM access grant out-of-band and verify Terraform plans
+			// a corrective re-create rather than erroring during read. The TEAM
+			// accessor fetches via a 200-OK list filter, so a missing grant
+			// surfaces as a synthetic not-found that must still drop the resource
+			// from state. Regression guard for PLA-2779.
+			{
+				PreConfig: func() {
+					c, err := testutils.NewTestClient()
+					if err != nil {
+						t.Fatalf("failed to construct test client: %v", err)
+					}
+					workspaceAccessClient, err := c.WorkspaceAccess(uuid.Nil, workspaceID)
+					if err != nil {
+						t.Fatalf("failed to construct workspace access client: %v", err)
+					}
+					// For TEAM access, Delete is keyed off the accessor (team) ID.
+					if err := workspaceAccessClient.Delete(context.Background(), utils.Team, workspaceAccess.ID, *workspaceAccess.TeamID); err != nil {
+						t.Fatalf("failed to delete team workspace access out-of-band: %v", err)
+					}
+				},
+				Config:             fixtureAccWorkspaceAccessResourceUpdateForTeam(workspace.Resource),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				ImportState:       true,
@@ -193,6 +222,21 @@ func TestAccResource_team_workspace_access(t *testing.T) {
 			},
 		},
 	})
+}
+
+// captureWorkspaceAccessWorkspaceID stores the ephemeral workspace ID from
+// state so a subsequent step's PreConfig hook (which does not receive the
+// Terraform state) can build a scoped client to mutate access out-of-band.
+func captureWorkspaceAccessWorkspaceID(out *uuid.UUID) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		workspaceID, err := testutils.GetResourceWorkspaceIDFromState(state)
+		if err != nil {
+			return fmt.Errorf("error fetching workspace ID: %w", err)
+		}
+		*out = workspaceID
+
+		return nil
+	}
 }
 
 func testAccCheckWorkspaceAccessExists(accessorType string, accessResourceName string, access *api.WorkspaceAccess) resource.TestCheckFunc {


### PR DESCRIPTION
### Summary

When a team's workspace-access grant is deleted in Prefect Cloud outside Terraform, the next run's refresh errored (`workspace access not found for accessID: ...`) and blocked the whole plan. The `customer-managed-next` TFC workspace hit this for ~26 consecutive runs, recoverable only via a manual `terraform state rm`.

The `Read` path already removes a resource from state on a 404, but the TEAM accessor never produced a recognizable one: its filter endpoint returns `200 OK` with a list, so a missing grant surfaced as a synthetic non-404 error and `Is404Error` returned false.

This adds a `helpers.ErrNotFound` sentinel, wraps the two synthetic not-found client errors with it, and teaches `Is404Error` to match it via `errors.Is`. The USER/SERVICE_ACCOUNT paths already self-heal via a real HTTP 404, so they're unchanged. The sibling `team_access` client had the same latent gap and gets the same treatment.

Related to PLA-2779

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes related issue
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

<details>
<summary>Notes on testing</summary>

Two layers:

- A table-driven unit test on `Is404Error` (`internal/provider/helpers/errors_test.go`) that runs under `mise run test` with no live infra.
- An acceptance step in `TestAccResource_team_workspace_access` that deletes the team grant out-of-band via a scoped client, then asserts `ExpectNonEmptyPlan` (Terraform plans a corrective re-create instead of erroring). This exercises the `RemoveResource` branch end-to-end for the TEAM path. It mirrors the out-of-band `PreConfig` pattern added for the block drift fix (PLA-2676).

I can't run the acceptance test locally (needs live Prefect Cloud + `TF_ACC`), so CI verifies it.

</details>