### PR TITLE
fix(deployments): correctly clear unset deployment concurrency limits

### DIFF
--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -70,8 +70,8 @@ type DeploymentCreate struct {
 type DeploymentUpdate struct {
 	// The Prefect API distinguishes "field absent" (no change) from "field is
 	// null" (clear). The resource builds concurrency_limit and
-	// global_concurrency_limit_id from the planned configuration and sends at
-	// most one of them. An update with no configured limit sends an explicit
+	// global_concurrency_limit_id from the configuration, plan, and prior state.
+	// It sends at most one of them. An update with no configured limit sends an explicit
 	// concurrency_limit:null; removing a global_concurrency_limit_id instead
 	// sends global_concurrency_limit_id:null so a shared limit is detached
 	// without being deleted. concurrency_options also receives an explicit null

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -70,8 +70,8 @@ type DeploymentCreate struct {
 type DeploymentUpdate struct {
 	// The Prefect API distinguishes "field absent" (no change) from "field is
 	// null" (clear). The resource builds concurrency_limit and
-	// global_concurrency_limit_id from the configuration, plan, and prior state.
-	// It sends at most one of them. An update with no configured limit sends an explicit
+	// global_concurrency_limit_id from the plan and prior state. It sends at
+	// most one of them. An update with no configured limit sends an explicit
 	// concurrency_limit:null; removing a global_concurrency_limit_id instead
 	// sends global_concurrency_limit_id:null so a shared limit is detached
 	// without being deleted. concurrency_options also receives an explicit null

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -69,17 +69,17 @@ type DeploymentCreate struct {
 // DeploymentUpdate is a subset of Deployment used when updating deployments.
 type DeploymentUpdate struct {
 	// The Prefect API distinguishes "field absent" (no change) from "field is
-	// null" (clear). concurrency_limit and global_concurrency_limit_id route
-	// through the same underlying limit, so sending an explicit null for either
-	// clears it, and sending concurrency_limit alongside an explicit
-	// global_concurrency_limit_id:null can trip a 409. concurrency_options is
-	// not cleared automatically when the limit is, so removing it also needs an
-	// explicit null.
+	// null" (clear). The resource builds concurrency_limit and
+	// global_concurrency_limit_id from the planned configuration and sends at
+	// most one of them. An update with no configured limit sends an explicit
+	// concurrency_limit:null; removing a global_concurrency_limit_id instead
+	// sends global_concurrency_limit_id:null so a shared limit is detached
+	// without being deleted. concurrency_options also receives an explicit null
+	// when it is absent from the planned configuration.
 	//
 	// Because the standard `omitempty` tag cannot emit an explicit null, these
-	// fields are encoded as json.RawMessage and populated only when they should
-	// change. See the concurrency*UpdateValue helpers in the deployment
-	// resource's Update.
+	// fields are encoded as json.RawMessage and populated by the concurrency
+	// payload helper in the deployment resource's Update.
 	ConcurrencyLimit         json.RawMessage `json:"concurrency_limit,omitempty"`
 	ConcurrencyOptions       json.RawMessage `json:"concurrency_options,omitempty"`
 	Description              *string         `json:"description,omitempty"`

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -984,31 +984,34 @@ type concurrencyUpdatePayload struct {
 }
 
 // concurrencyUpdateValues computes the concurrency fields to send in a
-// deployment update from the planned configuration. The Prefect API
-// distinguishes an absent field (no change) from an explicit null (clear), so
-// an update with no configured limit always sends an explicit
-// concurrency_limit:null. At most one of concurrency_limit and
-// global_concurrency_limit_id is sent:
+// deployment update. The Prefect API distinguishes an absent field (no change)
+// from an explicit null (clear). Configuration identifies which limit field the
+// user selected because an absent Optional and Computed field is unknown in the
+// plan. At most one of concurrency_limit and global_concurrency_limit_id is
+// sent:
 //
-//   - a planned concurrency_limit value -> send that value
-//   - a planned global_concurrency_limit_id value -> send that ID
+//   - a configured concurrency_limit value -> send the planned value
+//   - a configured global_concurrency_limit_id value -> send the planned ID
 //   - a removed global_concurrency_limit_id -> send global_concurrency_limit_id:null
 //   - otherwise -> send concurrency_limit:null
 //
 // Removing a global concurrency limit ID detaches the deployment without
-// deleting the underlying shared limit. concurrency_options also uses an
-// explicit null when it is absent from the planned configuration.
-func concurrencyUpdateValues(plan, prior DeploymentResourceModel) concurrencyUpdatePayload {
+// deleting the underlying shared limit. Unknown configured values are omitted
+// until Terraform resolves them. concurrency_options uses an explicit null when
+// it is absent from the planned configuration.
+func concurrencyUpdateValues(config, plan, prior DeploymentResourceModel) concurrencyUpdatePayload {
 	var payload concurrencyUpdatePayload
 
 	switch {
-	case !plan.ConcurrencyLimit.IsNull() && !plan.ConcurrencyLimit.IsUnknown():
-		payload.concurrencyLimit = json.RawMessage(fmt.Sprintf("%d", plan.ConcurrencyLimit.ValueInt64()))
-	case !plan.GlobalConcurrencyLimitID.IsNull() && !plan.GlobalConcurrencyLimitID.IsUnknown():
-		payload.globalConcurrencyLimitID = json.RawMessage(fmt.Sprintf("%q", plan.GlobalConcurrencyLimitID.ValueUUID().String()))
-	case plan.GlobalConcurrencyLimitID.IsNull() &&
-		!prior.GlobalConcurrencyLimitID.IsNull() &&
-		!prior.GlobalConcurrencyLimitID.IsUnknown():
+	case !config.ConcurrencyLimit.IsNull():
+		if !plan.ConcurrencyLimit.IsNull() && !plan.ConcurrencyLimit.IsUnknown() {
+			payload.concurrencyLimit = json.RawMessage(fmt.Sprintf("%d", plan.ConcurrencyLimit.ValueInt64()))
+		}
+	case !config.GlobalConcurrencyLimitID.IsNull():
+		if !plan.GlobalConcurrencyLimitID.IsNull() && !plan.GlobalConcurrencyLimitID.IsUnknown() {
+			payload.globalConcurrencyLimitID = json.RawMessage(fmt.Sprintf("%q", plan.GlobalConcurrencyLimitID.ValueUUID().String()))
+		}
+	case !prior.GlobalConcurrencyLimitID.IsNull() && !prior.GlobalConcurrencyLimitID.IsUnknown():
 		payload.globalConcurrencyLimitID = json.RawMessage("null")
 	default:
 		payload.concurrencyLimit = json.RawMessage("null")
@@ -1032,9 +1035,15 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	// The prior state distinguishes removing a global concurrency limit ID from
-	// having no limit configured. The planned configuration remains authoritative
-	// for all concurrency fields, and at most one limit field is sent.
+	// global_concurrency_limit_id is Optional and Computed, so an omitted value
+	// is unknown in the plan. The configuration preserves whether the value was
+	// removed or is still configured but unresolved.
+	var config DeploymentResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var priorState DeploymentResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
 	if resp.Diagnostics.HasError() {
@@ -1092,7 +1101,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	concurrencyUpdate := concurrencyUpdateValues(model, priorState)
+	concurrencyUpdate := concurrencyUpdateValues(config, model, priorState)
 	payload := api.DeploymentUpdate{
 		ConcurrencyLimit:         concurrencyUpdate.concurrencyLimit,
 		ConcurrencyOptions:       concurrencyUpdate.concurrencyOptions,

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -32,9 +32,33 @@ import (
 )
 
 var (
-	_ = resource.ResourceWithConfigure(&DeploymentResource{})
-	_ = resource.ResourceWithImportState(&DeploymentResource{})
+	_                     = resource.ResourceWithConfigure(&DeploymentResource{})
+	_                     = resource.ResourceWithImportState(&DeploymentResource{})
+	_ planmodifier.String = globalLimitRemovalModifier{}
 )
+
+type globalLimitRemovalModifier struct{}
+
+// Description describes the plan modification.
+func (globalLimitRemovalModifier) Description(_ context.Context) string {
+	return "plans a null global concurrency limit ID when the attribute is removed from configuration"
+}
+
+// MarkdownDescription describes the plan modification in Markdown.
+func (m globalLimitRemovalModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+// PlanModifyString plans a null ID when a configured global concurrency limit
+// is removed. Terraform otherwise retains the prior value for this Optional
+// and Computed attribute.
+func (globalLimitRemovalModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if !req.ConfigValue.IsNull() || req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = types.StringNull()
+}
 
 // DeploymentResource contains state for the resource.
 type DeploymentResource struct {
@@ -366,6 +390,9 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Optional:    true,
 				Computed:    true,
 				CustomType:  customtypes.UUIDType{},
+				PlanModifiers: []planmodifier.String{
+					globalLimitRemovalModifier{},
+				},
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("concurrency_limit")),
 				},
@@ -707,7 +734,11 @@ func CopyDeploymentToModel(ctx context.Context, deployment *api.Deployment, mode
 	model.Name = types.StringValue(deployment.Name)
 	model.Path = types.StringValue(deployment.Path)
 	model.Paused = types.BoolValue(deployment.Paused)
-	model.StorageDocumentID = customtypes.NewUUIDValue(deployment.StorageDocumentID)
+	if deployment.StorageDocumentID == uuid.Nil {
+		model.StorageDocumentID = customtypes.NewUUIDNull()
+	} else {
+		model.StorageDocumentID = customtypes.NewUUIDValue(deployment.StorageDocumentID)
+	}
 	model.Version = types.StringValue(deployment.Version)
 	model.WorkPoolName = types.StringValue(deployment.WorkPoolName)
 	model.WorkQueueName = types.StringValue(deployment.WorkQueueName)
@@ -985,13 +1016,11 @@ type concurrencyUpdatePayload struct {
 
 // concurrencyUpdateValues computes the concurrency fields to send in a
 // deployment update. The Prefect API distinguishes an absent field (no change)
-// from an explicit null (clear). Configuration identifies which limit field the
-// user selected because an absent Optional and Computed field is unknown in the
-// plan. At most one of concurrency_limit and global_concurrency_limit_id is
-// sent:
+// from an explicit null (clear). At most one of concurrency_limit and
+// global_concurrency_limit_id is sent:
 //
-//   - a configured concurrency_limit value -> send the planned value
-//   - a configured global_concurrency_limit_id value -> send the planned ID
+//   - a planned concurrency_limit value -> send that value
+//   - a planned global_concurrency_limit_id value -> send that ID
 //   - a removed global_concurrency_limit_id -> send global_concurrency_limit_id:null
 //   - otherwise -> send concurrency_limit:null
 //
@@ -999,20 +1028,24 @@ type concurrencyUpdatePayload struct {
 // deleting the underlying shared limit. Unknown configured values are omitted
 // until Terraform resolves them. concurrency_options uses an explicit null when
 // it is absent from the planned configuration.
-func concurrencyUpdateValues(config, plan, prior DeploymentResourceModel) concurrencyUpdatePayload {
+func concurrencyUpdateValues(plan, prior DeploymentResourceModel) concurrencyUpdatePayload {
 	var payload concurrencyUpdatePayload
 
 	switch {
-	case !config.ConcurrencyLimit.IsNull():
-		if !plan.ConcurrencyLimit.IsNull() && !plan.ConcurrencyLimit.IsUnknown() {
-			payload.concurrencyLimit = json.RawMessage(fmt.Sprintf("%d", plan.ConcurrencyLimit.ValueInt64()))
-		}
-	case !config.GlobalConcurrencyLimitID.IsNull():
-		if !plan.GlobalConcurrencyLimitID.IsNull() && !plan.GlobalConcurrencyLimitID.IsUnknown() {
-			payload.globalConcurrencyLimitID = json.RawMessage(fmt.Sprintf("%q", plan.GlobalConcurrencyLimitID.ValueUUID().String()))
-		}
-	case !prior.GlobalConcurrencyLimitID.IsNull() && !prior.GlobalConcurrencyLimitID.IsUnknown():
+	case !plan.ConcurrencyLimit.IsNull() && !plan.ConcurrencyLimit.IsUnknown():
+		payload.concurrencyLimit = json.RawMessage(fmt.Sprintf("%d", plan.ConcurrencyLimit.ValueInt64()))
+	case plan.ConcurrencyLimit.IsUnknown():
+		// Omit unresolved configured values.
+	case !plan.GlobalConcurrencyLimitID.IsNull() && !plan.GlobalConcurrencyLimitID.IsUnknown():
+		payload.globalConcurrencyLimitID = json.RawMessage(fmt.Sprintf("%q", plan.GlobalConcurrencyLimitID.ValueUUID().String()))
+	case plan.GlobalConcurrencyLimitID.IsNull() &&
+		!prior.GlobalConcurrencyLimitID.IsNull() &&
+		!prior.GlobalConcurrencyLimitID.IsUnknown():
 		payload.globalConcurrencyLimitID = json.RawMessage("null")
+	case plan.GlobalConcurrencyLimitID.IsUnknown() &&
+		!prior.GlobalConcurrencyLimitID.IsNull() &&
+		!prior.GlobalConcurrencyLimitID.IsUnknown():
+		// Omit unresolved configured values.
 	default:
 		payload.concurrencyLimit = json.RawMessage("null")
 	}
@@ -1031,15 +1064,6 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 	var model DeploymentResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// global_concurrency_limit_id is Optional and Computed, so an omitted value
-	// is unknown in the plan. The configuration preserves whether the value was
-	// removed or is still configured but unresolved.
-	var config DeploymentResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -1101,7 +1125,7 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	concurrencyUpdate := concurrencyUpdateValues(config, model, priorState)
+	concurrencyUpdate := concurrencyUpdateValues(model, priorState)
 	payload := api.DeploymentUpdate{
 		ConcurrencyLimit:         concurrencyUpdate.concurrencyLimit,
 		ConcurrencyOptions:       concurrencyUpdate.concurrencyOptions,

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -34,6 +34,7 @@ import (
 var (
 	_                     = resource.ResourceWithConfigure(&DeploymentResource{})
 	_                     = resource.ResourceWithImportState(&DeploymentResource{})
+	_                     = resource.ResourceWithModifyPlan(&DeploymentResource{})
 	_ planmodifier.String = globalLimitRemovalModifier{}
 )
 
@@ -525,6 +526,33 @@ func (r *DeploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 	}
 }
 
+// ModifyPlan marks the update timestamp unknown when removing a global
+// concurrency limit. The attribute plan modifier introduces the resource
+// change after Terraform has processed computed attributes.
+func (r *DeploymentResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+
+	var planGlobalLimitID customtypes.UUIDValue
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("global_concurrency_limit_id"), &planGlobalLimitID)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var priorGlobalLimitID customtypes.UUIDValue
+	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("global_concurrency_limit_id"), &priorGlobalLimitID)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !globalLimitRemoved(planGlobalLimitID, priorGlobalLimitID) {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("updated"), customtypes.NewTimestampUnknown())...)
+}
+
 func mapPullStepsTerraformToAPI(tfPullSteps []PullStepModel) ([]api.PullStep, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
@@ -1014,6 +1042,10 @@ type concurrencyUpdatePayload struct {
 	globalConcurrencyLimitID json.RawMessage
 }
 
+func globalLimitRemoved(plan, prior customtypes.UUIDValue) bool {
+	return plan.IsNull() && !prior.IsNull() && !prior.IsUnknown()
+}
+
 // concurrencyUpdateValues computes the concurrency fields to send in a
 // deployment update. The Prefect API distinguishes an absent field (no change)
 // from an explicit null (clear). At most one of concurrency_limit and
@@ -1038,9 +1070,7 @@ func concurrencyUpdateValues(plan, prior DeploymentResourceModel) concurrencyUpd
 		// Omit unresolved configured values.
 	case !plan.GlobalConcurrencyLimitID.IsNull() && !plan.GlobalConcurrencyLimitID.IsUnknown():
 		payload.globalConcurrencyLimitID = json.RawMessage(fmt.Sprintf("%q", plan.GlobalConcurrencyLimitID.ValueUUID().String()))
-	case plan.GlobalConcurrencyLimitID.IsNull() &&
-		!prior.GlobalConcurrencyLimitID.IsNull() &&
-		!prior.GlobalConcurrencyLimitID.IsUnknown():
+	case globalLimitRemoved(plan.GlobalConcurrencyLimitID, prior.GlobalConcurrencyLimitID):
 		payload.globalConcurrencyLimitID = json.RawMessage("null")
 	case plan.GlobalConcurrencyLimitID.IsUnknown() &&
 		!prior.GlobalConcurrencyLimitID.IsNull() &&

--- a/internal/provider/resources/deployment.go
+++ b/internal/provider/resources/deployment.go
@@ -975,60 +975,52 @@ func (r *DeploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 }
 
-// concurrencyUpdateValue computes the concurrency_limit value to send in a
-// deployment update. The Prefect API distinguishes an absent field (no change)
-// from an explicit null (clear the limit), so we only include the field when it
-// is being set or cleared:
-//
-//   - plan has a value          -> send that value
-//   - plan null, prior had value -> send null (clear)
-//   - plan null, prior null      -> omit (return nil RawMessage)
-//
-// Returning a nil json.RawMessage leaves the omitempty field out of the payload.
-func concurrencyUpdateValue(plan, prior types.Int64) json.RawMessage {
-	switch {
-	case !plan.IsNull():
-		return json.RawMessage(fmt.Sprintf("%d", plan.ValueInt64()))
-	case !prior.IsNull():
-		return json.RawMessage("null")
-	default:
-		return nil
-	}
+// concurrencyUpdatePayload contains the concurrency fields to send in a
+// deployment update.
+type concurrencyUpdatePayload struct {
+	concurrencyLimit         json.RawMessage
+	concurrencyOptions       json.RawMessage
+	globalConcurrencyLimitID json.RawMessage
 }
 
-// globalConcurrencyLimitUpdateValue mirrors concurrencyUpdateValue for the
-// global_concurrency_limit_id field. The same underlying limit backs both
-// fields server-side, so we send each only when it actually changes to avoid
-// clobbering the other or tripping a data-integrity conflict.
+// concurrencyUpdateValues computes the concurrency fields to send in a
+// deployment update from the planned configuration. The Prefect API
+// distinguishes an absent field (no change) from an explicit null (clear), so
+// an update with no configured limit always sends an explicit
+// concurrency_limit:null. At most one of concurrency_limit and
+// global_concurrency_limit_id is sent:
 //
-// This attribute is Computed, so when it is absent from config its planned
-// value is unknown (not null). An unknown value means "leave it alone", so we
-// omit the field in that case rather than sending the zero UUID.
-func globalConcurrencyLimitUpdateValue(plan, prior customtypes.UUIDValue) json.RawMessage {
-	switch {
-	case plan.IsUnknown():
-		return nil
-	case !plan.IsNull():
-		return json.RawMessage(fmt.Sprintf("%q", plan.ValueUUID().String()))
-	case !prior.IsNull() && !prior.IsUnknown():
-		return json.RawMessage("null")
-	default:
-		return nil
-	}
-}
+//   - a planned concurrency_limit value -> send that value
+//   - a planned global_concurrency_limit_id value -> send that ID
+//   - a removed global_concurrency_limit_id -> send global_concurrency_limit_id:null
+//   - otherwise -> send concurrency_limit:null
+//
+// Removing a global concurrency limit ID detaches the deployment without
+// deleting the underlying shared limit. concurrency_options also uses an
+// explicit null when it is absent from the planned configuration.
+func concurrencyUpdateValues(plan, prior DeploymentResourceModel) concurrencyUpdatePayload {
+	var payload concurrencyUpdatePayload
 
-// concurrencyOptionsUpdateValue mirrors concurrencyUpdateValue for the
-// concurrency_options field. The server does not clear concurrency_options when
-// the limit is cleared, so removing it from config requires an explicit null.
-func concurrencyOptionsUpdateValue(plan, prior *ConcurrencyOptions) json.RawMessage {
 	switch {
-	case plan != nil:
-		return json.RawMessage(fmt.Sprintf(`{"collision_strategy":%q}`, plan.CollisionStrategy.ValueString()))
-	case prior != nil:
-		return json.RawMessage("null")
+	case !plan.ConcurrencyLimit.IsNull() && !plan.ConcurrencyLimit.IsUnknown():
+		payload.concurrencyLimit = json.RawMessage(fmt.Sprintf("%d", plan.ConcurrencyLimit.ValueInt64()))
+	case !plan.GlobalConcurrencyLimitID.IsNull() && !plan.GlobalConcurrencyLimitID.IsUnknown():
+		payload.globalConcurrencyLimitID = json.RawMessage(fmt.Sprintf("%q", plan.GlobalConcurrencyLimitID.ValueUUID().String()))
+	case plan.GlobalConcurrencyLimitID.IsNull() &&
+		!prior.GlobalConcurrencyLimitID.IsNull() &&
+		!prior.GlobalConcurrencyLimitID.IsUnknown():
+		payload.globalConcurrencyLimitID = json.RawMessage("null")
 	default:
-		return nil
+		payload.concurrencyLimit = json.RawMessage("null")
 	}
+
+	if plan.ConcurrencyOptions != nil {
+		payload.concurrencyOptions = json.RawMessage(fmt.Sprintf(`{"collision_strategy":%q}`, plan.ConcurrencyOptions.CollisionStrategy.ValueString()))
+	} else {
+		payload.concurrencyOptions = json.RawMessage("null")
+	}
+
+	return payload
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -1040,10 +1032,9 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	// We need the prior state to know whether a concurrency limit is being
-	// cleared. The Prefect API only clears a limit when it receives an explicit
-	// null, and routes both concurrency_limit and global_concurrency_limit_id
-	// through the same underlying limit, so we send each only when it changes.
+	// The prior state distinguishes removing a global concurrency limit ID from
+	// having no limit configured. The planned configuration remains authoritative
+	// for all concurrency fields, and at most one limit field is sent.
 	var priorState DeploymentResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &priorState)...)
 	if resp.Diagnostics.HasError() {
@@ -1101,12 +1092,14 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	concurrencyUpdate := concurrencyUpdateValues(model, priorState)
 	payload := api.DeploymentUpdate{
-		ConcurrencyLimit:         concurrencyUpdateValue(model.ConcurrencyLimit, priorState.ConcurrencyLimit),
+		ConcurrencyLimit:         concurrencyUpdate.concurrencyLimit,
+		ConcurrencyOptions:       concurrencyUpdate.concurrencyOptions,
 		Description:              model.Description.ValueStringPointer(),
 		EnforceParameterSchema:   model.EnforceParameterSchema.ValueBoolPointer(),
 		Entrypoint:               model.Entrypoint.ValueStringPointer(),
-		GlobalConcurrencyLimitID: globalConcurrencyLimitUpdateValue(model.GlobalConcurrencyLimitID, priorState.GlobalConcurrencyLimitID),
+		GlobalConcurrencyLimitID: concurrencyUpdate.globalConcurrencyLimitID,
 		JobVariables:             jobVariables,
 		ParameterOpenAPISchema:   parameterOpenAPISchema,
 		Parameters:               parameters,
@@ -1119,8 +1112,6 @@ func (r *DeploymentResource) Update(ctx context.Context, req resource.UpdateRequ
 		WorkPoolName:             model.WorkPoolName.ValueStringPointer(),
 		WorkQueueName:            model.WorkQueueName.ValueStringPointer(),
 	}
-
-	payload.ConcurrencyOptions = concurrencyOptionsUpdateValue(model.ConcurrencyOptions, priorState.ConcurrencyOptions)
 
 	// Capture the planned parameter_openapi_schema before the API call
 	// overwrites it (same reason as in Create).

--- a/internal/provider/resources/deployment_concurrency_test.go
+++ b/internal/provider/resources/deployment_concurrency_test.go
@@ -16,6 +16,7 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 
 	tests := []struct {
 		name              string
+		config            DeploymentResourceModel
 		plan              DeploymentResourceModel
 		prior             DeploymentResourceModel
 		wantLimit         string
@@ -24,16 +25,38 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 	}{
 		{
 			name: "concurrency limit set",
-			plan: DeploymentResourceModel{
+			config: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Value(2),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Value(2),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
 			},
 			wantLimit:         "2",
 			wantOptions:       "null",
 			wantGlobalLimitID: "<omitted>",
 		},
 		{
+			name: "concurrency limit unknown",
+			config: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Unknown(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Unknown(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
+			},
+			wantLimit:         "<omitted>",
+			wantOptions:       "null",
+			wantGlobalLimitID: "<omitted>",
+		},
+		{
 			name: "global concurrency limit ID set",
+			config: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDValue(limitID),
+			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDValue(limitID),
@@ -44,19 +67,31 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "global concurrency limit ID unknown",
+			config: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
+			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
 			},
-			wantLimit:         "null",
+			prior: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDValue(limitID),
+			},
+			wantLimit:         "<omitted>",
 			wantOptions:       "null",
 			wantGlobalLimitID: "<omitted>",
 		},
 		{
 			name: "nothing configured with no prior limit",
-			plan: DeploymentResourceModel{
+			config: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
 			},
 			prior: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
@@ -68,9 +103,13 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "nothing configured with prior concurrency limit",
-			plan: DeploymentResourceModel{
+			config: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
 			},
 			prior: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Value(2),
@@ -82,9 +121,13 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "global concurrency limit ID removed",
-			plan: DeploymentResourceModel{
+			config: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
 			},
 			prior: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
@@ -96,9 +139,13 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "concurrency options set",
-			plan: DeploymentResourceModel{
+			config: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
 				ConcurrencyOptions: &ConcurrencyOptions{
 					CollisionStrategy: types.StringValue("ENQUEUE"),
 				},
@@ -109,9 +156,13 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "concurrency options removed with no prior options",
-			plan: DeploymentResourceModel{
+			config: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
 			},
 			wantLimit:         "null",
 			wantOptions:       "null",
@@ -119,9 +170,13 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "concurrency options removed with prior options",
-			plan: DeploymentResourceModel{
+			config: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
 			},
 			prior: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
@@ -140,7 +195,7 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := concurrencyUpdateValues(tt.plan, tt.prior)
+			got := concurrencyUpdateValues(tt.config, tt.plan, tt.prior)
 
 			if got := rawMessageString(got.concurrencyLimit); got != tt.wantLimit {
 				t.Errorf("concurrency_limit = %q, want %q", got, tt.wantLimit)

--- a/internal/provider/resources/deployment_concurrency_test.go
+++ b/internal/provider/resources/deployment_concurrency_test.go
@@ -1,13 +1,75 @@
-package resources // nolint:testpackage // need access to private concurrencyUpdateValues function
+package resources // nolint:testpackage // need access to private concurrency helpers
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
 )
+
+func TestGlobalLimitRemovalModifier(t *testing.T) {
+	t.Parallel()
+
+	limitID := "11111111-1111-1111-1111-111111111111"
+
+	tests := []struct {
+		name   string
+		config types.String
+		plan   types.String
+		state  types.String
+		want   types.String
+	}{
+		{
+			name:   "removed",
+			config: types.StringNull(),
+			plan:   types.StringValue(limitID),
+			state:  types.StringValue(limitID),
+			want:   types.StringNull(),
+		},
+		{
+			name:   "never configured",
+			config: types.StringNull(),
+			plan:   types.StringUnknown(),
+			state:  types.StringNull(),
+			want:   types.StringUnknown(),
+		},
+		{
+			name:   "still configured",
+			config: types.StringValue(limitID),
+			plan:   types.StringValue(limitID),
+			state:  types.StringValue(limitID),
+			want:   types.StringValue(limitID),
+		},
+		{
+			name:   "configured value unresolved",
+			config: types.StringUnknown(),
+			plan:   types.StringUnknown(),
+			state:  types.StringValue(limitID),
+			want:   types.StringUnknown(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := planmodifier.StringResponse{PlanValue: tt.plan}
+			globalLimitRemovalModifier{}.PlanModifyString(context.Background(), planmodifier.StringRequest{
+				ConfigValue: tt.config,
+				PlanValue:   tt.plan,
+				StateValue:  tt.state,
+			}, &resp)
+
+			if !resp.PlanValue.Equal(tt.want) {
+				t.Errorf("planned value = %s, want %s", resp.PlanValue, tt.want)
+			}
+		})
+	}
+}
 
 func TestConcurrencyUpdateValues(t *testing.T) {
 	t.Parallel()
@@ -16,7 +78,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 
 	tests := []struct {
 		name              string
-		config            DeploymentResourceModel
 		plan              DeploymentResourceModel
 		prior             DeploymentResourceModel
 		wantLimit         string
@@ -25,10 +86,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 	}{
 		{
 			name: "concurrency limit set",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Value(2),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Value(2),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
@@ -39,10 +96,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "concurrency limit unknown",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Unknown(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Unknown(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
@@ -53,10 +106,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "global concurrency limit ID set",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Null(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDValue(limitID),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDValue(limitID),
@@ -67,10 +116,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "global concurrency limit ID unknown",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Null(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
@@ -85,10 +130,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "nothing configured with no prior limit",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Null(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
@@ -103,10 +144,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "nothing configured with prior concurrency limit",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Null(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
@@ -121,13 +158,9 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "global concurrency limit ID removed",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Null(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
 			},
 			prior: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
@@ -139,10 +172,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "concurrency options set",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Null(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
@@ -156,10 +185,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "concurrency options removed with no prior options",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Null(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
@@ -170,10 +195,6 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		},
 		{
 			name: "concurrency options removed with prior options",
-			config: DeploymentResourceModel{
-				ConcurrencyLimit:         types.Int64Null(),
-				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
-			},
 			plan: DeploymentResourceModel{
 				ConcurrencyLimit:         types.Int64Null(),
 				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
@@ -195,7 +216,7 @@ func TestConcurrencyUpdateValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := concurrencyUpdateValues(tt.config, tt.plan, tt.prior)
+			got := concurrencyUpdateValues(tt.plan, tt.prior)
 
 			if got := rawMessageString(got.concurrencyLimit); got != tt.wantLimit {
 				t.Errorf("concurrency_limit = %q, want %q", got, tt.wantLimit)

--- a/internal/provider/resources/deployment_concurrency_test.go
+++ b/internal/provider/resources/deployment_concurrency_test.go
@@ -1,0 +1,168 @@
+package resources // nolint:testpackage // need access to private concurrencyUpdateValues function
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
+)
+
+func TestConcurrencyUpdateValues(t *testing.T) {
+	t.Parallel()
+
+	limitID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	tests := []struct {
+		name              string
+		plan              DeploymentResourceModel
+		prior             DeploymentResourceModel
+		wantLimit         string
+		wantOptions       string
+		wantGlobalLimitID string
+	}{
+		{
+			name: "concurrency limit set",
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Value(2),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			wantLimit:         "2",
+			wantOptions:       "null",
+			wantGlobalLimitID: "<omitted>",
+		},
+		{
+			name: "global concurrency limit ID set",
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDValue(limitID),
+			},
+			wantLimit:         "<omitted>",
+			wantOptions:       "null",
+			wantGlobalLimitID: `"11111111-1111-1111-1111-111111111111"`,
+		},
+		{
+			name: "global concurrency limit ID unknown",
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDUnknown(),
+			},
+			wantLimit:         "null",
+			wantOptions:       "null",
+			wantGlobalLimitID: "<omitted>",
+		},
+		{
+			name: "nothing configured with no prior limit",
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			prior: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			wantLimit:         "null",
+			wantOptions:       "null",
+			wantGlobalLimitID: "<omitted>",
+		},
+		{
+			name: "nothing configured with prior concurrency limit",
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			prior: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Value(2),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			wantLimit:         "null",
+			wantOptions:       "null",
+			wantGlobalLimitID: "<omitted>",
+		},
+		{
+			name: "global concurrency limit ID removed",
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			prior: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDValue(limitID),
+			},
+			wantLimit:         "<omitted>",
+			wantOptions:       "null",
+			wantGlobalLimitID: "null",
+		},
+		{
+			name: "concurrency options set",
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+				ConcurrencyOptions: &ConcurrencyOptions{
+					CollisionStrategy: types.StringValue("ENQUEUE"),
+				},
+			},
+			wantLimit:         "null",
+			wantOptions:       `{"collision_strategy":"ENQUEUE"}`,
+			wantGlobalLimitID: "<omitted>",
+		},
+		{
+			name: "concurrency options removed with no prior options",
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			wantLimit:         "null",
+			wantOptions:       "null",
+			wantGlobalLimitID: "<omitted>",
+		},
+		{
+			name: "concurrency options removed with prior options",
+			plan: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+			},
+			prior: DeploymentResourceModel{
+				ConcurrencyLimit:         types.Int64Null(),
+				GlobalConcurrencyLimitID: customtypes.NewUUIDNull(),
+				ConcurrencyOptions: &ConcurrencyOptions{
+					CollisionStrategy: types.StringValue("ENQUEUE"),
+				},
+			},
+			wantLimit:         "null",
+			wantOptions:       "null",
+			wantGlobalLimitID: "<omitted>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := concurrencyUpdateValues(tt.plan, tt.prior)
+
+			if got := rawMessageString(got.concurrencyLimit); got != tt.wantLimit {
+				t.Errorf("concurrency_limit = %q, want %q", got, tt.wantLimit)
+			}
+			if got := rawMessageString(got.concurrencyOptions); got != tt.wantOptions {
+				t.Errorf("concurrency_options = %q, want %q", got, tt.wantOptions)
+			}
+			if got := rawMessageString(got.globalConcurrencyLimitID); got != tt.wantGlobalLimitID {
+				t.Errorf("global_concurrency_limit_id = %q, want %q", got, tt.wantGlobalLimitID)
+			}
+
+			if got.concurrencyLimit != nil && got.globalConcurrencyLimitID != nil {
+				t.Fatal("concurrency_limit and global_concurrency_limit_id must not both be sent")
+			}
+		})
+	}
+}
+
+func rawMessageString(value json.RawMessage) string {
+	if value == nil {
+		return "<omitted>"
+	}
+
+	return string(value)
+}

--- a/internal/provider/resources/deployment_internal_test.go
+++ b/internal/provider/resources/deployment_internal_test.go
@@ -1,0 +1,51 @@
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/prefecthq/terraform-provider-prefect/internal/api"
+	"github.com/prefecthq/terraform-provider-prefect/internal/provider/customtypes"
+)
+
+func TestCopyDeploymentToModelStorageDocumentID(t *testing.T) {
+	t.Parallel()
+
+	storageDocumentID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	tests := []struct {
+		name              string
+		storageDocumentID uuid.UUID
+		want              customtypes.UUIDValue
+	}{
+		{
+			name:              "absent",
+			storageDocumentID: uuid.Nil,
+			want:              customtypes.NewUUIDNull(),
+		},
+		{
+			name:              "present",
+			storageDocumentID: storageDocumentID,
+			want:              customtypes.NewUUIDValue(storageDocumentID),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var model DeploymentResourceModel
+			diags := CopyDeploymentToModel(context.Background(), &api.Deployment{
+				StorageDocumentID: tt.storageDocumentID,
+			}, &model)
+			if diags.HasError() {
+				t.Fatalf("CopyDeploymentToModel returned errors: %v", diags)
+			}
+
+			if !model.StorageDocumentID.Equal(tt.want) {
+				t.Errorf("storage_document_id = %s, want %s", model.StorageDocumentID.ValueString(), tt.want.ValueString())
+			}
+		})
+	}
+}

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -303,7 +303,6 @@ resource "prefect_deployment" "%[6]s" {
 }
 `, workspace.Resource, flowName, workspace.IDArg, gcl1Name, gcl2Name, deploymentName)
 
-	// Configuration for removing the global concurrency limit from the deployment
 	cfgRemove := fmt.Sprintf(`
 %[1]s
 
@@ -352,7 +351,6 @@ resource "prefect_deployment" "%[6]s" {
 				},
 			},
 			{
-				// Check removal without deleting the shared global concurrency limit
 				Config: cfgRemove,
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNull(deploymentResourceName, "global_concurrency_limit_id"),

--- a/internal/provider/resources/deployment_test.go
+++ b/internal/provider/resources/deployment_test.go
@@ -303,6 +303,34 @@ resource "prefect_deployment" "%[6]s" {
 }
 `, workspace.Resource, flowName, workspace.IDArg, gcl1Name, gcl2Name, deploymentName)
 
+	// Configuration for removing the global concurrency limit from the deployment
+	cfgRemove := fmt.Sprintf(`
+%[1]s
+
+resource "prefect_flow" "%[2]s" {
+	name = "%[2]s"
+	%[3]s
+}
+
+resource "prefect_global_concurrency_limit" "test1" {
+	name = "%[4]s"
+	limit = 5
+	%[3]s
+}
+
+resource "prefect_global_concurrency_limit" "test2" {
+	name = "%[5]s"
+	limit = 10
+	%[3]s
+}
+
+resource "prefect_deployment" "%[6]s" {
+	name = "%[6]s"
+	flow_id = prefect_flow.%[2]s.id
+	%[3]s
+}
+`, workspace.Resource, flowName, workspace.IDArg, gcl1Name, gcl2Name, deploymentName)
+
 	deploymentResourceName := fmt.Sprintf("prefect_deployment.%s", deploymentName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -321,6 +349,14 @@ resource "prefect_deployment" "%[6]s" {
 				Config: cfgUpdate,
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValueNotNull(deploymentResourceName, "global_concurrency_limit_id"),
+				},
+			},
+			{
+				// Check removal without deleting the shared global concurrency limit
+				Config: cfgRemove,
+				ConfigStateChecks: []statecheck.StateCheck{
+					testutils.ExpectKnownValueNull(deploymentResourceName, "global_concurrency_limit_id"),
+					testutils.ExpectKnownValueNotNull("prefect_global_concurrency_limit.test2", "id"),
 				},
 			},
 		},

--- a/internal/provider/resources/global_concurrency_limit_test.go
+++ b/internal/provider/resources/global_concurrency_limit_test.go
@@ -44,14 +44,14 @@ func TestAccResource_global_concurrency_limit(t *testing.T) {
 				},
 			},
 			{
-				// Check updating the resource
-				Config: fixtureAccGlobalConcurrencyLimitCreate(workspace.Resource, workspace.IDArg, "test2", 20, false, 1, 2),
+				// Keep decay disabled so active_slots stays stable through import verification.
+				Config: fixtureAccGlobalConcurrencyLimitCreate(workspace.Resource, workspace.IDArg, "test2", 20, false, 1, 0),
 				ConfigStateChecks: []statecheck.StateCheck{
 					testutils.ExpectKnownValue(resourceName, "name", "test2"),
 					testutils.ExpectKnownValueNumber(resourceName, "limit", 20),
 					testutils.ExpectKnownValueBool(resourceName, "active", false),
 					testutils.ExpectKnownValueNumber(resourceName, "active_slots", 1),
-					testutils.ExpectKnownValueFloat(resourceName, "slot_decay_per_second", 2),
+					testutils.ExpectKnownValueFloat(resourceName, "slot_decay_per_second", 0),
 				},
 			},
 			{


### PR DESCRIPTION
### Summary

Closes PrefectHQ/terraform-provider-prefect#709

`prefect_deployment` updates built `concurrency_limit`, `global_concurrency_limit_id` and `concurrency_options` from a diff between the plan and the prior state, so a field was omitted from the payload when both the plan and the prior state were null. The Prefect API treats an absent field as "no change", so a concurrency limit set outside of Terraform survived the apply, and the post-apply read returned a value where the plan promised null. Terraform then failed with:

```
Error: Provider produced inconsistent result after apply

... produced an unexpected new value: .concurrency_limit: was null, but now cty.NumberIntVal(2).
```

The failure needed the drift to be missing from state, which happens with `terraform apply -refresh=false` or a stale saved plan. A refreshed apply put the out-of-band value into the prior state, the diff then produced the explicit null, and the apply succeeded — so the bug looked intermittent.

The planned configuration is now authoritative. An update with no configured limit always sends an explicit `concurrency_limit: null`, which is a no-op when there is no limit and clears an out-of-band one. `concurrency_options` had the same defect and is now also explicitly cleared when it is absent from the configuration.

<details><summary>Payload rules</summary>

Both `concurrency_limit` and `global_concurrency_limit_id` map to the same underlying limit, so at most one of them is sent:

1. A planned `concurrency_limit` value sends that value and omits the ID.
2. A planned `global_concurrency_limit_id` value sends that ID and omits `concurrency_limit`.
3. A `global_concurrency_limit_id` that is removed from the configuration sends `global_concurrency_limit_id: null` and omits `concurrency_limit`. This keeps the behavior from [#682](<https://github.com/PrefectHQ/terraform-provider-prefect/issues/682>): detaching through the ID leaves the limit object in place, while clearing through `concurrency_limit: null` makes the server delete the underlying limit, which would destroy a shared limit that a `prefect_global_concurrency_limit` resource owns.
4. Any other case sends `concurrency_limit: null`.

The three previous helpers become one `concurrencyUpdateValues` function that returns a named struct, so the call site in `Update` states which field receives which value.

</details>

<details><summary>Verification</summary>

Reproduced against a local Prefect OSS server. The deployment was created without a `concurrency_limit`, and the limit was then set through a direct `PATCH /deployments/{id}` call to simulate a change in the UI.

<!-- linear:table-colwidths:266,266,266 -->
| Scenario | Before | After |
| -- | -- | -- |
| `apply`, no other change | passes, limit cleared | passes, limit cleared |
| `apply -refresh=false`, `description` changed | fails with the inconsistent result error, limit still set | passes, limit cleared |
| `apply`, `description` changed | passes, limit cleared | passes, limit cleared |

Also run: `mise run lint` (0 issues), `mise run test` (192 pass), and `mise run testacc-oss` for `TestAccResource_deployment.*` (8 pass, `TestAccResource_deployment_access` skipped in OSS), which covers the existing removal and global concurrency limit tests. New unit tests in `deployment_concurrency_test.go` cover every branch above, including the regression case, and assert that the two limit fields are never sent together.

</details>

### Requirements

#### General

- [X] The [contributing guide](<https://github.com/PrefectHQ/terraform-provider-prefect/blob/main/_about/CONTRIBUTING.md>) has been read
- [X] Title follows the [conventional commits](<https://www.conventionalcommits.org>) format
- [X] Body includes `Closes <issue>`, if available
- [x] Relevant labels have been added
- [x] `Draft` status is used until ready for review

#### Code-level changes

- [X] Unit tests are added/updated
- [X] Acceptance tests are added/updated (including import tests, when needed). When relevant, a Prefect engineer has run `mise run testacc-cm` against the private Customer-Managed environment.  <br>- No new acceptance tests: the existing `TestAccResource_deployment_*` cases cover both concurrency paths. `testacc-cm` has not been run.

#### New or updated resource/datasource

- [X] N/A — no resource or datasource schema, documentation, or examples changed.