### PR TITLE
ci: remove privileged access from fork checks

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -10,7 +10,7 @@ name: Acceptance Tests
       - go.sum
       - "**/*.go"
       - .github/workflows/acceptance-tests.yaml
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -21,30 +21,21 @@ name: Acceptance Tests
 
 permissions: {}
 
-# Tests run the PR's code against live Prefect Cloud, so they need real keys.
-# Trust boundary is a same-repo branch (internal + Renovate), which only
-# push-access users can create; fork PRs are gated behind an environment.
 jobs:
-  # Trusted: push, or same-repo-branch PR. Runs automatically, no env gate.
-  acceptance_tests_internal:
+  acceptance_tests:
+    # Fork pull requests run the OSS acceptance workflow instead.
     if: |
-      github.event_name != 'pull_request_target' ||
+      github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
-    name: Acceptance Tests (internal)
-    environment: ${{ github.event_name == 'push' && 'Acceptance Tests (main)' || '' }}
+    name: Acceptance Tests
+    environment: Acceptance Tests (main)
     runs-on: ubuntu-latest
     steps:
-      - if: |
-          github.event_name == 'pull_request_target'
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-      - if: |
-          github.event_name != 'pull_request_target'
-        uses: actions/checkout@v7
 
       # This action installs go and caches downloaded modules, so we favor
       # this over using the `mise-action` to install Go.
@@ -82,50 +73,4 @@ jobs:
           PREFECT_CLOUD_ACCOUNT_ID: ${{ secrets.ACC_TEST_PREFECT_CLOUD_ACCOUNT_ID }}
           # This is the user ID retrieved by logging in as the Marvin user
           # and copying the ID on the "Profile" page.
-          ACC_TEST_USER_RESOURCE_ID: "48750018-b4c4-4484-8fbf-b61baf3926b5"
-
-  # Fork PR: gated by the `Acceptance Tests` environment (required reviewers)
-  # before keys release; opts into fork-head checkout explicitly.
-  acceptance_tests_fork:
-    if: |
-      github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository
-    permissions:
-      contents: read
-    name: Acceptance Tests (fork)
-    environment: Acceptance Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          # v7 blocks fork-head checkout; opt in (gated by the environment above).
-          allow-unsafe-pr-checkout: true
-          persist-credentials: false
-
-      - name: Set up Golang
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Install tool dependencies
-        uses: jdx/mise-action@v4
-        with:
-          install_args: gotestsum terraform
-
-      - name: Disable mise auto-install for task runs
-        run: mise settings set task_run_auto_install false
-
-      - name: Run acceptance tests
-        run: mise run testacc
-        env:
-          PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
-          PREFECT_API_KEY: ${{ secrets.ACC_TEST_PREFECT_API_KEY }}
-          PREFECT_CLOUD_ACCOUNT_ID: ${{ secrets.ACC_TEST_PREFECT_CLOUD_ACCOUNT_ID }}
-      - name: Run acceptance tests (user resource)
-        run: mise run testacc "TestAccResource_user*"
-        env:
-          PREFECT_API_URL: ${{ secrets.ACC_TEST_PREFECT_API_URL }}
-          PREFECT_API_KEY: ${{ secrets.ACC_TEST_PREFECT_MARVIN_API_KEY }}
-          PREFECT_CLOUD_ACCOUNT_ID: ${{ secrets.ACC_TEST_PREFECT_CLOUD_ACCOUNT_ID }}
           ACC_TEST_USER_RESOURCE_ID: "48750018-b4c4-4484-8fbf-b61baf3926b5"

--- a/.github/workflows/build-terraform-docs.yaml
+++ b/.github/workflows/build-terraform-docs.yaml
@@ -2,7 +2,7 @@
 name: Build Terraform Docs
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -14,23 +14,17 @@ on:
 
 permissions: {}
 
-# Generates docs from the PR's code and pushes them back, so it needs
-# `contents: write`. Trust boundary is a same-repo branch (internal +
-# Renovate); fork PRs are gated behind the `Docs` environment.
 jobs:
-  # Trusted: same-repo-branch PR. Runs automatically and pushes directly.
-  build_tf_docs_internal:
-    if: |
-      github.event.pull_request.head.repo.full_name == github.repository
-    name: Build Terraform Docs (internal)
+  build_tf_docs:
+    name: Build Terraform Docs
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Install tool dependencies
         uses: jdx/mise-action@v4
         with:
@@ -39,56 +33,10 @@ jobs:
         run: mise settings set task_run_auto_install false
       - name: Build Terraform Docs
         run: mise run docs
-      - name: Commit changes
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      - name: Check Terraform Docs
         run: |
