### PR TITLE
ci: migrate mise task arguments

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -54,18 +54,25 @@ run = "golangci-lint run"
 [tasks.test]
 alias = "t"
 description = "Run automated unit tests ({{vars.helper_tests_arg}})"
-run = 'gotestsum --max-fails=50 ./... -run {{arg(name="tests", default="")}}'
+usage = 'arg "[tests]" default=""'
+run = 'gotestsum --max-fails=50 ./... -run "${usage_tests?}"'
 run_windows = 'gotestsum --max-fails=50 ./...'
 
 [tasks.testacc]
 alias = "ta"
 description = "Run acceptance tests against real infrastructure ({{vars.helper_tests_arg}})"
-run = 'TF_ACC=1 mise run test {{arg(name="tests", default="")}}'
+usage = 'arg "[tests]" default=""'
+run = 'TF_ACC=1 mise run test "${usage_tests?}"'
 
 [tasks.testacc-dev]
 alias = "tad"
 description = "Run automated acceptance tests from a local machine ({{vars.helper_tests_arg}})"
-run = 'scripts/testacc-dev {{arg(name="tests", default="")}} {{arg(name="log_level", default="")}} {{arg(name="sweep",default="")}}'
+usage = '''
+arg "[tests]" default=""
+arg "[log_level]" default=""
+arg "[sweep]" default=""
+'''
+run = 'scripts/testacc-dev "${usage_tests?}" "${usage_log_level?}" "${usage_sweep?}"'
 
 [tasks.testacc-dev-user]
 alias = "tadu"
@@ -75,14 +82,20 @@ file = 'scripts/testacc-dev-user'
 [tasks.testacc-cm]
 alias = "tac"
 description = "Run automated acceptance tests against a Customer-Managed instance from a local machine ({{vars.helper_tests_arg}})"
-run = 'scripts/testacc-cm {{arg(name="tests", default="")}} {{arg(name="log_level", default="")}} {{arg(name="sweep",default="")}}'
+usage = '''
+arg "[tests]" default=""
+arg "[log_level]" default=""
+arg "[sweep]" default=""
+'''
+run = 'scripts/testacc-cm "${usage_tests?}" "${usage_log_level?}" "${usage_sweep?}"'
 
 [tasks.testacc-oss]
 alias = "tao"
 description = "Run automated acceptance tests for Prefect OSS"
+usage = 'arg "[tests]" default=""'
 run = [
   "docker compose up -d",
-  './scripts/testacc-oss {{arg(name="tests", default="")}}',
+  './scripts/testacc-oss "${usage_tests?}"',
   "docker compose down"
 ]
 
