### PR TITLE
fix(resources): clear deployment concurrency_limit on removal

### DIFF
--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -67,12 +67,18 @@ type DeploymentCreate struct {
 
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
 type DeploymentUpdate struct {
-	ConcurrencyLimit         *int64              `json:"concurrency_limit,omitempty"`
-	ConcurrencyOptions       *ConcurrencyOptions `json:"concurrency_options,omitempty"`
+	// The concurrency fields intentionally omit `omitempty`. The Prefect API
+	// distinguishes "field absent" (no change) from "field is null" (clear the
+	// limit). With `omitempty`, a nil pointer would be dropped from the PATCH
+	// body, so the server would never clear an existing concurrency limit when
+	// the user removes it from config. Emitting an explicit null instructs the
+	// server to clear it. See https://github.com/PrefectHQ/terraform-provider-prefect/issues/681.
+	ConcurrencyLimit         *int64              `json:"concurrency_limit"`
+	ConcurrencyOptions       *ConcurrencyOptions `json:"concurrency_options"`
 	Description              *string             `json:"description,omitempty"`
 	EnforceParameterSchema   *bool               `json:"enforce_parameter_schema,omitempty"`
 	Entrypoint               *string             `json:"entrypoint,omitempty"`
-	GlobalConcurrencyLimitID *uuid.UUID          `json:"global_concurrency_limit_id,omitempty"`
+	GlobalConcurrencyLimitID *uuid.UUID          `json:"global_concurrency_limit_id"`
 	JobVariables             map[string]any      `json:"job_variables,omitempty"`
 	ParameterOpenAPISchema   map[string]any      `json:"parameter_openapi_schema,omitempty"`
 	Parameters               map[string]any      `json:"parameters,omitempty"`

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -72,7 +72,7 @@ type DeploymentUpdate struct {
 	// limit). With `omitempty`, a nil pointer would be dropped from the PATCH
 	// body, so the server would never clear an existing concurrency limit when
 	// the user removes it from config. Emitting an explicit null instructs the
-	// server to clear it. See https://github.com/PrefectHQ/terraform-provider-prefect/issues/681.
+	// server to clear it.
 	ConcurrencyLimit         *int64              `json:"concurrency_limit"`
 	ConcurrencyOptions       *ConcurrencyOptions `json:"concurrency_options"`
 	Description              *string             `json:"description,omitempty"`

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/google/uuid"
 )
@@ -67,29 +68,35 @@ type DeploymentCreate struct {
 
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
 type DeploymentUpdate struct {
-	// The concurrency fields intentionally omit `omitempty`. The Prefect API
-	// distinguishes "field absent" (no change) from "field is null" (clear the
-	// limit). With `omitempty`, a nil pointer would be dropped from the PATCH
-	// body, so the server would never clear an existing concurrency limit when
-	// the user removes it from config. Emitting an explicit null instructs the
-	// server to clear it.
-	ConcurrencyLimit         *int64              `json:"concurrency_limit"`
-	ConcurrencyOptions       *ConcurrencyOptions `json:"concurrency_options"`
-	Description              *string             `json:"description,omitempty"`
-	EnforceParameterSchema   *bool               `json:"enforce_parameter_schema,omitempty"`
-	Entrypoint               *string             `json:"entrypoint,omitempty"`
-	GlobalConcurrencyLimitID *uuid.UUID          `json:"global_concurrency_limit_id"`
-	JobVariables             map[string]any      `json:"job_variables,omitempty"`
-	ParameterOpenAPISchema   map[string]any      `json:"parameter_openapi_schema,omitempty"`
-	Parameters               map[string]any      `json:"parameters,omitempty"`
-	Path                     *string             `json:"path,omitempty"`
-	Paused                   *bool               `json:"paused,omitempty"`
-	PullSteps                []PullStep          `json:"pull_steps,omitempty"`
-	StorageDocumentID        *uuid.UUID          `json:"storage_document_id,omitempty"`
-	Tags                     []string            `json:"tags,omitempty"`
-	Version                  *string             `json:"version,omitempty"`
-	WorkPoolName             *string             `json:"work_pool_name,omitempty"`
-	WorkQueueName            *string             `json:"work_queue_name,omitempty"`
+	// The Prefect API distinguishes "field absent" (no change) from "field is
+	// null" (clear). concurrency_limit and global_concurrency_limit_id route
+	// through the same underlying limit, so sending an explicit null for either
+	// clears it, and sending concurrency_limit alongside an explicit
+	// global_concurrency_limit_id:null can trip a 409. concurrency_options is
+	// not cleared automatically when the limit is, so removing it also needs an
+	// explicit null.
+	//
+	// Because the standard `omitempty` tag cannot emit an explicit null, these
+	// fields are encoded as json.RawMessage and populated only when they should
+	// change. See the concurrency*UpdateValue helpers in the deployment
+	// resource's Update.
+	ConcurrencyLimit         json.RawMessage `json:"concurrency_limit,omitempty"`
+	ConcurrencyOptions       json.RawMessage `json:"concurrency_options,omitempty"`
+	Description              *string         `json:"description,omitempty"`
+	EnforceParameterSchema   *bool           `json:"enforce_parameter_schema,omitempty"`
+	Entrypoint               *string         `json:"entrypoint,omitempty"`
+	GlobalConcurrencyLimitID json.RawMessage `json:"global_concurrency_limit_id,omitempty"`
+	JobVariables             map[string]any  `json:"job_variables,omitempty"`
+	ParameterOpenAPISchema   map[string]any  `json:"parameter_openapi_schema,omitempty"`
+	Parameters               map[string]any  `json:"parameters,omitempty"`
+	Path                     *string         `json:"path,omitempty"`
+	Paused                   *bool           `json:"paused,omitempty"`
+	PullSteps                []PullStep      `json:"pull_steps,omitempty"`
+	StorageDocumentID        *uuid.UUID      `json:"storage_document_id,omitempty"`
+	Tags                     []string        `json:"tags,omitempty"`
+	Version                  *string         `json:"version,omitempty"`
+	WorkPoolName             *string         `json:"work_pool_name,omitempty"`
+	WorkQueueName            *string         `json:"work_queue_name,omitempty"`
 }
 
 // ConcurrencyOptions is a representation of the deployment concurrency options.

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -745,6 +745,10 @@ func CopyDeploymentToModel(ctx context.Context, deployment *api.Deployment, mode
 		model.ConcurrencyOptions = &ConcurrencyOptions{
 			CollisionStrategy: types.StringValue(deployment.ConcurrencyOptions.CollisionStrategy),
 		}
+	} else {
+		// Reset to nil when the API returns no concurrency options, otherwise
+		// removing concurrency_options from config would leave stale state.
+		model.ConcurrencyOptions = nil
 	}
 
 	pullSteps, diags := mapPullStepsAPIToTerraform(deployment.PullSteps)

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -975,11 +975,77 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 }
 
+// concurrencyUpdateValue computes the concurrency_limit value to send in a
+// deployment update. The Prefect API distinguishes an absent field (no change)
+// from an explicit null (clear the limit), so we only include the field when it
+// is being set or cleared:
+//
+//   - plan has a value          -> send that value
+//   - plan null, prior had value -> send null (clear)
+//   - plan null, prior null      -> omit (return nil RawMessage)
+//
+// Returning a nil json.RawMessage leaves the omitempty field out of the payload.
+func concurrencyUpdateValue(plan, prior types.Int64) json.RawMessage {
+	switch {
+	case !plan.IsNull():
+		return json.RawMessage(fmt.Sprintf("%d", plan.ValueInt64()))
+	case !prior.IsNull():
+		return json.RawMessage("null")
+	default:
+		return nil
+	}
+}
+
+// globalConcurrencyLimitUpdateValue mirrors concurrencyUpdateValue for the
+// global_concurrency_limit_id field. The same underlying limit backs both
+// fields server-side, so we send each only when it actually changes to avoid
+// clobbering the other or tripping a data-integrity conflict.
+//
+// This attribute is Computed, so when it is absent from config its planned
+// value is unknown (not null). An unknown value means "leave it alone", so we
+// omit the field in that case rather than sending the zero UUID.
+func globalConcurrencyLimitUpdateValue(plan, prior customtypes.UUIDValue) json.RawMessage {
+	switch {
+	case plan.IsUnknown():
+		return nil
+	case !plan.IsNull():
+		return json.RawMessage(fmt.Sprintf("%q", plan.ValueUUID().String()))
+	case !prior.IsNull() && !prior.IsUnknown():
+		return json.RawMessage("null")
+	default:
+		return nil
+	}
+}
+
+// concurrencyOptionsUpdateValue mirrors concurrencyUpdateValue for the
+// concurrency_options field. The server does not clear concurrency_options when
+// the limit is cleared, so removing it from config requires an explicit null.
+func concurrencyOptionsUpdateValue(plan, prior *ConcurrencyOptions) json.RawMessage {
+	switch {
+	case plan != nil:
+		return json.RawMessage(fmt.Sprintf(`{"collision_strategy":%q}`, plan.CollisionStrategy.ValueString()))
+	case prior != nil:
+		return json.RawMessage("null")
+	default:
+		return nil
+	}
+}
+
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var model DeploymentResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// We need the prior state to know whether a concurrency limit is being
+	// cleared. The Prefect API only clears a limit when it receives an explicit
+	// null, and routes both concurrency_limit and global_concurrency_limit_id
+	// through the same underlying limit, so we send each only when it changes.
+	var priorState DeploymentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -1036,11 +1102,11 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	payload := api.DeploymentUpdate{
-		ConcurrencyLimit:         model.ConcurrencyLimit.ValueInt64Pointer(),
+		ConcurrencyLimit:         concurrencyUpdateValue(model.ConcurrencyLimit, priorState.ConcurrencyLimit),
 		Description:              model.Description.ValueStringPointer(),
 		EnforceParameterSchema:   model.EnforceParameterSchema.ValueBoolPointer(),
 		Entrypoint:               model.Entrypoint.ValueStringPointer(),
-		GlobalConcurrencyLimitID: model.GlobalConcurrencyLimitID.ValueUUIDPointer(),
+		GlobalConcurrencyLimitID: globalConcurrencyLimitUpdateValue(model.GlobalConcurrencyLimitID, priorState.GlobalConcurrencyLimitID),
 		JobVariables:             jobVariables,
 		ParameterOpenAPISchema:   parameterOpenAPISchema,
 		Parameters:               parameters,
@@ -1054,11 +1120,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		WorkQueueName:            model.WorkQueueName.ValueStringPointer(),
 	}
 
-	if model.ConcurrencyOptions != nil {
-		payload.ConcurrencyOptions = &api.ConcurrencyOptions{
-			CollisionStrategy: model.ConcurrencyOptions.CollisionStrategy.ValueString(),
-		}
-	}
+	payload.ConcurrencyOptions = concurrencyOptionsUpdateValue(model.ConcurrencyOptions, priorState.ConcurrencyOptions)
 
 	// Capture the planned parameter_openapi_schema before the API call
 	// overwrites it (same reason as in Create).

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -719,6 +719,115 @@ resource "prefect_deployment" "%[4]s" {
 	})
 }
 