-          git add .
-          if [[ $(git diff --staged) != '' ]]; then
-            git config --local user.email "github-actions[bot]@users.noreply.github.com"
-            git config --local user.name "github-actions[bot]"
-            git commit -m "Generate Terraform Docs"
-            git push --set-upstream origin ${{ env.HEAD_REF }}
-          else
-            echo "No changes to commit"
-          fi
-
-  # Fork PR: gated by the `Docs` environment (required reviewers); opts into
-  # fork-head checkout explicitly.
-  build_tf_docs_fork:
-    if: |
-      github.event.pull_request.head.repo.full_name != github.repository
-    name: Build Terraform Docs (fork)
-    environment: Docs
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          # v7 blocks fork-head checkout; opt in (gated by the environment above).
-          allow-unsafe-pr-checkout: true
-      - name: Install tool dependencies
-        uses: jdx/mise-action@v4
-        with:
-          install_args: terraform go:github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
-      - name: Disable mise auto-install for task runs
-        run: mise settings set task_run_auto_install false
-      - name: Build Terraform Docs
-        run: mise run docs
-      - name: Commit changes
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          git add .
-          if [[ $(git diff --staged) != '' ]]; then
-            git config --local user.email "github-actions[bot]@users.noreply.github.com"
-            git config --local user.name "github-actions[bot]"
-            git commit -m "Generate Terraform Docs"
-            git push --set-upstream origin ${{ env.HEAD_REF }}
-          else
-            echo "No changes to commit"
+          git add --intent-to-add .
+          if ! git diff --exit-code; then
+            echo "::error::Terraform docs are out of date. Run 'mise run docs' and commit the result."
+            exit 1
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,10 @@ repos:
         # - templates/
         # - examples/
         files: ^(.*\.go|docs/.*|templates/.*|examples/.*)$
-        entry: mise
-        args: [run, docs]
+        entry: bash
+        args:
+          - -c
+          - mise run docs && git add --intent-to-add docs/ && git diff --exit-code -- docs/
         language: system
         pass_filenames: false
 

--- a/_about/CONTRIBUTING.md
+++ b/_about/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Note that this _does not_ require building the provider binary with `mise run bu
 
 Acceptance tests create real Prefect Cloud resources, and require a Prefect Cloud account.
 
-In most development and contribution cases, acceptance tests will be run in CI/CD via Github Actions, as test-specific credentials are stored in the environment there. These tests happen in Prefect's internal staging environment, and a Prefect team member must approve the CI action for it to run.
+In CI, pull requests whose branches are in this repository run Prefect Cloud acceptance tests automatically. Pull requests from forks run only the OSS acceptance tests and do not receive Prefect Cloud credentials.
 
 The tests can optionally be triggered from a developer's machine by specifying the Prefect API url, API key, and account ID:
 
@@ -96,8 +96,8 @@ mise run testacc
 
 All acceptance tests run in an ephemeral Prefect workspace, except tests for Prefect workspaces and accounts.
 This means that the target Prefect environment needs to allow for multiple workspaces. If your account lacks this,
-contribute tests to your pull request and a Prefect team member will review and approve them to run in our internal
-infrastructure.
+contribute tests to your pull request. A Prefect team member can review them and run them from a branch in this
+repository.
 
 Here are some general guidelines for writing **datasource** acceptance tests
 
@@ -202,7 +202,7 @@ The `tfplugindocs` CLI will:
 2. Create and populate `.md` files for each page of documentation for the objects mentioned in (1)
 3. Crawl and extract all named examples in `examples/**` + add those HCL configurations into the examples section of each `.md`
 
-**NOTE:** If any documentation input files inside `examples/**` are modified, Github Actions will automatically run `mise run docs` and push any udpates to the working branch
+GitHub Actions runs this command when documentation inputs change. The check fails if generated files differ, so commit the updated `docs/` files with your change.
 
 Documentation will be rendered into the `docs/` directory. If you need to add additional
 information to a document page, create a template first. To do this, create a new file under either:


### PR DESCRIPTION
### Summary

Related to PLA-2852
Related to #702

PR #702 opts fork jobs into checkout v7's unsafe mode so they can run after environment approval. This draft uses read-only `pull_request` workflows instead.

Same-repository pull requests run OSS and Prefect Cloud acceptance tests automatically. The Cloud job uses the `Acceptance Tests (main)` environment, which has no required reviewers. Fork pull requests run the existing OSS acceptance tests without Cloud credentials.

Docs generation now uses a read-only token and fails when generated files differ. Contributors can run `mise run docs` and commit the result. The pre-commit hook also reports new generated files instead of missing them as untracked files. The labeler remains on `pull_request_target` because it does not check out pull request code.

Validated with actionlint, local documentation generation, and a pre-commit case that creates a new generated file.

### Requirements

#### General

- [x] The [contributing guide](https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md) has been read
- [x] Title follows the [conventional commits](https://www.conventionalcommits.org) format
- [x] No closing GitHub issue is available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [x] Unit tests are not applicable to these workflow changes
- [ ] Acceptance tests are added/updated (including import tests, when needed). When relevant, a Prefect engineer has run `mise run testacc-cm` against the private Customer-Managed environment.

#### New or updated resource/datasource
- [ ] Documentation is added (generated by `mise run docs` from source code)
      - When applicable, provide a link back to the relevant page in the [Prefect documentation site](https://docs.prefect.io).
      - Use the [doc preview tool](https://registry.terraform.io/tools/doc-preview) to confirm page(s) render correctly.
- [ ] For resources, the following are added:
      - Resource example under `examples/resources/prefect_<name>/resource.tf`
      - Import example under `examples/resources/prefect_<name>/import.sh`
- [ ] For datasources, the following is added:
      - Datasource example under `examples/data-sources,resources>/prefect_<name>/data-source.tf`

<details>
<summary>Session context</summary>

Review of #702 found that its checkout v7 override still executes fork code with Cloud credentials or a write token. Environment approval delays that execution but does not isolate the credentials. This version follows the read-only, contributor-owned update pattern used in PrefectHQ/prefect-helm#644.

</details>