@@ -103,7 +116,11 @@ run = [
 [tasks.dev-new]
 alias = "dn"
 description = "Creates a new dev testfile"
-run = 'sh create-dev-testfile.sh {{arg(name="resource")}} {{arg(name="resourcename",default="")}}'
+usage = '''
+arg "<resource>"
+arg "[resourcename]" default=""
+'''
+run = 'sh create-dev-testfile.sh "${usage_resource?}" "${usage_resourcename?}"'
 
 [settings]
 # Enable experimental mode to support installing

--- a/.mise.toml
+++ b/.mise.toml
@@ -54,25 +54,25 @@ run = "golangci-lint run"
 [tasks.test]
 alias = "t"
 description = "Run automated unit tests ({{vars.helper_tests_arg}})"
-usage = 'arg "[tests]" default=""'
-run = 'gotestsum --max-fails=50 ./... -run "${usage_tests?}"'
+usage = 'arg "[tests]" default="" env="TESTS"'
+run = 'tests="${usage_tests?}"; gotestsum --max-fails=50 ./... -run "${tests#TESTS=}"'
 run_windows = 'gotestsum --max-fails=50 ./...'
 
 [tasks.testacc]
 alias = "ta"
 description = "Run acceptance tests against real infrastructure ({{vars.helper_tests_arg}})"
-usage = 'arg "[tests]" default=""'
-run = 'TF_ACC=1 mise run test "${usage_tests?}"'
+usage = 'arg "[tests]" default="" env="TESTS"'
+run = 'tests="${usage_tests?}"; TF_ACC=1 mise run test "${tests#TESTS=}"'
 
 [tasks.testacc-dev]
 alias = "tad"
 description = "Run automated acceptance tests from a local machine ({{vars.helper_tests_arg}})"
 usage = '''
-arg "[tests]" default=""
-arg "[log_level]" default=""
-arg "[sweep]" default=""
+arg "[tests]" default="" env="TESTS"
+arg "[log_level]" default="" env="LOG_LEVEL"
+arg "[sweep]" default="" env="SWEEP"
 '''
-run = 'scripts/testacc-dev "${usage_tests?}" "${usage_log_level?}" "${usage_sweep?}"'
+run = 'tests="${usage_tests?}"; log_level="${usage_log_level?}"; sweep="${usage_sweep?}"; scripts/testacc-dev "${tests#TESTS=}" "${log_level#LOG_LEVEL=}" "${sweep#SWEEP=}"'
 
 [tasks.testacc-dev-user]
 alias = "tadu"
@@ -83,19 +83,19 @@ file = 'scripts/testacc-dev-user'
 alias = "tac"
 description = "Run automated acceptance tests against a Customer-Managed instance from a local machine ({{vars.helper_tests_arg}})"
 usage = '''
-arg "[tests]" default=""
-arg "[log_level]" default=""
-arg "[sweep]" default=""
+arg "[tests]" default="" env="TESTS"
+arg "[log_level]" default="" env="LOG_LEVEL"
+arg "[sweep]" default="" env="SWEEP"
 '''
-run = 'scripts/testacc-cm "${usage_tests?}" "${usage_log_level?}" "${usage_sweep?}"'
+run = 'tests="${usage_tests?}"; log_level="${usage_log_level?}"; sweep="${usage_sweep?}"; scripts/testacc-cm "${tests#TESTS=}" "${log_level#LOG_LEVEL=}" "${sweep#SWEEP=}"'
 
 [tasks.testacc-oss]
 alias = "tao"
 description = "Run automated acceptance tests for Prefect OSS"
-usage = 'arg "[tests]" default=""'
+usage = 'arg "[tests]" default="" env="TESTS"'
 run = [
   "docker compose up -d",
-  './scripts/testacc-oss "${usage_tests?}"',
+  'tests="${usage_tests?}"; ./scripts/testacc-oss "${tests#TESTS=}"',
   "docker compose down"
 ]
 

--- a/scripts/testacc-cm
+++ b/scripts/testacc-cm
@@ -7,8 +7,9 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name as the first argument:
+# To run specific tests, add the test name or glob-style pattern as the first argument:
 #   ./scripts/testacc-cm TestAccResource_deployment
+#   ./scripts/testacc-cm 'TestAccResource_block*'
 #
 # To adjust the log level, specify it as the second argument:
 #   ./scripts/testacc-cm TestAccResource_deployment DEBUG
@@ -22,6 +23,16 @@ tests=${1:-""}
 log_level=${2:-"INFO"}
 sweep=${3:-""}
 
+normalize_test_filter() {
+  local filter="${1}"
+
+  if [[ "${filter}" == *"*"* && "${filter}" != *".*"* ]]; then
+    filter="${filter//\*/.*}"
+  fi
+
+  printf '%s' "${filter}"
+}
+
 run_arg=""
 if [ "${sweep}" != "" ]; then
   # If sweep is set to anything, only run the sweepers and skip the acceptance tests.
@@ -33,7 +44,8 @@ if [ "${sweep}" != "" ]; then
   run_arg="go test ./internal/sweep -v -sweep=all"
 elif [ "${tests}" != "" ]; then
   echo "specific test(s) configured: ${tests}"
-  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests}$"
+  tests_filter=$(normalize_test_filter "${tests}")
+  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests_filter}$"
 else
   echo "no specific test configured, running all"
   run_arg="gotestsum --max-fails=50 ./... -count=1 -v"

--- a/scripts/testacc-cm
+++ b/scripts/testacc-cm
@@ -7,7 +7,7 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name or regex as the first argument:
+# To run specific tests, add the test name as the first argument:
 #   ./scripts/testacc-cm TestAccResource_deployment
 #
 # To adjust the log level, specify it as the second argument:
@@ -33,7 +33,7 @@ if [ "${sweep}" != "" ]; then
   run_arg="go test ./internal/sweep -v -sweep=all"
 elif [ "${tests}" != "" ]; then
   echo "specific test(s) configured: ${tests}"
-  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ${tests}"
+  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests}$"
 else
   echo "no specific test configured, running all"
   run_arg="gotestsum --max-fails=50 ./... -count=1 -v"

