### PR TITLE
chore(codeowners): replace platform team with cloud_platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PrefectHQ/platform
+* @PrefectHQ/cloud_platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @PrefectHQ/cloud_platform
+* @PrefectHQ/cloud-platform


### PR DESCRIPTION
### Summary

Replace the broad `@PrefectHQ/platform` CODEOWNERS reference with its product-scoped successor `@PrefectHQ/cloud_platform`, created in PrefectHQ/platform#11333.

This is part of retiring the old `platform`/`backend`/`frontend` teams so they can be deleted once nothing references them. 1:1 mapping, no other ownership routing changed.

Related to https://linear.app/prefect/issue/ENGPAR-72/revisit-github-engineering-teams