+// TestAccResource_deployment_remove_concurrency_limit tests that a
+// concurrency_limit (and concurrency_options) added to a deployment can later
+// be removed from configuration. Previously, removing them produced a
+// "Provider produced inconsistent result after apply (.concurrency_limit)"
+// error and left the limit in place server-side, because the update payload
+// omitted the field instead of sending an explicit null.
+// See: https://github.com/PrefectHQ/terraform-provider-prefect/issues/681
+//
+//nolint:paralleltest // we use the resource.ParallelTest helper instead
+func TestAccResource_deployment_remove_concurrency_limit(t *testing.T) {
+	workspace := testutils.NewEphemeralWorkspace()
+	deploymentName := testutils.NewRandomPrefixedString()
+	flowName := testutils.NewRandomPrefixedString()
+	deploymentResourceName := fmt.Sprintf("prefect_deployment.%s", deploymentName)
+
+	// Config with a concurrency_limit and concurrency_options set.
+	configWithConcurrency := fmt.Sprintf(`
+%[1]s
+
+resource "prefect_flow" "%[2]s" {
+  name = "%[2]s"
+  %[3]s
+}
+
+resource "prefect_deployment" "%[4]s" {
+  name              = "%[4]s"
+  flow_id           = prefect_flow.%[2]s.id
+  entrypoint        = "hello_world.py:hello_world"
+  concurrency_limit = 1
+  concurrency_options = {
+    collision_strategy = "ENQUEUE"
+  }
+  %[3]s
+}
+`, workspace.Resource, flowName, workspace.IDArg, deploymentName)
+
+	// Same deployment, with concurrency_limit and concurrency_options removed.
+	configWithoutConcurrency := fmt.Sprintf(`
+%[1]s
+
+resource "prefect_flow" "%[2]s" {
+  name = "%[2]s"
+  %[3]s
+}
+
+resource "prefect_deployment" "%[4]s" {
+  name       = "%[4]s"
+  flow_id    = prefect_flow.%[2]s.id
+  entrypoint = "hello_world.py:hello_world"
+  %[3]s
+}
+`, workspace.Resource, flowName, workspace.IDArg, deploymentName)
+
+	var deployment api.Deployment
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { testutils.AccTestPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				// Create with a concurrency limit.
+				Config: configWithConcurrency,
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValueNumber(deploymentResourceName, "concurrency_limit", 1),
+					testutils.ExpectKnownValueMap(deploymentResourceName, "concurrency_options", map[string]string{
+						"collision_strategy": "ENQUEUE",
+					}),
+				},
+			},
+			{
+				// Remove the concurrency limit and options. This previously
+				// failed with an inconsistent-result error.
+				Config: configWithoutConcurrency,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDeploymentExists(deploymentResourceName, &deployment),
+					testAccCheckDeploymentConcurrencyLimitCleared(&deployment),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValueNull(deploymentResourceName, "concurrency_limit"),
+					testutils.ExpectKnownValueNull(deploymentResourceName, "concurrency_options"),
+				},
+			},
+			{
+				// Re-apply the same config to confirm there is no perpetual diff.
+				Config: configWithoutConcurrency,
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValueNull(deploymentResourceName, "concurrency_limit"),
+					testutils.ExpectKnownValueNull(deploymentResourceName, "concurrency_options"),
+				},
+			},
+		},
+	})
+}
+
+// testAccCheckDeploymentConcurrencyLimitCleared verifies that the deployment no
+// longer has a concurrency limit set server-side.
+func testAccCheckDeploymentConcurrencyLimitCleared(deployment *api.Deployment) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		if deployment.GlobalConcurrencyLimit != nil {
+			return fmt.Errorf(
+				"expected deployment concurrency limit to be cleared, got limit %d",
+				deployment.GlobalConcurrencyLimit.Limit,
+			)
+		}
+
+		return nil
+	}
+}
+
 // testAccCheckDeploymentExists is a Custom Check Function that
 // verifies that the API object was created correctly.
 func testAccCheckDeploymentExists(deploymentResourceName string, deployment *api.Deployment) resource.TestCheckFunc {

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -725,7 +725,6 @@ resource "prefect_deployment" "%[4]s" {
 // "Provider produced inconsistent result after apply (.concurrency_limit)"
 // error and left the limit in place server-side, because the update payload
 // omitted the field instead of sending an explicit null.
-// See: https://github.com/PrefectHQ/terraform-provider-prefect/issues/681
 //
 //nolint:paralleltest // we use the resource.ParallelTest helper instead
 func TestAccResource_deployment_remove_concurrency_limit(t *testing.T) {


### PR DESCRIPTION
### Summary

Removing `concurrency_limit` (and `concurrency_options`) from a `prefect_deployment` failed with `Provider produced inconsistent result after apply (.concurrency_limit)` and left the limit set in Prefect.

The Prefect API distinguishes an absent field (no change) from an explicit `null` (clear), and routes `concurrency_limit` and `global_concurrency_limit_id` through the same underlying limit. The update payload couldn't express "explicit null" (it used `omitempty` pointers), so removing a limit never told the server to clear it.

This switches the three concurrency fields on `DeploymentUpdate` to `json.RawMessage` and builds each from a prior-state-vs-plan diff: send a value when set, an explicit `null` only when clearing, and omit otherwise (including when the Computed `global_concurrency_limit_id` plans as unknown). That matches the server's `exclude_unset` contract.

Closes #681

### Notes

- A first attempt that unconditionally emitted explicit nulls broke two existing acceptance tests in CI; that feedback is what revealed the shared-limit / Computed-unknown behaviors above. Reproduced and verified the final approach against a local Prefect OSS server.
- Removing `global_concurrency_limit_id` (global limit → none) is a related but distinct gap with its own root cause (the attribute is `Computed`, so removal plans as unknown). Tracked separately in #683 to keep this PR scoped.

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are added/updated
- [x] Acceptance tests are added/updated (including import tests, when needed)

<details>
<summary>Session context</summary>

Started from #681 with the question of whether this was an upstream API change. Traced the Prefect server's `update_deployment` (`model_dump(exclude_unset=True)` plus an `"unset"` sentinel) and confirmed the provider was at fault: `omitempty` couldn't emit an explicit null, so a removed limit was never cleared.

The first push dropped `omitempty` to always send explicit nulls. CI's OSS acceptance job then failed two existing tests, which exposed the real semantics: `concurrency_limit` and `global_concurrency_limit_id` back the same server-side limit (explicit null on either clears it; sending both trips a 409/422), `global_concurrency_limit_id` is Computed so it plans as unknown rather than null, and `concurrency_options` isn't cleared automatically when the limit is. Reworked to a prior-state-vs-plan diff per field via `json.RawMessage`.

Verified against a local Prefect OSS server (3.6.29): the two previously-failing tests, the new `TestAccResource_deployment_remove_concurrency_limit`, and the rest of the deployment acceptance suite all pass; `lint` and unit tests are clean.
</details>