--- a/scripts/testacc-cm
+++ b/scripts/testacc-cm
@@ -7,9 +7,8 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name or glob-style pattern as the first argument:
+# To run specific tests, add the test name as the first argument:
 #   ./scripts/testacc-cm TestAccResource_deployment
-#   ./scripts/testacc-cm 'TestAccResource_block*'
 #
 # To adjust the log level, specify it as the second argument:
 #   ./scripts/testacc-cm TestAccResource_deployment DEBUG
@@ -23,16 +22,6 @@ tests=${1:-""}
 log_level=${2:-"INFO"}
 sweep=${3:-""}
 
-normalize_test_filter() {
-  local filter="${1}"
-
-  if [[ "${filter}" == *"*"* && "${filter}" != *".*"* ]]; then
-    filter="${filter//\*/.*}"
-  fi
-
-  printf '%s' "${filter}"
-}
-
 run_arg=""
 if [ "${sweep}" != "" ]; then
   # If sweep is set to anything, only run the sweepers and skip the acceptance tests.
@@ -44,8 +33,7 @@ if [ "${sweep}" != "" ]; then
   run_arg="go test ./internal/sweep -v -sweep=all"
 elif [ "${tests}" != "" ]; then
   echo "specific test(s) configured: ${tests}"
-  tests_filter=$(normalize_test_filter "${tests}")
-  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests_filter}$"
+  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests}$"
 else
   echo "no specific test configured, running all"
   run_arg="gotestsum --max-fails=50 ./... -count=1 -v"

--- a/scripts/testacc-cm
+++ b/scripts/testacc-cm
@@ -7,7 +7,7 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name as the first argument:
+# To run specific tests, add the test name or regex as the first argument:
 #   ./scripts/testacc-cm TestAccResource_deployment
 #
 # To adjust the log level, specify it as the second argument:
@@ -33,7 +33,7 @@ if [ "${sweep}" != "" ]; then
   run_arg="go test ./internal/sweep -v -sweep=all"
 elif [ "${tests}" != "" ]; then
   echo "specific test(s) configured: ${tests}"
-  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests}$"
+  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ${tests}"
 else
   echo "no specific test configured, running all"
   run_arg="gotestsum --max-fails=50 ./... -count=1 -v"

--- a/scripts/testacc-cm
+++ b/scripts/testacc-cm
@@ -7,8 +7,9 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name as the first argument:
+# To run specific tests, add the test name or Go test regex as the first argument:
 #   ./scripts/testacc-cm TestAccResource_deployment
+#   ./scripts/testacc-cm 'TestAccResource_block.*'
 #
 # To adjust the log level, specify it as the second argument:
 #   ./scripts/testacc-cm TestAccResource_deployment DEBUG

--- a/scripts/testacc-dev
+++ b/scripts/testacc-dev
@@ -6,8 +6,9 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name as the first argument:
+# To run specific tests, add the test name or Go test regex as the first argument:
 #   ./scripts/testacc-dev TestAccResource_deployment
+#   ./scripts/testacc-dev 'TestAccResource_block.*'
 #
 # To adjust the log level, specify it as the second argument:
 #   ./scripts/testacc-dev TestAccResource_deployment DEBUG

--- a/scripts/testacc-dev
+++ b/scripts/testacc-dev
@@ -6,8 +6,9 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name as the first argument:
+# To run specific tests, add the test name or glob-style pattern as the first argument:
 #   ./scripts/testacc-dev TestAccResource_deployment
+#   ./scripts/testacc-dev 'TestAccResource_block*'
 #
 # To adjust the log level, specify it as the second argument:
 #   ./scripts/testacc-dev TestAccResource_deployment DEBUG
@@ -21,6 +22,16 @@ tests=${1:-""}
 log_level=${2:-"INFO"}
 sweep=${3:-""}
 
+normalize_test_filter() {
+  local filter="${1}"
+
+  if [[ "${filter}" == *"*"* && "${filter}" != *".*"* ]]; then
+    filter="${filter//\*/.*}"
+  fi
+
+  printf '%s' "${filter}"
+}
+
 run_arg=""
 if [ "${sweep}" != "" ]; then
   # If sweep is set to anything, only run the sweepers and skip the acceptance tests.
@@ -32,7 +43,8 @@ if [ "${sweep}" != "" ]; then
   run_arg="go test ./internal/sweep -v -sweep=all"
 elif [ "${tests}" != "" ]; then
   echo "specific test(s) configured: ${tests}"
-  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests}$"
+  tests_filter=$(normalize_test_filter "${tests}")
+  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests_filter}$"
 else
   echo "no specific test configured, running all"
   run_arg="gotestsum --max-fails=50 ./... -count=1 -v"

--- a/scripts/testacc-dev
+++ b/scripts/testacc-dev
@@ -6,7 +6,7 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name or regex as the first argument:
+# To run specific tests, add the test name as the first argument:
 #   ./scripts/testacc-dev TestAccResource_deployment
 #
 # To adjust the log level, specify it as the second argument:
@@ -32,7 +32,7 @@ if [ "${sweep}" != "" ]; then
   run_arg="go test ./internal/sweep -v -sweep=all"
 elif [ "${tests}" != "" ]; then
   echo "specific test(s) configured: ${tests}"
-  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ${tests}"
+  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests}$"
 else
   echo "no specific test configured, running all"
   run_arg="gotestsum --max-fails=50 ./... -count=1 -v"

--- a/scripts/testacc-dev
+++ b/scripts/testacc-dev
@@ -6,7 +6,7 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name as the first argument:
+# To run specific tests, add the test name or regex as the first argument:
 #   ./scripts/testacc-dev TestAccResource_deployment
 #
 # To adjust the log level, specify it as the second argument:
@@ -32,7 +32,7 @@ if [ "${sweep}" != "" ]; then
   run_arg="go test ./internal/sweep -v -sweep=all"
 elif [ "${tests}" != "" ]; then
   echo "specific test(s) configured: ${tests}"
-  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests}$"
+  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ${tests}"
 else
   echo "no specific test configured, running all"
   run_arg="gotestsum --max-fails=50 ./... -count=1 -v"

--- a/scripts/testacc-dev
+++ b/scripts/testacc-dev
@@ -6,9 +6,8 @@ set -e
 # It collects the required environment variables from 1Password
 # using its CLI: https://developer.1password.com/docs/cli/secrets-scripts
 #
-# To run specific tests, add the test name or glob-style pattern as the first argument:
+# To run specific tests, add the test name as the first argument:
 #   ./scripts/testacc-dev TestAccResource_deployment
-#   ./scripts/testacc-dev 'TestAccResource_block*'
 #
 # To adjust the log level, specify it as the second argument:
 #   ./scripts/testacc-dev TestAccResource_deployment DEBUG
@@ -22,16 +21,6 @@ tests=${1:-""}
 log_level=${2:-"INFO"}
 sweep=${3:-""}
 
-normalize_test_filter() {
-  local filter="${1}"
-
-  if [[ "${filter}" == *"*"* && "${filter}" != *".*"* ]]; then
-    filter="${filter//\*/.*}"
-  fi
-
-  printf '%s' "${filter}"
-}
-
 run_arg=""
 if [ "${sweep}" != "" ]; then
   # If sweep is set to anything, only run the sweepers and skip the acceptance tests.
@@ -43,8 +32,7 @@ if [ "${sweep}" != "" ]; then
   run_arg="go test ./internal/sweep -v -sweep=all"
 elif [ "${tests}" != "" ]; then
   echo "specific test(s) configured: ${tests}"
-  tests_filter=$(normalize_test_filter "${tests}")
-  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests_filter}$"
+  run_arg="gotestsum --max-fails=50 ./... -count=1 -v -run ^${tests}$"
 else
   echo "no specific test configured, running all"
   run_arg="gotestsum --max-fails=50 ./... -count=1 -v"

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -6,7 +6,7 @@ set -e
 # Start Prefect OSS by running:
 #   docker compose up -d
 #
-# Then, run the OSS tests by name or regex:
+# Then, run the OSS tests:
 #   ./scripts/testacc-oss [tests]
 
 tests=${1:-""}
@@ -23,5 +23,5 @@ if [ "${tests}" == "" ]; then
   run
 else
   echo "Running specified tests: ${tests}"
-  run "${tests}"
+  run "^${tests}$"
 fi

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -6,7 +6,7 @@ set -e
 # Start Prefect OSS by running:
 #   docker compose up -d
 #
-# Then, run the OSS tests:
+# Then, run the OSS tests by name or regex:
 #   ./scripts/testacc-oss [tests]
 
 tests=${1:-""}
@@ -23,5 +23,5 @@ if [ "${tests}" == "" ]; then
   run
 else
   echo "Running specified tests: ${tests}"
-  run "^${tests}$"
+  run "${tests}"
 fi

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -6,10 +6,20 @@ set -e
 # Start Prefect OSS by running:
 #   docker compose up -d
 #
-# Then, run the OSS tests:
+# Then, run the OSS tests by name or glob-style pattern:
 #   ./scripts/testacc-oss [tests]
 
 tests=${1:-""}
+
+function normalize_test_filter() {
+  local filter="${1}"
+
+  if [[ "${filter}" == *"*"* && "${filter}" != *".*"* ]]; then
+    filter="${filter//\*/.*}"
+  fi
+
+  printf '%s' "${filter}"
+}
 
 function run() {
   TF_ACC=1 \
@@ -23,5 +33,6 @@ if [ "${tests}" == "" ]; then
   run
 else
   echo "Running specified tests: ${tests}"
-  run "^${tests}$"
+  tests_filter=$(normalize_test_filter "${tests}")
+  run "^${tests_filter}$"
 fi

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -6,20 +6,10 @@ set -e
 # Start Prefect OSS by running:
 #   docker compose up -d
 #
-# Then, run the OSS tests by name or glob-style pattern:
+# Then, run the OSS tests:
 #   ./scripts/testacc-oss [tests]
 
 tests=${1:-""}
-
-function normalize_test_filter() {
-  local filter="${1}"
-
-  if [[ "${filter}" == *"*"* && "${filter}" != *".*"* ]]; then
-    filter="${filter//\*/.*}"
-  fi
-
-  printf '%s' "${filter}"
-}
 
 function run() {
   TF_ACC=1 \
@@ -33,6 +23,5 @@ if [ "${tests}" == "" ]; then
   run
 else
   echo "Running specified tests: ${tests}"
-  tests_filter=$(normalize_test_filter "${tests}")
-  run "^${tests_filter}$"
+  run "^${tests}$"
 fi

--- a/scripts/testacc-oss
+++ b/scripts/testacc-oss
@@ -6,8 +6,9 @@ set -e
 # Start Prefect OSS by running:
 #   docker compose up -d
 #
-# Then, run the OSS tests:
+# Then, run the OSS tests by name or Go test regex:
 #   ./scripts/testacc-oss [tests]
+#   ./scripts/testacc-oss 'TestAccResource_block.*'
 
 tests=${1:-""}
 


### PR DESCRIPTION
### Summary

GitHub Actions started warning that the `testacc` task still used deprecated mise Tera argument helpers.

Moved the affected task arguments to `usage` specs so mise can parse them without the removal warning. Kept the local acceptance helpers compatible with existing `TESTS=...` usage while preserving their exact-match test filtering behavior.

Related log: https://github.com/PrefectHQ/terraform-provider-prefect/actions/runs/28198390039/job/83531186860

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

Test confirmation:

```
$ mise run testacc-dev TESTS='TestAccResource_block.*'
[testacc-dev] $ tests="${usage_tests?}"; log_level="${usage_log_level?}"; sweep="${usage_sweep?…
specific test(s) configured: TestAccResource_block.*
∅  .
∅  internal/provider/customtypes
∅  internal/testutils
∅  internal/utils
∅  scripts
∅  internal/api (440ms)
∅  internal/client (646ms)
∅  internal/provider (860ms)
∅  internal/provider/helpers (856ms)
∅  internal/provider/datasources (879ms)
∅  internal/sweep (1.325s)
✓  internal/provider/resources (50.373s)

DONE 4 tests in 51.120s
```

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`

<details>
<summary>Session context</summary>

This started from a mise deprecation warning in a GitHub Actions job. I checked the mise task argument reference, then migrated the `.mise.toml` tasks from deprecated `arg()` templates to `usage` definitions with `usage_*` variables.

A follow-up check showed `mise run testacc-dev TESTS=...` needed compatibility handling. I kept the existing `^...$` wrapping in the helper scripts so broad matching remains explicit. To run a family of tests, pass Go regex syntax such as `TESTS='TestAccResource_block.*'`. The helper script comments now show that example too.

Validated with `mise tasks validate`, task info checks for the affected tasks, `mise run test`, `go test ./... -list '^TestAccResource_block.*$'`, and local `testacc-dev`/`testacc-cm` checks for the `TESTS=...` compatibility path.

</details>
